### PR TITLE
fix: to property "error" does not exist on GetTaskResponse & SendMessageResponse

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -90,7 +90,7 @@ export type GetTaskPushNotificationConfigResponse = JSONRPCErrorResponse | GetTa
  * This interface was referenced by `MySchema`'s JSON-Schema
  * via the `definition` "GetTaskResponse".
  */
-export type GetTaskResponse = JSONRPCErrorResponse | GetTaskSuccessResponse;
+export type GetTaskResponse = JSONRPCErrorResponse & GetTaskSuccessResponse;
 /**
  * Represents a JSON-RPC 2.0 Response object.
  *
@@ -111,7 +111,7 @@ export type JSONRPCResponse =
  * This interface was referenced by `MySchema`'s JSON-Schema
  * via the `definition` "SendMessageResponse".
  */
-export type SendMessageResponse = JSONRPCErrorResponse | SendMessageSuccessResponse;
+export type SendMessageResponse = JSONRPCErrorResponse & SendMessageSuccessResponse;
 /**
  * JSON-RPC response model for the 'message/stream' method.
  *


### PR DESCRIPTION
# This fixes the issue property "error" does not exist on GetTaskResponse & SendMessageResponse which occurs while handling errors in A2AClient sendMessage method

Fixes #75 🦕
