### PR TITLE
chore: repin express to 5.1 and express types to 5.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "express": "^5.1.0"
+        "express": "^4.21.2 || ^5.1.0"
       },
       "peerDependenciesMeta": {
         "express": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "uuid": "^11.1.0"
   },
   "peerDependencies": {
-    "express": "^5.1.0"
+    "express": "^4.21.2 || ^5.1.0"
   },
   "peerDependenciesMeta": {
     "express": {


### PR DESCRIPTION
repin express to ^5.1.0 and express types to ^5.0.3

This is necessary in order to depend on this package in gemini-cli which already has a dependency on 5.1