### PR TITLE
feat: Added push notifications support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 ## Installation
 
 You can install the A2A SDK using `npm`.
-You can install the A2A SDK using `npm`.
 
 ```bash
 npm install @a2a-js/sdk
@@ -24,7 +23,6 @@ npm install @a2a-js/sdk
 
 ### For Server Usage
 
-If you plan to use the A2A server functionality (`A2AExpressApp`), you'll also need to install Express as it's a peer dependency:
 If you plan to use the A2A server functionality (`A2AExpressApp`), you'll also need to install Express as it's a peer dependency:
 
 ```bash
@@ -42,21 +40,8 @@ This example shows how to create a simple "Hello World" agent server and a clien
 ### Server: Hello World Agent
 
 The core of an A2A server is the `AgentExecutor`, which contains your agent's logic.
------
-
-## Quickstart
-
-This example shows how to create a simple "Hello World" agent server and a client to interact with it.
-
-### Server: Hello World Agent
-
-The core of an A2A server is the `AgentExecutor`, which contains your agent's logic.
 
 ```typescript
-// server.ts
-import express from "express";
-import { v4 as uuidv4 } from "uuid";
-import type { AgentCard, Message } from "@a2a-js/sdk";
 // server.ts
 import express from "express";
 import { v4 as uuidv4 } from "uuid";
@@ -66,7 +51,6 @@ import {
   RequestContext,
   ExecutionEventBus,
   DefaultRequestHandler,
-  InMemoryTaskStore,
   InMemoryTaskStore,
 } from "@a2a-js/sdk/server";
 import { A2AExpressApp } from "@a2a-js/sdk/server/express";
@@ -86,110 +70,7 @@ const helloAgentCard: AgentCard = {
 class HelloExecutor implements AgentExecutor {
   async execute(
     requestContext: RequestContext,
-// 1. Define your agent's identity card.
-const helloAgentCard: AgentCard = {
-  name: "Hello Agent",
-  description: "A simple agent that says hello.",
-  protocolVersion: "0.3.0",
-  version: "0.1.0",
-  url: "http://localhost:4000/", // The public URL of your agent server
-  skills: [ { id: "chat", name: "Chat", description: "Say hello", tags: ["chat"] } ],
-  // --- Other AgentCard fields omitted for brevity ---
-};
-
-// 2. Implement the agent's logic.
-class HelloExecutor implements AgentExecutor {
-  async execute(
-    requestContext: RequestContext,
     eventBus: ExecutionEventBus
-  ): Promise<void> {
-    // Create a direct message response.
-    const responseMessage: Message = {
-      kind: "message",
-      messageId: uuidv4(),
-      role: "agent",
-      parts: [{ kind: "text", text: "Hello, world!" }],
-      // Associate the response with the incoming request's context.
-      contextId: requestContext.contextId,
-    };
-
-    // Publish the message and signal that the interaction is finished.
-    eventBus.publish(responseMessage);
-    eventBus.finished();
-  }
-  
-  // cancelTask is not needed for this simple, non-stateful agent.
-  cancelTask = async (): Promise<void> => {};
-}
-
-// 3. Set up and run the server.
-const agentExecutor = new HelloExecutor();
-const requestHandler = new DefaultRequestHandler(
-  helloAgentCard,
-  new InMemoryTaskStore(),
-  agentExecutor
-);
-
-const appBuilder = new A2AExpressApp(requestHandler);
-const expressApp = appBuilder.setupRoutes(express());
-
-expressApp.listen(4000, () => {
-  console.log(`🚀 Server started on http://localhost:4000`);
-});
-```
-
-### Client: Sending a Message
-
-The `A2AClient` makes it easy to communicate with any A2A-compliant agent.
-
-```typescript
-// client.ts
-import { A2AClient, SendMessageSuccessResponse } from "@a2a-js/sdk/client";
-import { Message, MessageSendParams } from "@a2a-js/sdk";
-import { v4 as uuidv4 } from "uuid";
-
-async function run() {
-  // Create a client pointing to the agent's Agent Card URL.
-  const client = await A2AClient.fromCardUrl("http://localhost:4000/.well-known/agent-card.json");
-
-  const sendParams: MessageSendParams = {
-    message: {
-      messageId: uuidv4(),
-      role: "user",
-      parts: [{ kind: "text", text: "Hi there!" }],
-      kind: "message",
-    },
-  };
-
-  const response = await client.sendMessage(sendParams);
-
-  if ("error" in response) {
-    console.error("Error:", response.error.message);
-  } else {
-    const result = (response as SendMessageSuccessResponse).result as Message;
-    console.log("Agent response:", result.parts[0].text); // "Hello, world!"
-  }
-}
-
-await run();
-```
-
------
-
-## A2A `Task` Support
-
-For operations that are stateful or long-running, agents create a `Task`. A task has a state (e.g., `working`, `completed`) and can produce `Artifacts` (e.g., files, data).
-
-### Server: Creating a Task
-
-This agent creates a task, attaches a file artifact to it, and marks it as complete.
-
-```typescript
-// server.ts
-import { Task, TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from "@a2a-js/sdk";
-// ... other imports from the quickstart server ...
-
-class TaskExecutor implements AgentExecutor {
   ): Promise<void> {
     // Create a direct message response.
     const responseMessage: Message = {
@@ -283,7 +164,6 @@ class TaskExecutor implements AgentExecutor {
     eventBus: ExecutionEventBus
   ): Promise<void> {
     const { taskId, contextId } = requestContext;
-    const { taskId, contextId } = requestContext;
 
     // 1. Create and publish the initial task object.
     const initialTask: Task = {
@@ -296,33 +176,20 @@ class TaskExecutor implements AgentExecutor {
       },
     };
     eventBus.publish(initialTask);
-    // 1. Create and publish the initial task object.
-    const initialTask: Task = {
-      kind: "task",
-      id: taskId,
-      contextId: contextId,
-      status: {
-        state: "submitted",
-        timestamp: new Date().toISOString(),
-      },
-    };
-    eventBus.publish(initialTask);
 
-    // 2. Create and publish an artifact.
     // 2. Create and publish an artifact.
     const artifactUpdate: TaskArtifactUpdateEvent = {
       kind: "artifact-update",
       taskId: taskId,
       contextId: contextId,
       artifact: {
-        artifactId: "artifact-1",
-        name: "artifact-1",
-        parts: [{ kind: "text", text: `Task ${taskId} completed.` }],
+        artifactId: "report-1",
+        name: "analysis_report.txt",
+        parts: [{ kind: "text", text: `This is the analysis for task ${taskId}.` }],
       },
     };
     eventBus.publish(artifactUpdate);
 
-    // 3. Publish the final status and mark the event as 'final'.
     // 3. Publish the final status and mark the event as 'final'.
     const finalUpdate: TaskStatusUpdateEvent = {
       kind: "status-update",
@@ -665,330 +532,7 @@ class CancellableExecutor implements AgentExecutor {
     eventBus.publish(finalUpdate);
     eventBus.finished();
   }
-
-  cancelTask = async (): Promise<void> => {};
 }
-```
-
-### 3. Start the server
-
-```typescript
-const taskStore: TaskStore = new InMemoryTaskStore();
-const agentExecutor: AgentExecutor = new MyAgentExecutor();
-
-const requestHandler = new DefaultRequestHandler(
-  coderAgentCard,
-  taskStore,
-  agentExecutor
-);
-
-const appBuilder = new A2AExpressApp(requestHandler);
-const expressApp = appBuilder.setupRoutes(express(), "");
-
-const PORT = process.env.CODER_AGENT_PORT || 41242; // Different port for coder agent
-expressApp.listen(PORT, () => {
-  console.log(
-    `[MyAgent] Server using new framework started on http://localhost:${PORT}`
-  );
-  console.log(
-    `[MyAgent] Agent Card: http://localhost:${PORT}/.well-known/agent-card.json`
-  );
-  console.log("[MyAgent] Press Ctrl+C to stop the server");
-});
-```
-
-### Agent Executor
-
-Developers are expected to implement this interface and provide two methods: `execute` and `cancelTask`.
-
-#### `execute`
-
-- This method is provided with a `RequestContext` and an `EventBus` to publish execution events.
-- Executor can either respond by publishing a Message or Task.
-- For a task, check if there's an existing task in `RequestContext`. If not, publish an initial Task event using `taskId` & `contextId` from `RequestContext`.
-- Executor can subsequently publish `TaskStatusUpdateEvent` or `TaskArtifactUpdateEvent`.
-- Executor should indicate which is the `final` event and also call `finished()` method of event bus.
-- Executor should also check if an ongoing task has been cancelled. If yes, cancel the execution and emit an `TaskStatusUpdateEvent` with cancelled state.
-
-#### `cancelTask`
-
-Executors should implement cancellation mechanism for an ongoing task.
-
-### Push Notifications
-
-The A2A JavaScript SDK supports push notifications, allowing clients to receive real-time updates about task status changes without polling. This feature is optional and can be enabled by setting `pushNotifications: true` in the agent card capabilities.
-
-#### Server-Side Configuration
-
-To enable push notifications, your agent card must declare support:
-
-```typescript
-const movieAgentCard: AgentCard = {
-  // ... other properties
-  capabilities: {
-    streaming: true,
-    pushNotifications: true, // Enable push notifications
-    stateTransitionHistory: true,
-  },
-  // ... rest of agent card
-};
-```
-
-When creating the `DefaultRequestHandler`, you can optionally provide custom push notification components:
-
-```typescript
-import { 
-  DefaultRequestHandler, 
-  InMemoryPushNotificationStore,
-  DefaultPushNotificationSender 
-} from "@a2a-js/sdk/server";
-
-// Optional: Custom push notification store and sender
-const pushNotificationStore = new InMemoryPushNotificationStore();
-const pushNotificationSender = new DefaultPushNotificationSender(
-  pushNotificationStore,
-  {
-    timeout: 5000, // 5 second timeout
-    tokenHeaderName: 'X-A2A-Notification-Token' // Custom header name
-  }
-);
-
-const requestHandler = new DefaultRequestHandler(
-  movieAgentCard,
-  taskStore,
-  agentExecutor,
-  undefined, // eventBusManager (optional)
-  pushNotificationStore, // custom store
-  pushNotificationSender, // custom sender
-  undefined // extendedAgentCard (optional)
-);
-```
-
-#### Client-Side Usage
-
-Configure push notifications when sending messages:
-
-```typescript
-// Configure push notification for a message
-const pushConfig: PushNotificationConfig = {
-  id: "my-notification-config", // Optional, defaults to task ID
-  url: "https://my-app.com/webhook/task-updates",
-  token: "your-auth-token" // Optional authentication token
-};
-
-const sendParams: MessageSendParams = {
-  message: {
-    messageId: uuidv4(),
-    role: "user",
-    parts: [{ kind: "text", text: "Hello, agent!" }],
-    kind: "message",
-  },
-  configuration: {
-    blocking: true,
-    acceptedOutputModes: ["text/plain"],
-    pushNotificationConfig: pushConfig // Add push notification config
-  },
-};
-
-const response = await client.sendMessage(sendParams);
-```
-
-
-#### Webhook Endpoint Implementation
-
-Your webhook endpoint should expect POST requests with the task data:
-
-```typescript
-// Example Express.js webhook endpoint
-app.post('/webhook/task-updates', (req, res) => {
-  const task = req.body; // The complete task object
-  
-  // Verify the token if provided
-  const token = req.headers['x-a2a-notification-token'];
-  if (token !== 'your-auth-token') {
-    return res.status(401).json({ error: 'Unauthorized' });
-  }
-  
-  console.log(`Task ${task.id} status: ${task.status.state}`);
-  
-  // Process the task update
-  // ...
-  
-  res.status(200).json({ received: true });
-});
-```
-
-## A2A Client
-
-There's a `A2AClient` class, which provides methods for interacting with an A2A server over HTTP using JSON-RPC.
-
-### Key Features:
-
-- **JSON-RPC Communication:** Handles sending requests and receiving responses (both standard and streaming via Server-Sent Events) according to the JSON-RPC 2.0 specification.
-- **A2A Methods:** Implements standard A2A methods like `sendMessage`, `sendMessageStream`, `getTask`, `cancelTask`, `setTaskPushNotificationConfig`, `getTaskPushNotificationConfig`, and `resubscribeTask`.
-- **Error Handling:** Provides basic error handling for network issues and JSON-RPC errors.
-- **Streaming Support:** Manages Server-Sent Events (SSE) for real-time task updates (`sendMessageStream`, `resubscribeTask`).
-- **Extensibility:** Allows providing a custom `fetch` implementation for different environments (e.g., Node.js).
-
-### Basic Usage
-
-```typescript
-import { A2AClient } from "@a2a-js/sdk/client";
-import type {
-  Message,
-  MessageSendParams,
-  Task,
-  TaskQueryParams,
-  SendMessageResponse,
-  GetTaskResponse,
-  SendMessageSuccessResponse,
-  GetTaskSuccessResponse,
-} from "@a2a-js/sdk";
-import { v4 as uuidv4 } from "uuid";
-
-const client = new A2AClient("http://localhost:41241"); // Replace with your server URL
-
-async function run() {
-  const messageId = uuidv4();
-  let taskId: string | undefined;
-
-  try {
-    // 1. Send a message to the agent.
-    const sendParams: MessageSendParams = {
-      message: {
-        messageId: messageId,
-        role: "user",
-        parts: [{ kind: "text", text: "Hello, agent!" }],
-        kind: "message",
-      },
-      configuration: {
-        blocking: true,
-        acceptedOutputModes: ["text/plain"],
-      },
-    };
-
-    const sendResponse: SendMessageResponse =
-      await client.sendMessage(sendParams);
-
-    if (sendResponse.error) {
-      console.error("Error sending message:", sendResponse.error);
-      return;
-    }
-
-    // On success, the result can be a Task or a Message. Check which one it is.
-    const result = (sendResponse as SendMessageSuccessResponse).result;
-
-    if (result.kind === "task") {
-      // The agent created a task.
-      const taskResult = result as Task;
-      console.log("Send Message Result (Task):", taskResult);
-      taskId = taskResult.id; // Save the task ID for the next call
-    } else if (result.kind === "message") {
-      // The agent responded with a direct message.
-      const messageResult = result as Message;
-      console.log("Send Message Result (Direct Message):", messageResult);
-      // No task was created, so we can't get task status.
-    }
-
-    // 2. If a task was created, get its status.
-    if (taskId) {
-      const getParams: TaskQueryParams = { id: taskId };
-      const getResponse: GetTaskResponse = await client.getTask(getParams);
-
-      if (getResponse.error) {
-        console.error(`Error getting task ${taskId}:`, getResponse.error);
-        return;
-      }
-
-      const getTaskResult = (getResponse as GetTaskSuccessResponse).result;
-      console.log("Get Task Result:", getTaskResult);
-    }
-  } catch (error) {
-    console.error("A2A Client Communication Error:", error);
-  }
-}
-
-run();
-```
-
-### Streaming Usage
-
-```typescript
-import { A2AClient } from "@a2a-js/sdk/client";
-import type {
-  TaskStatusUpdateEvent,
-  TaskArtifactUpdateEvent,
-  MessageSendParams,
-  Task,
-  Message,
-} from "@a2a-js/sdk";
-import { v4 as uuidv4 } from "uuid";
-
-const client = new A2AClient("http://localhost:41241");
-
-async function streamTask() {
-  const messageId = uuidv4();
-  try {
-    console.log(`\n--- Starting streaming task for message ${messageId} ---`);
-
-    // Construct the `MessageSendParams` object.
-    const streamParams: MessageSendParams = {
-      message: {
-        messageId: messageId,
-        role: "user",
-        parts: [{ kind: "text", text: "Stream me some updates!" }],
-        kind: "message",
-      },
-    };
-
-    // Use the `sendMessageStream` method.
-    const stream = client.sendMessageStream(streamParams);
-    let currentTaskId: string | undefined;
-
-    for await (const event of stream) {
-      // The first event is often the Task object itself, establishing the ID.
-      if ((event as Task).kind === "task") {
-        currentTaskId = (event as Task).id;
-        console.log(
-          `[${currentTaskId}] Task created. Status: ${(event as Task).status.state}`
-        );
-        continue;
-      }
-
-      // Differentiate subsequent stream events.
-      if ((event as TaskStatusUpdateEvent).kind === "status-update") {
-        const statusEvent = event as TaskStatusUpdateEvent;
-        console.log(
-          `[${statusEvent.taskId}] Status Update: ${statusEvent.status.state} - ${
-            statusEvent.status.message?.parts[0]?.text ?? ""
-          }`
-        );
-        if (statusEvent.final) {
-          console.log(`[${statusEvent.taskId}] Stream marked as final.`);
-          break; // Exit loop when server signals completion
-        }
-      } else if (
-        (event as TaskArtifactUpdateEvent).kind === "artifact-update"
-      ) {
-        const artifactEvent = event as TaskArtifactUpdateEvent;
-        // Use artifact.name or artifact.artifactId for identification
-        console.log(
-          `[${artifactEvent.taskId}] Artifact Update: ${
-            artifactEvent.artifact.name ?? artifactEvent.artifact.artifactId
-          } - Part Count: ${artifactEvent.artifact.parts.length}`
-        );
-      } else {
-        // This could be a direct Message response if the agent doesn't create a task.
-        console.log("Received direct message response in stream:", event);
-      }
-    }
-    console.log(`--- Streaming for message ${messageId} finished ---`);
-  } catch (error) {
-    console.error(`Error during streaming for message ${messageId}:`, error);
-  }
-}
-
-streamTask();
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ class CancellableExecutor implements AgentExecutor {
 
 For very long-running tasks (e.g., lasting minutes, hours, or even days) or when clients cannot or prefer not to maintain persistent connections (like mobile clients or serverless functions), A2A supports asynchronous updates via push notifications. This mechanism allows the A2A Server to actively notify a client-provided webhook when a significant task update occurs.
 
-#### Server-Side Configuration
+### Server-Side Configuration
 
 To enable push notifications, your agent card must declare support:
 
@@ -585,7 +585,7 @@ const requestHandler = new DefaultRequestHandler(
 );
 ```
 
-#### Client-Side Usage
+### Client-Side Usage
 
 Configure push notifications when sending messages:
 
@@ -612,7 +612,7 @@ const sendParams: MessageSendParams = {
 };
 ```
 
-#### Webhook Endpoint Implementation
+### Webhook Endpoint Implementation
 
 Your webhook endpoint should expect POST requests with the task data:
 

--- a/README.md
+++ b/README.md
@@ -535,6 +535,107 @@ class CancellableExecutor implements AgentExecutor {
 }
 ```
 
+## A2A Push Notifications
+
+For very long-running tasks (e.g., lasting minutes, hours, or even days) or when clients cannot or prefer not to maintain persistent connections (like mobile clients or serverless functions), A2A supports asynchronous updates via push notifications. This mechanism allows the A2A Server to actively notify a client-provided webhook when a significant task update occurs.
+
+#### Server-Side Configuration
+
+To enable push notifications, your agent card must declare support:
+
+```typescript
+const movieAgentCard: AgentCard = {
+  // ... other properties
+  capabilities: {
+    streaming: true,
+    pushNotifications: true, // Enable push notifications
+    stateTransitionHistory: true,
+  },
+  // ... rest of agent card
+};
+```
+
+When creating the `DefaultRequestHandler`, you can optionally provide custom push notification components:
+
+```typescript
+import { 
+  DefaultRequestHandler, 
+  InMemoryPushNotificationStore,
+  DefaultPushNotificationSender 
+} from "@a2a-js/sdk/server";
+
+// Optional: Custom push notification store and sender
+const pushNotificationStore = new InMemoryPushNotificationStore();
+const pushNotificationSender = new DefaultPushNotificationSender(
+  pushNotificationStore,
+  {
+    timeout: 5000, // 5 second timeout
+    tokenHeaderName: 'X-A2A-Notification-Token' // Custom header name
+  }
+);
+
+const requestHandler = new DefaultRequestHandler(
+  movieAgentCard,
+  taskStore,
+  agentExecutor,
+  undefined, // eventBusManager (optional)
+  pushNotificationStore, // custom store
+  pushNotificationSender, // custom sender
+  undefined // extendedAgentCard (optional)
+);
+```
+
+#### Client-Side Usage
+
+Configure push notifications when sending messages:
+
+```typescript
+// Configure push notification for a message
+const pushConfig: PushNotificationConfig = {
+  id: "my-notification-config", // Optional, defaults to task ID
+  url: "https://my-app.com/webhook/task-updates",
+  token: "your-auth-token" // Optional authentication token
+};
+
+const sendParams: MessageSendParams = {
+  message: {
+    messageId: uuidv4(),
+    role: "user",
+    parts: [{ kind: "text", text: "Hello, agent!" }],
+    kind: "message",
+  },
+  configuration: {
+    blocking: true,
+    acceptedOutputModes: ["text/plain"],
+    pushNotificationConfig: pushConfig // Add push notification config
+  },
+};
+```
+
+#### Webhook Endpoint Implementation
+
+Your webhook endpoint should expect POST requests with the task data:
+
+```typescript
+// Example Express.js webhook endpoint
+app.post('/webhook/task-updates', (req, res) => {
+  const task = req.body; // The complete task object
+  
+  // Verify the token if provided
+  const token = req.headers['x-a2a-notification-token'];
+  if (token !== 'your-auth-token') {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  
+  console.log(`Task ${task.id} status: ${task.status.state}`);
+  
+  // Process the task update
+  // ...
+  
+  res.status(200).json({ received: true });
+});
+```
+
 ## License
 
 This project is licensed under the terms of the [Apache 2.0 License](https://raw.githubusercontent.com/google-a2a/a2a-python/refs/heads/main/LICENSE).

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -23,5 +23,6 @@ export { A2AError } from "./error.js";
 
 export type { PushNotificationSender } from "./push_notification/push_notification_sender.js";
 export { DefaultPushNotificationSender } from "./push_notification/default_push_notification_sender.js";
+export type { DefaultPushNotificationSenderOptions } from "./push_notification/default_push_notification_sender.js";
 export type { PushNotificationStore } from "./push_notification/push_notification_store.js";
 export { InMemoryPushNotificationStore } from "./push_notification/push_notification_store.js";

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -20,3 +20,8 @@ export { InMemoryTaskStore } from "./store.js";
 
 export { JsonRpcTransportHandler } from "./transports/jsonrpc_transport_handler.js";
 export { A2AError } from "./error.js";
+
+export type { PushNotificationSender } from "./push_notification/push_notification_sender.js";
+export { DefaultPushNotificationSender } from "./push_notification/default_push_notification_sender.js";
+export type { PushNotificationStore } from "./push_notification/push_notification_store.js";
+export { InMemoryPushNotificationStore } from "./push_notification/push_notification_store.js";

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -39,8 +39,6 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
                     console.error(`Error sending push notification for task_id=${task.id} to URL: ${pushConfig.url}. Error:`, error);
                 });
         });
-        // Return a resolved promise to indicate success
-        return Promise.resolve();
     }
 
     private async _dispatchNotification(

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -30,7 +30,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     async send(task: Task): Promise<void> {
         const pushConfigs = await this.pushNotificationStore.load(task.id);
         if (!pushConfigs || pushConfigs.length === 0) {
-            return Promise.resolve();
+            return;
         }
 
         pushConfigs.forEach(pushConfig => {
@@ -77,6 +77,5 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
         } finally {
             clearTimeout(timeoutId);
         }
-        return Promise.resolve();
     }
 }

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -16,19 +16,17 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
             return;
         }
 
-        const promises = pushConfigs.map(pushConfig => 
+        pushConfigs.forEach(pushConfig => {
             this._dispatchNotification(task, pushConfig)
-        );
-        
-        const results = await Promise.allSettled(promises);
-        
-        const failedCount = results.filter(result => 
-            result.status === 'rejected' || (result.status === 'fulfilled' && !result.value)
-        ).length;
-        
-        if (failedCount > 0) {
-            console.warn(`Some push notifications failed to send for task_id=${task.id}. ${failedCount}/${results.length} failed.`);
-        }
+                .then(success => {
+                    if (!success) {
+                        console.warn(`Push notification failed to send for task_id=${task.id} to URL: ${pushConfig.url}`);
+                    }
+                })
+                .catch(error => {
+                    console.error(`Error sending push notification for task_id=${task.id} to URL: ${pushConfig.url}. Error:`, error);
+                });
+        });
     }
 
     private async _dispatchNotification(

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -1,0 +1,65 @@
+import { Task, PushNotificationConfig } from "../../types.js";
+import { PushNotificationSender } from "./push_notification_sender.js";
+import { PushNotificationStore } from "./push_notification_store.js";
+
+export class DefaultPushNotificationSender implements PushNotificationSender {
+
+    private readonly pushNotificationStore: PushNotificationStore;
+    
+    constructor(pushNotificationStore: PushNotificationStore) {
+        this.pushNotificationStore = pushNotificationStore;
+    }
+
+    async send(task: Task): Promise<void> {
+        const pushConfigs = await this.pushNotificationStore.load(task.id);
+        if (!pushConfigs || pushConfigs.length === 0) {
+            return;
+        }
+
+        const promises = pushConfigs.map(pushConfig => 
+            this._dispatchNotification(task, pushConfig)
+        );
+        
+        const results = await Promise.allSettled(promises);
+        
+        const failedCount = results.filter(result => 
+            result.status === 'rejected' || (result.status === 'fulfilled' && !result.value)
+        ).length;
+        
+        if (failedCount > 0) {
+            console.warn(`Some push notifications failed to send for task_id=${task.id}. ${failedCount}/${results.length} failed.`);
+        }
+    }
+
+    private async _dispatchNotification(
+        task: Task, 
+        pushConfig: PushNotificationConfig
+    ): Promise<boolean> {
+        const url = pushConfig.url;
+        try {
+            const headers: Record<string, string> = {
+                'Content-Type': 'application/json'
+            };
+            
+            if (pushConfig.token) {
+                headers['X-A2A-Notification-Token'] = pushConfig.token;
+            }
+
+            const response = await fetch(url, {
+                method: 'POST',
+                headers,
+                body: JSON.stringify(task)
+            });
+
+            if (!response.ok) {
+                throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+            }
+
+            console.info(`Push notification sent for task_id=${task.id} to URL: ${url}`);
+            return true;
+        } catch (error) {
+            console.error(`Error sending push notification for task_id=${task.id} to URL: ${url}. Error:`, error);
+            return false;
+        }
+    }
+}

--- a/src/server/push_notification/push_notification_sender.ts
+++ b/src/server/push_notification/push_notification_sender.ts
@@ -1,0 +1,5 @@
+import { Task } from "../../types.js";
+
+export interface PushNotificationSender {
+    send(task: Task): Promise<void>;
+}

--- a/src/server/push_notification/push_notification_store.ts
+++ b/src/server/push_notification/push_notification_store.ts
@@ -1,0 +1,58 @@
+import { PushNotificationConfig } from "../../types.js";
+
+export interface PushNotificationStore {
+    save(taskId: string, pushNotificationConfig: PushNotificationConfig): Promise<void>;
+    load(taskId: string): Promise<PushNotificationConfig[]>;
+    delete(taskId: string, configId?: string): Promise<void>;
+}
+
+export class InMemoryPushNotificationStore implements PushNotificationStore {   
+    private store: Map<string, PushNotificationConfig[]> = new Map();
+
+    async save(taskId: string, pushNotificationConfig: PushNotificationConfig): Promise<void> {
+        const configs = this.store.get(taskId) || [];
+        
+        // Set ID if it's not already set
+        if (!pushNotificationConfig.id) {
+            pushNotificationConfig.id = taskId;
+        }
+        
+        // Remove existing config with the same ID if it exists
+        const existingIndex = configs.findIndex(config => config.id === pushNotificationConfig.id);
+        if (existingIndex !== -1) {
+            configs.splice(existingIndex, 1);
+        }
+        
+        // Add the new/updated config
+        configs.push(pushNotificationConfig);
+        this.store.set(taskId, configs);
+    }
+
+    async load(taskId: string): Promise<PushNotificationConfig[]> {
+        const configs = this.store.get(taskId);
+        return configs || [];
+    }
+
+    async delete(taskId: string, configId?: string): Promise<void> {
+        // If no configId is provided, use taskId as the configId (backward compatibility)
+        if (configId === undefined) {
+            configId = taskId;
+        }
+
+        const configs = this.store.get(taskId);
+        if (!configs) {
+            return;
+        }
+
+        const configIndex = configs.findIndex(config => config.id === configId);
+        if (configIndex !== -1) {
+            configs.splice(configIndex, 1);
+        }
+
+        if (configs.length === 0) {
+            this.store.delete(taskId);
+        } else {
+            this.store.set(taskId, configs);
+        }
+    }
+}

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -165,6 +165,11 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         // Use the (potentially updated) contextId from requestContext
         const finalMessageForAgent = requestContext.userMessage;
 
+        // If push notification config is provided, save it to the store.
+        if (params.configuration?.pushNotificationConfig) {
+            await this.pushNotificationStore.save(taskId, params.configuration.pushNotificationConfig);
+        }
+
 
         const eventBus = this.eventBusManager.createOrGetByTaskId(taskId);
         // EventQueue should be attached to the bus, before the agent execution begins.
@@ -258,6 +263,11 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
         const eventBus = this.eventBusManager.createOrGetByTaskId(taskId);
         const eventQueue = new ExecutionEventQueue(eventBus);
+
+        // If push notification config is provided, save it to the store.
+        if (params.configuration?.pushNotificationConfig) {
+            await this.pushNotificationStore.save(taskId, params.configuration.pushNotificationConfig);
+        }
 
 
         // Start agent execution (non-blocking)

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -5,11 +5,14 @@ import { AgentExecutor } from "../agent_execution/agent_executor.js";
 import { RequestContext } from "../agent_execution/request_context.js";
 import { A2AError } from "../error.js";
 import { ExecutionEventBusManager, DefaultExecutionEventBusManager } from "../events/execution_event_bus_manager.js";
-import { ExecutionEventBus } from "../events/execution_event_bus.js";
+import { AgentExecutionEvent, ExecutionEventBus } from "../events/execution_event_bus.js";
 import { ExecutionEventQueue } from "../events/execution_event_queue.js";
 import { ResultManager } from "../result_manager.js";
 import { TaskStore } from "../store.js";
 import { A2ARequestHandler } from "./a2a_request_handler.js";
+import { InMemoryPushNotificationStore, PushNotificationStore } from '../push_notification/push_notification_store.js';
+import { PushNotificationSender } from '../push_notification/push_notification_sender.js';
+import { DefaultPushNotificationSender } from '../push_notification/default_push_notification_sender.js';
 
 const terminalStates: TaskState[] = ["completed", "failed", "canceled", "rejected"];
 
@@ -19,8 +22,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     private readonly taskStore: TaskStore;
     private readonly agentExecutor: AgentExecutor;
     private readonly eventBusManager: ExecutionEventBusManager;
-    // Store for push notification configurations (could be part of TaskStore or separate)
-    private readonly pushNotificationConfigs: Map<string, PushNotificationConfig[]> = new Map();
+    private readonly pushNotificationStore: PushNotificationStore;
+    private readonly pushNotificationSender: PushNotificationSender;
 
 
     constructor(
@@ -28,6 +31,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         taskStore: TaskStore,
         agentExecutor: AgentExecutor,
         eventBusManager: ExecutionEventBusManager = new DefaultExecutionEventBusManager(),
+        pushNotificationStore: PushNotificationStore = new InMemoryPushNotificationStore(),
+        pushNotificationSender?: PushNotificationSender,
         extendedAgentCard?: AgentCard,
     ) {
         this.agentCard = agentCard;
@@ -35,6 +40,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         this.agentExecutor = agentExecutor;
         this.eventBusManager = eventBusManager;
         this.extendedAgentCard = extendedAgentCard;
+        this.pushNotificationStore = pushNotificationStore;
+        this.pushNotificationSender = pushNotificationSender || new DefaultPushNotificationSender(pushNotificationStore);
     }
 
     async getAgentCard(): Promise<AgentCard> {
@@ -113,6 +120,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         try {
             for await (const event of eventQueue.events()) {
                 await resultManager.processEvent(event);
+
+                await this._sendPushNotificationIfNeeded(event);
 
                 if (options?.firstResultResolver && !firstResultSent) {
                     if (event.kind === 'message' || event.kind === 'task') {
@@ -279,6 +288,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         try {
             for await (const event of eventQueue.events()) {
                 await resultManager.processEvent(event); // Update store in background
+                await this._sendPushNotificationIfNeeded(event);
                 yield event; // Stream the event to the client
             }
         } finally {
@@ -362,14 +372,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
             pushNotificationConfig.id = taskId;
         }
 
-        const configs = this.pushNotificationConfigs.get(taskId) || [];
-        
-        // Remove existing config with the same ID to replace it
-        const updatedConfigs = configs.filter(c => c.id !== pushNotificationConfig.id);
-        
-        updatedConfigs.push(pushNotificationConfig);
-
-        this.pushNotificationConfigs.set(taskId, updatedConfigs);
+        await this.pushNotificationStore.save(taskId, pushNotificationConfig);
 
         return params;
     }
@@ -385,7 +388,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
             throw A2AError.taskNotFound(params.id);
         }
 
-        const configs = this.pushNotificationConfigs.get(params.id) || [];
+        const configs = await this.pushNotificationStore.load(params.id);
         if (configs.length === 0) {
             throw A2AError.internalError(`Push notification config not found for task ${params.id}.`);
         }
@@ -417,7 +420,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
             throw A2AError.taskNotFound(params.id);
         }
 
-        const configs = this.pushNotificationConfigs.get(params.id) || [];
+        const configs = await this.pushNotificationStore.load(params.id);
 
         return configs.map(config => ({
             taskId: params.id,
@@ -438,18 +441,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         
         const { id: taskId, pushNotificationConfigId } = params;
 
-        const configs = this.pushNotificationConfigs.get(taskId);
-        if (!configs) {
-            return;
-        }
-
-        const updatedConfigs = configs.filter(c => c.id !== pushNotificationConfigId);
-
-        if (updatedConfigs.length === 0) {
-            this.pushNotificationConfigs.delete(taskId);
-        } else if (updatedConfigs.length < configs.length) {
-            this.pushNotificationConfigs.set(taskId, updatedConfigs);
-        }
+        await this.pushNotificationStore.delete(taskId, pushNotificationConfigId);
     }
 
     async *resubscribe(
@@ -510,6 +502,22 @@ export class DefaultRequestHandler implements A2ARequestHandler {
             }
         } finally {
             eventQueue.stop();
+        }
+    }
+
+    private async _sendPushNotificationIfNeeded(event: AgentExecutionEvent): Promise<void> {
+        if (event.kind === 'status-update') {
+            const statusUpdate = event as TaskStatusUpdateEvent;
+            const task = await this.taskStore.load(statusUpdate.taskId);
+            if (!task) {
+                console.error(`Task ${statusUpdate.taskId} not found.`);
+                return;
+            }
+            try {
+                await this.pushNotificationSender.send(task);
+            } catch (error) {
+                console.error(`Failed to send push notification for task ${statusUpdate.taskId}:`, error);
+            }
         }
     }
 }

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -594,24 +594,13 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
             url: 'https://push-1.com'
         };
         const contextId = 'ctx-push-1';
-        const taskId = 'task-push-1';
-
-        const task: Task = {
-            id: taskId,
-            contextId,
-            status: { state: "submitted" },
-            kind: 'task'
-        };
-        await mockTaskStore.save(task);
 
         const params: MessageSendParams = {
-            message: {
-                ...createTestMessage('msg-push-1', 'Work more on the task'),
-                taskId
-            },
+            message: createTestMessage('msg-push-1', 'Work on task with push notification'),
+            configuration: {
+                pushNotificationConfig: pushNotificationConfig
+            }
         };
-
-        await handler.setTaskPushNotificationConfig({ taskId, pushNotificationConfig });
 
         (mockAgentExecutor as MockAgentExecutor).execute.callsFake(async (ctx, bus) => {
             bus.publish({
@@ -640,12 +629,12 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
         const result = await handler.sendMessage(params);
         const taskResult = result as Task;
 
-        assert.equal(taskResult.id, taskId);
+        assert.equal(taskResult.id, taskResult.id);
         assert.equal(taskResult.status.state, "completed");
 
         assert.isTrue((mockPushNotificationSender as MockPushNotificationSender).send.calledTwice);
-        assert.equal((mockPushNotificationSender as MockPushNotificationSender).send.firstCall.args[0].id, taskId);
-        assert.equal((mockPushNotificationSender as MockPushNotificationSender).send.secondCall.args[0].id, taskId);
+        assert.equal((mockPushNotificationSender as MockPushNotificationSender).send.firstCall.args[0].id, taskResult.id);
+        assert.equal((mockPushNotificationSender as MockPushNotificationSender).send.secondCall.args[0].id, taskResult.id);
     });
 
     it('Push Notification methods should throw error if task does not exist', async () => {

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -91,8 +91,6 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     // Before each test, reset the components to a clean state
     beforeEach(() => {
         mockTaskStore = new InMemoryTaskStore();
-        mockPushNotificationStore = new InMemoryPushNotificationStore();
-        mockPushNotificationSender = new MockPushNotificationSender();
         // Default mock for most tests
         mockAgentExecutor = new MockAgentExecutor();
         executionEventBusManager = new DefaultExecutionEventBusManager();
@@ -582,6 +580,9 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     });
 
     it('should send push notification when task update is received', async () => {
+        const mockPushNotificationStore = new InMemoryPushNotificationStore();
+        const mockPushNotificationSender = new MockPushNotificationSender();
+        
         const handler = new DefaultRequestHandler(
             testAgentCard,
             mockTaskStore,
@@ -632,9 +633,10 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
         assert.equal(taskResult.id, taskResult.id);
         assert.equal(taskResult.status.state, "completed");
 
-        assert.isTrue((mockPushNotificationSender as MockPushNotificationSender).send.calledTwice);
+        assert.isTrue((mockPushNotificationSender as MockPushNotificationSender).send.calledThrice);
         assert.equal((mockPushNotificationSender as MockPushNotificationSender).send.firstCall.args[0].id, taskResult.id);
         assert.equal((mockPushNotificationSender as MockPushNotificationSender).send.secondCall.args[0].id, taskResult.id);
+        assert.equal((mockPushNotificationSender as MockPushNotificationSender).send.thirdCall.args[0].id, taskResult.id);
     });
 
     it('Push Notification methods should throw error if task does not exist', async () => {

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -629,40 +629,37 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
 
         const result = await handler.sendMessage(params);
         const taskResult = result as Task;
+        const task = await mockTaskStore.load(taskResult.id);
 
         // Verify the complete task object
-        assert.isDefined(taskResult.id);
-        assert.equal(taskResult.contextId, contextId);
-        assert.equal(taskResult.kind, 'task');
-        assert.equal(taskResult.status.state, "completed");
-        assert.isArray(taskResult.history);
+        assert.deepEqual(taskResult, task);
 
         // Verify push notifications were sent with complete task objects
         assert.isTrue((mockPushNotificationSender as MockPushNotificationSender).send.calledThrice);
         
         // Verify first call (submitted state)
         const firstCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.firstCall.args[0] as Task;
-        assert.isDefined(firstCallTask.id, 'First call task ID should be defined');
-        assert.equal(firstCallTask.id, taskResult.id);
-        assert.equal(firstCallTask.contextId, contextId);
-        assert.equal(firstCallTask.kind, 'task');
-        assert.equal(firstCallTask.status.state, 'submitted');
+        const expectedFirstTask: Task = {
+            ...taskResult,
+            status: { state: 'submitted' }
+        };
+        assert.deepEqual(firstCallTask, expectedFirstTask);
         
-        // Verify second call (working state)
+        // // Verify second call (working state)
         const secondCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.secondCall.args[0] as Task;
-        assert.isDefined(secondCallTask.id, 'Second call task ID should be defined');
-        assert.equal(secondCallTask.id, taskResult.id);
-        assert.equal(secondCallTask.contextId, contextId);
-        assert.equal(secondCallTask.kind, 'task');
-        assert.equal(secondCallTask.status.state, 'working');
+        const expectedSecondTask: Task = {
+            ...taskResult,
+            status: { state: 'working' }
+        };
+        assert.deepEqual(secondCallTask, expectedSecondTask);
         
-        // Verify third call (completed state)
+        // // Verify third call (completed state)
         const thirdCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.thirdCall.args[0] as Task;
-        assert.isDefined(thirdCallTask.id, 'Third call task ID should be defined');
-        assert.equal(thirdCallTask.id, taskResult.id);
-        assert.equal(thirdCallTask.contextId, contextId);
-        assert.equal(thirdCallTask.kind, 'task');
-        assert.equal(thirdCallTask.status.state, 'completed');
+        const expectedThirdTask: Task = {
+            ...taskResult,
+            status: { state: 'completed' }
+        };
+        assert.deepEqual(thirdCallTask, expectedThirdTask);
     });
 
     it('sendMessageStream: should send push notification when task update is received', async () => {
@@ -729,26 +726,32 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
         // Verify push notifications were sent with complete task objects
         assert.isTrue((mockPushNotificationSender as MockPushNotificationSender).send.calledThrice);
         
+        const taskId = (events[0] as Task).id;
+        const taskResult = await mockTaskStore.load(taskId);
+        
         // Verify first call (submitted state)
         const firstCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.firstCall.args[0] as Task;
-        assert.equal(firstCallTask.id, (events[0] as Task).id);
-        assert.equal(firstCallTask.contextId, contextId);
-        assert.equal(firstCallTask.kind, 'task');
-        assert.equal(firstCallTask.status.state, 'submitted');
+        const expectedFirstTask: Task = {
+            ...taskResult,
+            status: { state: 'submitted' }
+        };
+        assert.deepEqual(firstCallTask, expectedFirstTask);
         
         // Verify second call (working state)
         const secondCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.secondCall.args[0] as Task;
-        assert.equal(secondCallTask.id, (events[0] as Task).id);
-        assert.equal(secondCallTask.contextId, contextId);
-        assert.equal(secondCallTask.kind, 'task');
-        assert.equal(secondCallTask.status.state, 'working');
+        const expectedSecondTask: Task = {
+            ...taskResult,
+            status: { state: 'working' }
+        };
+        assert.deepEqual(secondCallTask, expectedSecondTask);
         
         // Verify third call (completed state)
         const thirdCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.thirdCall.args[0] as Task;
-        assert.equal(thirdCallTask.id, (events[0] as Task).id);
-        assert.equal(thirdCallTask.contextId, contextId);
-        assert.equal(thirdCallTask.kind, 'task');
-        assert.equal(thirdCallTask.status.state, 'completed');
+        const expectedThirdTask: Task = {
+            ...taskResult,
+            status: { state: 'completed' }
+        };
+        assert.deepEqual(thirdCallTask, expectedThirdTask);
     });
 
     it('Push Notification methods should throw error if task does not exist', async () => {

--- a/test/server/mocks/agent-executor.mock.ts
+++ b/test/server/mocks/agent-executor.mock.ts
@@ -17,6 +17,42 @@ export class MockAgentExecutor implements AgentExecutor {
 }
 
 /**
+ * Fake implementation of the task execution events.
+ */
+export const fakeTaskExecute = async (ctx: RequestContext, bus: ExecutionEventBus) => {
+    const taskId = ctx.taskId;
+    const contextId = ctx.contextId;
+    
+    // Publish task creation
+    bus.publish({ 
+        id: taskId, 
+        contextId, 
+        status: { state: "submitted" }, 
+        kind: 'task' 
+    });
+    
+    // Publish working status
+    bus.publish({ 
+        taskId, 
+        contextId, 
+        kind: 'status-update', 
+        status: { state: "working" }, 
+        final: false 
+    });
+    
+    // Publish completion
+    bus.publish({ 
+        taskId, 
+        contextId, 
+        kind: 'status-update', 
+        status: { state: "completed" }, 
+        final: true 
+    });
+    
+    bus.finished();
+}
+
+/**
  * A realistic mock of AgentExecutor for cancellation tests.
  */
 export class CancellableMockAgentExecutor implements AgentExecutor {

--- a/test/server/mocks/agent-executor.mock.ts
+++ b/test/server/mocks/agent-executor.mock.ts
@@ -1,0 +1,65 @@
+import sinon, { SinonStub, SinonFakeTimers } from 'sinon';
+import { AgentExecutor } from '../../../src/server/agent_execution/agent_executor.js';
+import { RequestContext, ExecutionEventBus } from '../../../src/server/index.js';
+
+/**
+ * A mock implementation of AgentExecutor to control agent behavior during tests.
+ */
+export class MockAgentExecutor implements AgentExecutor {
+    // Stubs to control and inspect calls to execute and cancelTask
+    public execute: SinonStub<
+        [RequestContext, ExecutionEventBus],
+        Promise<void>
+    > = sinon.stub();
+    
+    public cancelTask: SinonStub<[string, ExecutionEventBus], Promise<void>> =
+        sinon.stub();
+}
+
+/**
+ * A realistic mock of AgentExecutor for cancellation tests.
+ */
+export class CancellableMockAgentExecutor implements AgentExecutor {
+    private cancelledTasks = new Set<string>();
+    private clock: SinonFakeTimers;
+
+    constructor(clock: SinonFakeTimers) {
+        this.clock = clock;
+    }
+
+    public execute = async (
+        requestContext: RequestContext,
+        eventBus: ExecutionEventBus,
+    ): Promise<void> => {
+        const taskId = requestContext.taskId;
+        const contextId = requestContext.contextId;
+        
+        eventBus.publish({ id: taskId, contextId, status: { state: "submitted" }, kind: 'task' });
+        eventBus.publish({ taskId, contextId, kind: 'status-update', status: { state: "working" }, final: false });
+        
+        // Simulate a long-running process
+        for (let i = 0; i < 5; i++) {
+            if (this.cancelledTasks.has(taskId)) {
+                eventBus.publish({ taskId, contextId, kind: 'status-update', status: { state: "canceled" }, final: true });
+                eventBus.finished();
+                return;
+            }
+            // Use fake timers to simulate work
+            await this.clock.tickAsync(100); 
+        }
+
+        eventBus.publish({ taskId, contextId, kind: 'status-update', status: { state: "completed" }, final: true });
+        eventBus.finished();
+    };
+    
+    public cancelTask = async (
+        taskId: string,
+        eventBus: ExecutionEventBus,
+    ): Promise<void> => {
+        this.cancelledTasks.add(taskId);
+        // The execute loop is responsible for publishing the final state
+    };
+    
+    // Stub for spying on cancelTask calls
+    public cancelTaskSpy = sinon.spy(this, 'cancelTask');
+}

--- a/test/server/mocks/push_notification_sender.mock.ts
+++ b/test/server/mocks/push_notification_sender.mock.ts
@@ -1,0 +1,7 @@
+import sinon, { SinonStub } from 'sinon';
+import { Task } from '../../../src/index.js';
+import { PushNotificationSender } from '../../../src/server/push_notification/push_notification_sender.js';
+
+export class MockPushNotificationSender implements PushNotificationSender {
+    public send: SinonStub<[Task], Promise<void>> = sinon.stub();
+}

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -11,9 +11,7 @@ import { InMemoryPushNotificationStore } from '../../src/server/push_notificatio
 import { DefaultPushNotificationSender } from '../../src/server/push_notification/default_push_notification_sender.js';
 import { DefaultExecutionEventBusManager } from '../../src/server/events/execution_event_bus_manager.js';
 import { AgentCard, Message, MessageSendParams, PushNotificationConfig, Task } from '../../src/index.js';
-import { AgentExecutor } from '../../src/server/agent_execution/agent_executor.js';
-import { RequestContext } from '../../src/server/agent_execution/request_context.js';
-import { ExecutionEventBus } from '../../src/server/events/execution_event_bus.js';
+import { MockAgentExecutor } from './mocks/agent-executor.mock.js';
 
 describe('Push Notification Integration Tests', () => {
     let testServer: Server;
@@ -41,20 +39,6 @@ describe('Push Notification Integration Tests', () => {
         defaultOutputModes: ['text/plain'],
         skills: [],
     };
-
-    // Mock AgentExecutor following the pattern from default_request_handler.spec.ts
-    class MockAgentExecutor implements AgentExecutor {
-        // Stubs to control and inspect calls to execute
-        public execute: sinon.SinonStub<
-            [RequestContext, ExecutionEventBus],
-            Promise<void>
-        > = sinon.stub();
-        
-        public cancelTask: sinon.SinonStub<
-            [string, ExecutionEventBus],
-            Promise<void>
-        > = sinon.stub();
-    }
 
     // Create test Express server to receive push notifications
     const createTestServer = (): Promise<{ server: Server; port: number; url: string }> => {

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -72,9 +72,6 @@ describe('Push Notification Integration Tests', () => {
                     case 'error':
                         res.status(500).json({ error: 'Internal Server Error' });
                         break;
-                    case 'unauthorized':
-                        res.status(401).json({ error: 'Unauthorized' });
-                        break;
                     default:
                         res.status(200).json({ received: true });
                 }

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -118,9 +118,7 @@ describe('Push Notification Integration Tests', () => {
     afterEach(async () => {
         // Clean up test server
         if (testServer) {
-            await new Promise<void>((resolve) => {
-                testServer.close(() => resolve());
-            });
+           await testServer.close();
         }
         sinon.restore();
     });

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -1,0 +1,360 @@
+import 'mocha';
+import { assert, expect } from 'chai';
+import sinon from 'sinon';
+import express, { Request, Response } from 'express';
+import { Server } from 'http';
+import { AddressInfo } from 'net';
+
+import { DefaultRequestHandler } from '../../src/server/request_handler/default_request_handler.js';
+import { InMemoryTaskStore } from '../../src/server/store.js';
+import { InMemoryPushNotificationStore } from '../../src/server/push_notification/push_notification_store.js';
+import { DefaultPushNotificationSender } from '../../src/server/push_notification/default_push_notification_sender.js';
+import { DefaultExecutionEventBusManager } from '../../src/server/events/execution_event_bus_manager.js';
+import { AgentCard, Message, MessageSendParams, PushNotificationConfig, Task } from '../../src/index.js';
+import { AgentExecutor } from '../../src/server/agent_execution/agent_executor.js';
+import { RequestContext } from '../../src/server/agent_execution/request_context.js';
+import { ExecutionEventBus } from '../../src/server/events/execution_event_bus.js';
+
+describe('Push Notification Integration Tests', () => {
+    let testServer: Server;
+    let testServerPort: number;
+    let testServerUrl: string;
+    let receivedNotifications: Array<{ body: any; headers: any; url: string; method: string }> = [];
+    
+    let taskStore: InMemoryTaskStore;
+    let handler: DefaultRequestHandler;
+    let mockAgentExecutor: MockAgentExecutor;
+    let pushNotificationStore: InMemoryPushNotificationStore;
+    let pushNotificationSender: DefaultPushNotificationSender;
+
+    const testAgentCard: AgentCard = {
+        name: 'Test Agent',
+        description: 'An agent for testing push notifications',
+        url: 'http://localhost:8080',
+        version: '1.0.0',
+        protocolVersion: '0.3.0',
+        capabilities: {
+            streaming: true,
+            pushNotifications: true,
+        },
+        defaultInputModes: ['text/plain'],
+        defaultOutputModes: ['text/plain'],
+        skills: [],
+    };
+
+    // Mock AgentExecutor following the pattern from default_request_handler.spec.ts
+    class MockAgentExecutor implements AgentExecutor {
+        // Stubs to control and inspect calls to execute
+        public execute: sinon.SinonStub<
+            [RequestContext, ExecutionEventBus],
+            Promise<void>
+        > = sinon.stub();
+        
+        public cancelTask: sinon.SinonStub<
+            [string, ExecutionEventBus],
+            Promise<void>
+        > = sinon.stub();
+    }
+
+    // Create test Express server to receive push notifications
+    const createTestServer = (): Promise<{ server: Server; port: number; url: string }> => {
+        return new Promise((resolve) => {
+            const app = express();
+            app.use(express.json());
+
+            // Endpoint to receive push notifications
+            app.post('/notify', (req: Request, res: Response) => {
+                receivedNotifications.push({
+                    body: req.body,
+                    headers: req.headers,
+                    url: req.url,
+                    method: req.method
+                });
+                res.status(200).json({ received: true, timestamp: new Date().toISOString() });
+            });
+
+            // Endpoint to simulate different response scenarios
+            app.post('/notify/:scenario', (req: Request, res: Response) => {
+                const scenario = req.params.scenario;
+                
+                receivedNotifications.push({
+                    body: req.body,
+                    headers: req.headers,
+                    url: req.url,
+                    method: req.method
+                });
+
+                switch (scenario) {
+                    case 'slow':
+                        setTimeout(() => res.status(200).json({ received: true }), 50);
+                        break;
+                    case 'error':
+                        res.status(500).json({ error: 'Internal Server Error' });
+                        break;
+                    case 'unauthorized':
+                        res.status(401).json({ error: 'Unauthorized' });
+                        break;
+                    default:
+                        res.status(200).json({ received: true });
+                }
+            });
+
+            const server = app.listen(0, () => {
+                const port = (server.address() as AddressInfo).port;
+                const url = `http://localhost:${port}`;
+                resolve({ server, port, url });
+            });
+        });
+    };
+
+    beforeEach(async () => {
+        // Reset state
+        receivedNotifications = [];
+        
+        // Create and start test server
+        const serverInfo = await createTestServer();
+        testServer = serverInfo.server;
+        testServerPort = serverInfo.port;
+        testServerUrl = serverInfo.url;
+
+        // Create fresh instances for each test
+        taskStore = new InMemoryTaskStore();
+        mockAgentExecutor = new MockAgentExecutor();
+        const executionEventBusManager = new DefaultExecutionEventBusManager();
+        pushNotificationStore = new InMemoryPushNotificationStore();
+        pushNotificationSender = new DefaultPushNotificationSender(pushNotificationStore);
+
+        handler = new DefaultRequestHandler(
+            testAgentCard,
+            taskStore,
+            mockAgentExecutor,
+            executionEventBusManager,
+            pushNotificationStore,
+            pushNotificationSender,
+        );
+    });
+
+    afterEach(async () => {
+        // Clean up test server
+        if (testServer) {
+            await new Promise<void>((resolve) => {
+                testServer.close(() => resolve());
+            });
+        }
+        sinon.restore();
+    });
+
+    const createTestMessage = (text: string, taskId?: string): Message => ({
+        messageId: `msg-${Date.now()}`,
+        role: 'user',
+        parts: [{ kind: 'text', text }],
+        kind: 'message',
+        ...(taskId && { taskId })
+    });
+
+    describe('End-to-End Push Notification Flow', () => {
+        it('should send push notifications for task status updates', async () => {
+            const pushConfig: PushNotificationConfig = {
+                id: 'test-push-config',
+                url: `${testServerUrl}/notify`,
+                token: 'test-auth-token'
+            };
+
+            const params: MessageSendParams = {
+                message: createTestMessage('Test task with push notifications'),
+                configuration: {
+                    pushNotificationConfig: pushConfig
+                }
+            };
+
+            // Mock the agent executor to publish all three states for this test only
+            mockAgentExecutor.execute.callsFake(async (ctx, bus) => {
+                const taskId = ctx.taskId;
+                const contextId = ctx.contextId;
+                
+                // Publish task creation
+                bus.publish({ 
+                    id: taskId, 
+                    contextId, 
+                    status: { state: "submitted" }, 
+                    kind: 'task' 
+                });
+                
+                // Publish working status
+                bus.publish({ 
+                    taskId, 
+                    contextId, 
+                    kind: 'status-update', 
+                    status: { state: "working" }, 
+                    final: false 
+                });
+                
+                // Publish completion
+                bus.publish({ 
+                    taskId, 
+                    contextId, 
+                    kind: 'status-update', 
+                    status: { state: "completed" }, 
+                    final: true 
+                });
+                
+                bus.finished();
+            });
+
+            // Send message and wait for completion
+            const result = await handler.sendMessage(params);
+            const task = result as Task;
+
+            // Wait for async push notifications to be sent
+            await new Promise(resolve => setTimeout(resolve, 200));
+
+            // Verify push notifications were sent
+            assert.lengthOf(receivedNotifications, 3, 'Should send notifications for submitted, working, and completed states');
+            
+            // Verify all three states are present (order may vary)
+            const states = receivedNotifications.map(n => n.body.status.state);
+            assert.include(states, 'submitted', 'Should include submitted state');
+            assert.include(states, 'working', 'Should include working state');
+            assert.include(states, 'completed', 'Should include completed state');
+            
+            // Verify first notification has correct format
+            const firstNotification = receivedNotifications[0];
+            assert.equal(firstNotification.method, 'POST');
+            assert.equal(firstNotification.url, '/notify');
+            assert.equal(firstNotification.headers['content-type'], 'application/json');
+            assert.equal(firstNotification.headers['x-a2a-notification-token'], 'test-auth-token');
+            assert.equal(firstNotification.body.id, task.id);
+        });
+
+        it('should handle multiple push notification endpoints for the same task', async () => {
+            const pushConfig1: PushNotificationConfig = {
+                id: 'config-1',
+                url: `${testServerUrl}/notify`,
+                token: 'token-1'
+            };
+            
+            const pushConfig2: PushNotificationConfig = {
+                id: 'config-2',
+                url: `${testServerUrl}/notify/second`,
+                token: 'token-2'
+            };
+
+            const params: MessageSendParams = {
+                message: {
+                    ...createTestMessage('Test task with multiple push endpoints'),
+                    taskId: 'test-multi-endpoints',
+                    contextId: 'test-context'
+                }
+            };
+
+            // Assume the task is created by a previous message
+            const task: Task = {
+                id: 'test-multi-endpoints',
+                contextId: 'test-context',
+                status: { state: 'submitted' },
+                kind: 'task'
+            };
+            await taskStore.save(task);
+
+            // Set multiple push notification configs for this message
+            await handler.setTaskPushNotificationConfig({
+                taskId: task.id,
+                pushNotificationConfig: pushConfig1
+            });
+
+            await handler.setTaskPushNotificationConfig({
+                taskId: task.id,
+                pushNotificationConfig: pushConfig2
+            });
+
+            // Mock the agent executor to publish only completed state
+            mockAgentExecutor.execute.callsFake(async (ctx, bus) => {
+                const taskId = ctx.taskId;
+                const contextId = ctx.contextId;
+                
+                // Publish working status
+                bus.publish({ 
+                    id: taskId, 
+                    contextId, 
+                    status: { state: "working" }, 
+                    kind: 'task' 
+                });
+                
+                // Publish completion directly
+                bus.publish({ 
+                    taskId, 
+                    contextId, 
+                    kind: 'status-update', 
+                    status: { state: "completed" }, 
+                    final: true 
+                });
+                
+                bus.finished();
+            });
+
+            // Send a message to trigger notifications
+            await handler.sendMessage(params);
+
+            // Wait for async push notifications to be sent
+            await new Promise(resolve => setTimeout(resolve, 300));
+
+            // Should now have notifications from both endpoints
+            const allEndpoints = receivedNotifications.map(n => n.url);
+            assert.include(allEndpoints, '/notify', 'Should notify primary endpoint');
+            assert.include(allEndpoints, '/notify/second', 'Should notify second endpoint');
+        });
+
+        it('should handle slow push notification endpoints gracefully', async () => {
+            const slowConfig: PushNotificationConfig = {
+                id: 'slow-config',
+                url: `${testServerUrl}/notify/slow`,
+                token: 'slow-token'
+            };
+
+            const params: MessageSendParams = {
+                message: createTestMessage('Test task with slow push notifications'),
+                configuration: {
+                    pushNotificationConfig: slowConfig
+                }
+            };
+
+            // Mock the agent executor to publish only completed state
+            mockAgentExecutor.execute.callsFake(async (ctx, bus) => {
+                const taskId = ctx.taskId;
+                const contextId = ctx.contextId;
+                
+                // Publish task creation
+                bus.publish({ 
+                    id: taskId, 
+                    contextId, 
+                    status: { state: "submitted" }, 
+                    kind: 'task' 
+                });
+                
+                // Publish completion directly
+                bus.publish({ 
+                    taskId, 
+                    contextId, 
+                    kind: 'status-update', 
+                    status: { state: "completed" }, 
+                    final: true 
+                });
+                
+                bus.finished();
+            });
+
+            // Send message
+            await handler.sendMessage(params);
+
+            // Wait for slow push notifications
+            await new Promise(resolve => setTimeout(resolve, 300));
+
+            // Should receive notifications even from slow endpoint
+            assert.isTrue(receivedNotifications.length >= 2, 'Should receive notifications from slow endpoint');
+            
+            // Verify all notifications were received
+            const slowNotifications = receivedNotifications.filter(n => n.url === '/notify/slow');
+            assert.isTrue(slowNotifications.length >= 2, 'Slow endpoint should receive all status updates');
+        });
+    });
+});


### PR DESCRIPTION
# Description

Added push notifications support in the Server sdk.
Defines the configuration for setting up push notifications for task updates.

Added an `InMemoryPushNotificationStore`, refactored from within the `DefaultRequestHandler`.
Provided interface for push notification store which can be extended
Added a default implementation in `DefaultRequestHandler`.

Added support when pushNotification config available in `messageSendParams`

Existing push notification tests still pass
Added new test to ensure push notifications are being called


Fixes #89  🦕
