### PR TITLE
docs: Add `protocolVersion` to agent card in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ const movieAgentCard: AgentCard = {
     organization: "A2A Agents",
     url: "https://example.com/a2a-agents", // Added provider URL
   },
+  protocolVersion: "0.3.0", // A2A protocol this agent supports.
   version: "0.0.2", // Incremented version
   capabilities: {
     streaming: true, // Supports streaming


### PR DESCRIPTION
# Description

Include `protocolVersion` in `AgentCard` in docs. This is a required property according to type definition in `0.3.0` js sdk.  Otherwise I'm getting linter errors.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-js/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
