### PR TITLE
feat: allow custom http client and more generic client options

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,9 +422,7 @@ const customClient = new MyCustomClient("your-auth-token");
 
 // Pass the custom HTTP client to the A2AClient constructor
 const client = new A2AClient("http://localhost:41241", {
-  options: {
-    httpClient: customClient,
-  },
+  httpClient: customClient,
 });
 
 // Use the client as normal - all requests will include the authorization header

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -89,7 +89,7 @@ export class A2AClient {
    * @param agentBaseUrl The base URL of the A2A agent (e.g., https://agent.example.com)
    * @param options A2AClientOptions object that can include:
    * - `agentCardPath`: The path to the agent card, defaults to '.well-known/agent-card.json'.
-   * - `httpClient`: An optional custom HTTP client implementation that implements the `HttpClient` interface. If not provided, a default implementation using the fetch
+   * - `httpClient`: An optional custom HTTP client implementation that implements the `HttpClient` interface. If not provided, a default HttpClient will be used, that is native node js fetch under the hood.
    */
   constructor(
     agentBaseUrl: string,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -2,4 +2,4 @@
  * Client entry point for the A2A Server V2 library.
  */
 
-export { A2AClient } from "./client.js";
+export { A2AClient, HttpClient, A2AClientOptions } from "./client.js";

--- a/test/client/client.spec.ts
+++ b/test/client/client.spec.ts
@@ -1,0 +1,331 @@
+import 'mocha';
+import { assert, expect } from 'chai';
+import sinon, { SinonStub } from 'sinon';
+
+// Import directly from client.ts instead of index.js to avoid build issues
+import { A2AClient, HttpClient, DefaultHttpClient } from '../../src/client/client.js';
+import { AgentCard, MessageSendParams, SendMessageResponse } from '../../src/index.js';
+
+describe('A2AClient with HttpClient', () => {
+  let mockResponse: Response;
+  let mockAgentCard: AgentCard;
+  
+  beforeEach(() => {
+    // Create a mock agent card
+    mockAgentCard = {
+      name: 'Test Agent',
+      description: 'An agent for testing purposes',
+      url: 'http://localhost:8080/rpc',
+      version: '1.0.0',
+      protocolVersion: '0.3.0',
+      capabilities: {
+        streaming: true,
+        pushNotifications: true,
+      },
+      defaultInputModes: ['text/plain'],
+      defaultOutputModes: ['text/plain'],
+      skills: [
+        {
+          id: 'test-skill',
+          name: 'Test Skill',
+          description: 'A skill for testing',
+          tags: ['test'],
+        },
+      ],
+    };
+    
+    // Create a mock response
+    mockResponse = new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        result: {
+          kind: 'message',
+          messageId: 'response-1',
+          role: 'agent',
+          parts: [{ kind: 'text', text: 'Hello from the agent!' }],
+        },
+      }),
+      {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+  });
+  
+  afterEach(() => {
+    sinon.restore();
+  });
+  
+  it('should use the default HttpClient when none is provided', async () => {
+    // Stub the global fetch function
+    const fetchStub = sinon.stub(global, 'fetch').resolves(
+      new Response(
+        JSON.stringify(mockAgentCard),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+    );
+    
+    const client = new A2AClient('http://localhost:8080');
+    
+    // Wait for the agent card to be fetched
+    await client.getAgentCard();
+    
+    // Verify that fetch was called with the expected URL
+    assert.isTrue(fetchStub.calledOnce);
+    assert.equal(fetchStub.firstCall.args[0], 'http://localhost:8080/.well-known/agent-card.json');
+  });
+  
+  it('should use the provided custom HttpClient', async () => {
+    // Create a mock HttpClient
+    const mockHttpClient: HttpClient = {
+      sendRequest: sinon.stub().resolves(
+        new Response(
+          JSON.stringify(mockAgentCard),
+          {
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }
+        )
+      ),
+    };
+    
+    const client = new A2AClient('http://localhost:8080', { httpClient: mockHttpClient } );
+    
+    // Wait for the agent card to be fetched
+    await client.getAgentCard();
+    
+    // Verify that the custom HttpClient was used
+    assert.isTrue((mockHttpClient.sendRequest as SinonStub).calledOnce);
+    assert.equal((mockHttpClient.sendRequest as SinonStub).firstCall.args[0], 'http://localhost:8080/.well-known/agent-card.json');
+  });
+  
+  it('should use the custom HttpClient for all HTTP requests', async () => {
+    // Create a mock HttpClient
+    const mockHttpClient: HttpClient = {
+      sendRequest: sinon.stub().resolves(mockResponse),
+    };
+    
+    // First response is for the agent card fetch
+    (mockHttpClient.sendRequest as SinonStub).onFirstCall().resolves(
+      new Response(
+        JSON.stringify(mockAgentCard),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+    );
+    
+    const client = new A2AClient('http://localhost:8080', { httpClient: mockHttpClient });
+    
+    // Wait for the agent card to be fetched
+    await client.getAgentCard();
+    
+    // Send a message
+    const params: MessageSendParams = {
+      message: {
+        messageId: 'msg-1',
+        role: 'user',
+        parts: [{ kind: 'text', text: 'Hello!' }],
+        kind: 'message',
+      },
+    };
+    
+    await client.sendMessage(params);
+    
+    // Verify that the custom HttpClient was used for both requests
+    assert.isTrue((mockHttpClient.sendRequest as SinonStub).calledTwice);
+    assert.equal((mockHttpClient.sendRequest as SinonStub).firstCall.args[0], 'http://localhost:8080/.well-known/agent-card.json');
+    assert.equal((mockHttpClient.sendRequest as SinonStub).secondCall.args[0], 'http://localhost:8080/rpc');
+  });
+  
+  it('should allow adding custom headers via a custom HttpClient', async () => {
+    // Create a custom HttpClient that adds an authorization header
+    class AuthHttpClient implements HttpClient {
+      private authToken: string;
+      
+      constructor(authToken: string) {
+        this.authToken = authToken;
+      }
+      
+      async sendRequest(url: string, options?: RequestInit): Promise<Response> {
+        // Add authorization header to all requests
+        const headers = {
+          ...options.headers,
+          'Authorization': `Bearer ${this.authToken}`
+        };
+        
+        // Create a new options object with the updated headers
+        const updatedOptions = {
+          ...options,
+          headers
+        };
+        
+        // For testing, just return a mock response
+        if (url.includes('agent-card')) {
+          return new Response(
+            JSON.stringify(mockAgentCard),
+            {
+              status: 200,
+              headers: {
+                'Content-Type': 'application/json',
+              },
+            }
+          );
+        }
+        
+        // Store the options for inspection in tests
+        (this.sendRequest as any).lastOptions = updatedOptions;
+        
+        return mockResponse;
+      }
+    }
+    
+    // Create a spy to inspect the headers
+    const sendRequestSpy = sinon.spy(AuthHttpClient.prototype, 'sendRequest');
+    
+    const customAuthClient = new AuthHttpClient('test-token');
+    const client = new A2AClient('http://localhost:8080', { httpClient: customAuthClient });
+    
+    // Wait for the agent card to be fetched
+    await client.getAgentCard();
+    
+    // Send a message
+    const params: MessageSendParams = {
+      message: {
+        messageId: 'msg-1',
+        role: 'user',
+        parts: [{ kind: 'text', text: 'Hello!' }],
+        kind: 'message',
+      },
+    };
+    
+    await client.sendMessage(params);
+    
+    // Verify that the authorization header was added to both requests
+    assert.isTrue(sendRequestSpy.calledTwice);
+    
+    // Access the last options directly from the spy
+    const injectedAuthClient = client['httpClient'] as AuthHttpClient;
+    const lastOptions = (injectedAuthClient.sendRequest as any).lastOptions;
+    
+    // Verify the Authorization header was added
+    assert.equal(lastOptions.headers['Authorization'], 'Bearer test-token');
+  });
+  
+  it('should handle streaming requests with a custom HttpClient', async () => {
+    // Create a mock HttpClient for streaming
+    const mockHttpClient: HttpClient = {
+      sendRequest: sinon.stub(),
+    };
+    
+    // First response is for the agent card fetch
+    (mockHttpClient.sendRequest as SinonStub).onFirstCall().resolves(
+      new Response(
+        JSON.stringify({
+          ...mockAgentCard,
+          capabilities: {
+            ...mockAgentCard.capabilities,
+            streaming: true,
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      )
+    );
+    
+    // Second response is for the streaming request
+    const mockReadable = new ReadableStream({
+      start(controller) {
+        // Send SSE events
+        const encoder = new TextEncoder();
+        
+        // Task event
+        controller.enqueue(encoder.encode('data: {"jsonrpc":"2.0","id":1,"result":{"kind":"task","id":"task-1","contextId":"ctx-1","status":{"state":"submitted"}}}\n\n'));
+        
+        // Status update event
+        controller.enqueue(encoder.encode('data: {"jsonrpc":"2.0","id":1,"result":{"kind":"status-update","taskId":"task-1","contextId":"ctx-1","status":{"state":"working"},"final":false}}\n\n'));
+        
+        // Final status update event
+        controller.enqueue(encoder.encode('data: {"jsonrpc":"2.0","id":1,"result":{"kind":"status-update","taskId":"task-1","contextId":"ctx-1","status":{"state":"completed"},"final":true}}\n\n'));
+        
+        controller.close();
+      }
+    });
+    
+    (mockHttpClient.sendRequest as SinonStub).onSecondCall().resolves(
+      new Response(mockReadable, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/event-stream',
+        },
+      })
+    );
+    
+    const client = new A2AClient('http://localhost:8080', { httpClient: mockHttpClient });
+    
+    // Wait for the agent card to be fetched
+    await client.getAgentCard();
+    
+    // Send a streaming message
+    const params: MessageSendParams = {
+      message: {
+        messageId: 'msg-1',
+        role: 'user',
+        parts: [{ kind: 'text', text: 'Hello!' }],
+        kind: 'message',
+      },
+    };
+    
+    const events = [];
+    for await (const event of client.sendMessageStream(params)) {
+      events.push(event);
+    }
+    
+    // Verify that the custom HttpClient was used for both requests
+    assert.isTrue((mockHttpClient.sendRequest as SinonStub).calledTwice);
+    
+    // Verify that we received the expected events
+    assert.equal(events.length, 3);
+    assert.equal(events[0].kind, 'task');
+    assert.equal(events[1].kind, 'status-update');
+    assert.equal(events[2].kind, 'status-update');
+    assert.isTrue(events[2].final);
+  });
+  
+  it('DefaultHttpClient should use fetch API', async () => {
+    // Stub the global fetch function
+    const fetchStub = sinon.stub(global, 'fetch').resolves(mockResponse);
+    
+    const defaultClient = new DefaultHttpClient();
+    
+    await defaultClient.sendRequest('http://example.com', {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+    });
+    
+    // Verify that fetch was called with the expected arguments
+    assert.isTrue(fetchStub.calledOnce);
+    assert.equal(fetchStub.firstCall.args[0], 'http://example.com');
+    assert.deepEqual(fetchStub.firstCall.args[1], {
+      method: 'GET',
+      headers: { 'Accept': 'application/json' },
+    });
+  });
+});

--- a/test/client/client.spec.ts
+++ b/test/client/client.spec.ts
@@ -163,7 +163,7 @@ describe('A2AClient with HttpClient', () => {
       async sendRequest(url: string, options?: RequestInit): Promise<Response> {
         // Add authorization header to all requests
         const headers = {
-          ...options.headers,
+          ...options?.headers,
           'Authorization': `Bearer ${this.authToken}`
         };
         

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -68,6 +68,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
         description: 'An agent for testing purposes',
         url: 'http://localhost:8080',
         version: '1.0.0',
+        protocolVersion: '0.3.0',
         capabilities: {
             streaming: true,
             pushNotifications: true,


### PR DESCRIPTION
# Description

Addressing a few issues here to better support enterprise: 
- allow injection of own custom http client i.e. `got`, `ky`, `axios` - not restricted to native node js`fetch`
- this in turn allows us to add our own headers, addressing #101 
- also allows us to add a http time out as part of your custom client, addressing #78 
- defaults to using native nodejs `fetch` under the hood
- better implementation of what https://github.com/a2aproject/a2a-js/pull/109 is trying to do 
- allows better extensibility of future contributors to add to an `A2AClientOptions` type if community wants to extend client options as the protocol evolves
- tests added
- docs added 
- lastly, in `test/server/default_request_handler.spec.ts` there was type error, so i fixed that as well

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-js/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

Fixes #78  🦕
Fixes #101 🦕
IMO Better implementation of what https://github.com/a2aproject/a2a-js/pull/109 is trying to do as well
