### PR TITLE
feat!: Update A2AClient constructor to initialize with full agentCardUrl

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -31,11 +31,13 @@ import {
   A2AError,
   SendMessageSuccessResponse
 } from '../types.js'; // Assuming schema.ts is in the same directory or appropriately pathed
+import { AGENT_CARD_PATH } from "../constants.js";
 
 // Helper type for the data yielded by streaming methods
 type A2AStreamEventData = Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent;
 
 export interface A2AClientOptions {
+  agentCardPath?: string;
   fetchImpl?: typeof fetch;
 }
 
@@ -43,9 +45,9 @@ export interface A2AClientOptions {
  * A2AClient is a TypeScript HTTP client for interacting with A2A-compliant agents.
  */
 export class A2AClient {
-  private agentCard: AgentCard;
+  private agentCardPromise: Promise<AgentCard>;
   private requestIdCounter: number = 1;
-  private serviceEndpointUrl: string;
+  private serviceEndpointUrl?: string; // To be populated from AgentCard after fetching
   private fetchImpl: typeof fetch;
 
   /**
@@ -53,14 +55,19 @@ export class A2AClient {
    * @param agentCard The AgentCard object.
    * @param options Optional. The options for the A2AClient including the fetch/auth implementation.
    */
-  constructor(agentCard: AgentCard, options?: A2AClientOptions) {
-    if (!agentCard.url) {
-      throw new Error("Provided Agent Card does not contain a valid 'url' for the service endpoint.");
-    }
+  constructor(agentCard: AgentCard | string, options?: A2AClientOptions) {
     this.fetchImpl = options?.fetchImpl ?? fetch;
-    this.agentCard = agentCard;
-    this.serviceEndpointUrl = agentCard.url;
-}
+    if (typeof agentCard === 'string') {
+      console.warn("Warning: Constructing A2AClient with a URL is deprecated. Please use A2AClient.fromCardUrl() instead.");
+      this.agentCardPromise = this._fetchAndCacheAgentCard( agentCard, options?.agentCardPath );
+    } else {
+        if (!agentCard.url) {
+            throw new Error("Provided Agent Card does not contain a valid 'url' for the service endpoint.");
+        }
+        this.serviceEndpointUrl = agentCard.url;
+        this.agentCardPromise = Promise.resolve(agentCard);
+    }
+  }
 
   /**
    * Creates an A2AClient instance by fetching the AgentCard from a URL then constructing the A2AClient.
@@ -89,22 +96,6 @@ export class A2AClient {
   }
 
   /**
-   * Retrieves the Agent Card.
-   * @returns The AgentCard object used to construct the client.
-   */
-  public getAgentCard(): AgentCard {
-    return this.agentCard;
-  }
-
-  /**
-   * Gets the RPC service endpoint URL.
-   * @returns The service endpoint URL string.
-   */
-  private _getServiceEndpoint(): string {
-    return this.serviceEndpointUrl;
-  }
-
-  /**
    * Helper method to make a generic JSON-RPC POST request.
    * @param method The RPC method name.
    * @param params The parameters for the RPC method.
@@ -114,7 +105,7 @@ export class A2AClient {
     method: string,
     params: TParams
   ): Promise<TResponse> {
-    const endpoint = this._getServiceEndpoint();
+    const endpoint = await this._getServiceEndpoint();
     const requestId = this.requestIdCounter++;
     const rpcRequest: JSONRPCRequest = {
       jsonrpc: "2.0",
@@ -200,11 +191,12 @@ export class A2AClient {
    * The generator throws an error if streaming is not supported or if an HTTP/SSE error occurs.
    */
   public async *sendMessageStream(params: MessageSendParams): AsyncGenerator<A2AStreamEventData, void, undefined> {
-    if (!this.agentCard.capabilities?.streaming) {
+    const agentCard = await this.agentCardPromise; // Ensure agent card is fetched
+    if (!agentCard.capabilities?.streaming) {
       throw new Error("Agent does not support streaming (AgentCard.capabilities.streaming is not true).");
     }
 
-    const endpoint = this._getServiceEndpoint();
+    const endpoint = await this._getServiceEndpoint();
     const clientRequestId = this.requestIdCounter++; // Use a unique ID for this stream request
     const rpcRequest: JSONRPCRequest = { // This is the initial JSON-RPC request to establish the stream
       jsonrpc: "2.0",
@@ -248,7 +240,8 @@ export class A2AClient {
    * @returns A Promise resolving to SetTaskPushNotificationConfigResponse.
    */
   public async setTaskPushNotificationConfig(params: TaskPushNotificationConfig): Promise<SetTaskPushNotificationConfigResponse> {
-    if (!this.agentCard.capabilities?.pushNotifications) {
+    const agentCard = await this.agentCardPromise;
+    if (!agentCard.capabilities?.pushNotifications) {
       throw new Error("Agent does not support push notifications (AgentCard.capabilities.pushNotifications is not true).");
     }
     // The 'params' directly matches the structure expected by the RPC method.
@@ -298,11 +291,12 @@ export class A2AClient {
    * @returns An AsyncGenerator yielding A2AStreamEventData (Message, Task, TaskStatusUpdateEvent, or TaskArtifactUpdateEvent).
    */
   public async *resubscribeTask(params: TaskIdParams): AsyncGenerator<A2AStreamEventData, void, undefined> {
-    if (!this.agentCard.capabilities?.streaming) {
+    const agentCard = await this.agentCardPromise;
+    if (!agentCard.capabilities?.streaming) {
       throw new Error("Agent does not support streaming (required for tasks/resubscribe).");
     }
 
-    const endpoint = this._getServiceEndpoint();
+    const endpoint = await this._getServiceEndpoint();
     const clientRequestId = this.requestIdCounter++; // Unique ID for this resubscribe request
     const rpcRequest: JSONRPCRequest = { // Initial JSON-RPC request to establish the stream
       jsonrpc: "2.0",
@@ -461,5 +455,97 @@ export class A2AClient {
 
   isErrorResponse(response: JSONRPCResponse): response is JSONRPCErrorResponse {
     return "error" in response;
+  }
+
+////////////////////////////////////////////////////////////////////////////////
+// Functions used to support old A2AClient Constructor to be deprecated soon
+// TODOs:
+// * remove `agentCardPromise`, and just use agentCard initialized
+// * _getServiceEndpoint can be made synchronous or deleted and accessed via
+//   agentCard.url
+// * getAgentCard changed to this.agentCard
+// * delete resolveAgentCardUrl(), _fetchAndCacheAgentCard(),
+//   agentCardPath from A2AClientOptions
+////////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * Fetches the Agent Card from the agent's well-known URI and caches its service endpoint URL.
+   * This method is called by the constructor.
+   * @param agentBaseUrl The base URL of the A2A agent (e.g., https://agent.example.com)
+   * @param agentCardPath path to the agent card, defaults to .well-known/agent-card.json
+   * @returns A Promise that resolves to the AgentCard.
+   */
+  private async _fetchAndCacheAgentCard( agentBaseUrl: string, agentCardPath?: string ): Promise<AgentCard> {
+    try {
+      const agentCardUrl = this.resolveAgentCardUrl( agentBaseUrl, agentCardPath );
+      const response = await this.fetchImpl(agentCardUrl, {
+        headers: { 'Accept': 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Agent Card from ${agentCardUrl}: ${response.status} ${response.statusText}`);
+      }
+      const agentCard: AgentCard = await response.json();
+      if (!agentCard.url) {
+        throw new Error("Fetched Agent Card does not contain a valid 'url' for the service endpoint.");
+      }
+      this.serviceEndpointUrl = agentCard.url; // Cache the service endpoint URL from the agent card
+      return agentCard;
+    } catch (error) {
+      console.error("Error fetching or parsing Agent Card:", error);
+      // Allow the promise to reject so users of agentCardPromise can handle it.
+      throw error;
+    }
+  }
+
+    /**
+   * Retrieves the Agent Card.
+   * If an `agentBaseUrl` is provided, it fetches the card from that specific URL.
+   * Otherwise, it returns the card fetched and cached during client construction.
+   * @param agentBaseUrl Optional. The base URL of the agent to fetch the card from.
+   * @param agentCardPath path to the agent card, defaults to .well-known/agent-card.json
+   * If provided, this will fetch a new card, not use the cached one from the constructor's URL.
+   * @returns A Promise that resolves to the AgentCard.
+   */
+  public async getAgentCard(agentBaseUrl?: string, agentCardPath?: string): Promise<AgentCard> {
+    if (agentBaseUrl) {
+      const agentCardUrl = this.resolveAgentCardUrl( agentBaseUrl, agentCardPath );
+
+      const response = await this.fetchImpl(agentCardUrl, {
+        headers: { 'Accept': 'application/json' },
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Agent Card from ${agentCardUrl}: ${response.status} ${response.statusText}`);
+      }
+      return await response.json() as AgentCard;
+    }
+    // If no specific URL is given, return the promise for the initially configured agent's card.
+    return this.agentCardPromise;
+  }
+
+  /**
+   * Determines the agent card URL based on the agent URL.
+   * @param agentBaseUrl The agent URL.
+   * @param agentCardPath Optional relative path to the agent card, defaults to .well-known/agent-card.json
+   */
+  private resolveAgentCardUrl( agentBaseUrl: string, agentCardPath: string = AGENT_CARD_PATH ): string {
+    return `${agentBaseUrl.replace(/\/$/, "")}/${agentCardPath.replace(/^\//, "")}`;
+  }
+
+  /**
+   * Gets the RPC service endpoint URL. Ensures the agent card has been fetched first.
+   * @returns A Promise that resolves to the service endpoint URL string.
+   */
+  private async _getServiceEndpoint(): Promise<string> {
+    if (this.serviceEndpointUrl) {
+      return this.serviceEndpointUrl;
+    }
+    // If serviceEndpointUrl is not set, it means the agent card fetch is pending or failed.
+    // Awaiting agentCardPromise will either resolve it or throw if fetching failed.
+    await this.agentCardPromise;
+    if (!this.serviceEndpointUrl) {
+      // This case should ideally be covered by the error handling in _fetchAndCacheAgentCard
+      throw new Error("Agent Card URL for RPC endpoint is not available. Fetching might have failed.");
+    }
+    return this.serviceEndpointUrl;
   }
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -61,6 +61,31 @@ export class A2AClient {
   }
 
   /**
+   * Creates an A2AClient instance from an already-fetched AgentCard.
+   * This method is useful when the AgentCard is obtained through means other than
+   * the client's own fetching mechanism (e.g., from a discovery service).
+   * @param agentCard The AgentCard object.
+   * @param options Optional. The options for the A2AClient including the fetch implementation.
+   * @returns A new A2AClient instance.
+   */
+  public static fromAgentCard(agentCard: AgentCard, options?: A2AClientOptions): A2AClient {
+    if (!agentCard.url) {
+      throw new Error("Provided Agent Card does not contain a valid 'url' for the service endpoint.");
+    }
+
+    // Create an instance without calling the constructor to avoid initial fetch
+    const client = Object.create(A2AClient.prototype) as A2AClient;
+
+    // Set necessary properties
+    client.fetchImpl = options?.fetchImpl ?? fetch;
+    client.agentCardPromise = Promise.resolve(agentCard);
+    client.serviceEndpointUrl = agentCard.url;
+    client.requestIdCounter = 1;
+
+    return client;
+  }
+
+  /**
    * Fetches the Agent Card from the agent's well-known URI and caches its service endpoint URL.
    * This method is called by the constructor.
    * @param agentCardUrl The URL of the agent card.

--- a/test/client/client.spec.ts
+++ b/test/client/client.spec.ts
@@ -56,7 +56,6 @@ describe('A2AClient Basic Tests', () => {
     it('should fetch agent card during initialization', async () => {
       // Wait for agent card to be fetched
       await client.getAgentCard();
-
       expect(mockFetch.callCount).to.be.greaterThan(0);
       const agentCardCall = mockFetch.getCalls().find(call =>
         call.args[0].includes(AGENT_CARD_PATH)
@@ -68,7 +67,6 @@ describe('A2AClient Basic Tests', () => {
   describe('Agent Card Handling', () => {
     it('should fetch and parse agent card correctly', async () => {
       const agentCard = await client.getAgentCard();
-
       expect(agentCard).to.have.property('name', 'Test Agent');
       expect(agentCard).to.have.property('description', 'A test agent for basic client testing');
       expect(agentCard).to.have.property('url', 'https://test-agent.example.com/api');
@@ -80,10 +78,8 @@ describe('A2AClient Basic Tests', () => {
     it('should cache agent card for subsequent requests', async () => {
       // First call
       await client.getAgentCard();
-
       // Second call - should not fetch agent card again
       await client.getAgentCard();
-
       const agentCardCalls = mockFetch.getCalls().filter(call =>
         call.args[0].includes(AGENT_CARD_PATH)
       );
@@ -132,7 +128,6 @@ describe('A2AClient Basic Tests', () => {
 
       // Verify fetch was called
       expect(mockFetch.callCount).to.be.greaterThan(0);
-
       // Verify RPC call was made
       const rpcCall = mockFetch.getCalls().find(call =>
         call.args[0].includes('/api')
@@ -163,11 +158,9 @@ describe('A2AClient Basic Tests', () => {
           });
           return createAgentCardResponse(mockAgentCard);
         }
-
         if (url.includes('/api')) {
           // Extract request ID from the request body
           const requestId = extractRequestId(options);
-
           return createResponse(requestId, undefined, {
             code: -32603,
             message: 'Internal error'
@@ -205,7 +198,6 @@ describe('A2AClient Basic Tests', () => {
   describe('Error Handling', () => {
     it('should handle network errors gracefully', async () => {
       const networkErrorFetch = sinon.stub().rejects(new Error('Network error'));
-
       const networkErrorClient = new A2AClient(agentCardUrl, {
         fetchImpl: networkErrorFetch
       });

--- a/test/client/client.spec.ts
+++ b/test/client/client.spec.ts
@@ -15,15 +15,16 @@ describe('A2AClient Basic Tests', () => {
   let client: A2AClient;
   let mockFetch: sinon.SinonStub;
   let originalConsoleError: typeof console.error;
+  const agentCardUrl = `https://test-agent.example.com/${AGENT_CARD_PATH}`;
 
-  beforeEach(() => {    
+  beforeEach(() => {
     // Suppress console.error during tests to avoid noise
     originalConsoleError = console.error;
     console.error = () => {};
-    
+
     // Create a fresh mock fetch for each test
     mockFetch = createMockFetch();
-    client = new A2AClient('https://test-agent.example.com', {
+    client = new A2AClient(agentCardUrl, {
       fetchImpl: mockFetch
     });
   });
@@ -38,7 +39,7 @@ describe('A2AClient Basic Tests', () => {
     it('should initialize client with default options', () => {
       // Use a mock fetch to avoid real HTTP requests during testing
       const mockFetchForDefault = createMockFetch();
-      const basicClient = new A2AClient('https://test-agent.example.com', {
+      const basicClient = new A2AClient(agentCardUrl, {
         fetchImpl: mockFetchForDefault
       });
       expect(basicClient).to.be.instanceOf(A2AClient);
@@ -46,7 +47,7 @@ describe('A2AClient Basic Tests', () => {
 
     it('should initialize client with custom fetch implementation', () => {
       const customFetch = sinon.stub();
-      const clientWithCustomFetch = new A2AClient('https://test-agent.example.com', {
+      const clientWithCustomFetch = new A2AClient(agentCardUrl, {
         fetchImpl: customFetch
       });
       expect(clientWithCustomFetch).to.be.instanceOf(A2AClient);
@@ -55,9 +56,9 @@ describe('A2AClient Basic Tests', () => {
     it('should fetch agent card during initialization', async () => {
       // Wait for agent card to be fetched
       await client.getAgentCard();
-      
+
       expect(mockFetch.callCount).to.be.greaterThan(0);
-      const agentCardCall = mockFetch.getCalls().find(call => 
+      const agentCardCall = mockFetch.getCalls().find(call =>
         call.args[0].includes(AGENT_CARD_PATH)
       );
       expect(agentCardCall).to.exist;
@@ -67,7 +68,7 @@ describe('A2AClient Basic Tests', () => {
   describe('Agent Card Handling', () => {
     it('should fetch and parse agent card correctly', async () => {
       const agentCard = await client.getAgentCard();
-      
+
       expect(agentCard).to.have.property('name', 'Test Agent');
       expect(agentCard).to.have.property('description', 'A test agent for basic client testing');
       expect(agentCard).to.have.property('url', 'https://test-agent.example.com/api');
@@ -79,14 +80,14 @@ describe('A2AClient Basic Tests', () => {
     it('should cache agent card for subsequent requests', async () => {
       // First call
       await client.getAgentCard();
-      
+
       // Second call - should not fetch agent card again
       await client.getAgentCard();
-      
-      const agentCardCalls = mockFetch.getCalls().filter(call => 
+
+      const agentCardCalls = mockFetch.getCalls().filter(call =>
         call.args[0].includes(AGENT_CARD_PATH)
       );
-      
+
       expect(agentCardCalls).to.have.length(1);
     });
 
@@ -99,7 +100,7 @@ describe('A2AClient Basic Tests', () => {
       });
 
       // Create client after setting up the mock to avoid console.error during construction
-      const errorClient = new A2AClient('https://test-agent.example.com', {
+      const errorClient = new A2AClient(agentCardUrl, {
         fetchImpl: errorFetch
       });
 
@@ -131,9 +132,9 @@ describe('A2AClient Basic Tests', () => {
 
       // Verify fetch was called
       expect(mockFetch.callCount).to.be.greaterThan(0);
-      
+
       // Verify RPC call was made
-      const rpcCall = mockFetch.getCalls().find(call => 
+      const rpcCall = mockFetch.getCalls().find(call =>
         call.args[0].includes('/api')
       );
       expect(rpcCall).to.exist;
@@ -162,21 +163,21 @@ describe('A2AClient Basic Tests', () => {
           });
           return createAgentCardResponse(mockAgentCard);
         }
-        
+
         if (url.includes('/api')) {
           // Extract request ID from the request body
           const requestId = extractRequestId(options);
-          
+
           return createResponse(requestId, undefined, {
             code: -32603,
             message: 'Internal error'
           }, 500);
         }
-        
+
         return new Response('Not found', { status: 404 });
       });
 
-      const errorClient = new A2AClient('https://test-agent.example.com', {
+      const errorClient = new A2AClient(agentCardUrl, {
         fetchImpl: errorFetch
       });
 
@@ -204,8 +205,8 @@ describe('A2AClient Basic Tests', () => {
   describe('Error Handling', () => {
     it('should handle network errors gracefully', async () => {
       const networkErrorFetch = sinon.stub().rejects(new Error('Network error'));
-      
-      const networkErrorClient = new A2AClient('https://test-agent.example.com', {
+
+      const networkErrorClient = new A2AClient(agentCardUrl, {
         fetchImpl: networkErrorFetch
       });
 
@@ -229,7 +230,7 @@ describe('A2AClient Basic Tests', () => {
         return new Response('Not found', { status: 404 });
       });
 
-      const malformedClient = new A2AClient('https://test-agent.example.com', {
+      const malformedClient = new A2AClient(agentCardUrl, {
         fetchImpl: malformedFetch
       });
 
@@ -263,7 +264,7 @@ describe('A2AClient Basic Tests', () => {
         return new Response('Not found', { status: 404 });
       });
 
-      const missingUrlClient = new A2AClient('https://test-agent.example.com', {
+      const missingUrlClient = new A2AClient(agentCardUrl, {
         fetchImpl: missingUrlFetch
       });
 

--- a/test/client/client.spec.ts
+++ b/test/client/client.spec.ts
@@ -56,6 +56,7 @@ describe('A2AClient Basic Tests', () => {
     it('should fetch agent card during initialization', async () => {
       // Wait for agent card to be fetched
       await client.getAgentCard();
+
       expect(mockFetch.callCount).to.be.greaterThan(0);
       const agentCardCall = mockFetch.getCalls().find(call =>
         call.args[0].includes(AGENT_CARD_PATH)
@@ -67,6 +68,7 @@ describe('A2AClient Basic Tests', () => {
   describe('Agent Card Handling', () => {
     it('should fetch and parse agent card correctly', async () => {
       const agentCard = await client.getAgentCard();
+
       expect(agentCard).to.have.property('name', 'Test Agent');
       expect(agentCard).to.have.property('description', 'A test agent for basic client testing');
       expect(agentCard).to.have.property('url', 'https://test-agent.example.com/api');
@@ -78,8 +80,10 @@ describe('A2AClient Basic Tests', () => {
     it('should cache agent card for subsequent requests', async () => {
       // First call
       await client.getAgentCard();
+
       // Second call - should not fetch agent card again
       await client.getAgentCard();
+
       const agentCardCalls = mockFetch.getCalls().filter(call =>
         call.args[0].includes(AGENT_CARD_PATH)
       );
@@ -128,6 +132,7 @@ describe('A2AClient Basic Tests', () => {
 
       // Verify fetch was called
       expect(mockFetch.callCount).to.be.greaterThan(0);
+
       // Verify RPC call was made
       const rpcCall = mockFetch.getCalls().find(call =>
         call.args[0].includes('/api')
@@ -158,9 +163,11 @@ describe('A2AClient Basic Tests', () => {
           });
           return createAgentCardResponse(mockAgentCard);
         }
+
         if (url.includes('/api')) {
           // Extract request ID from the request body
           const requestId = extractRequestId(options);
+
           return createResponse(requestId, undefined, {
             code: -32603,
             message: 'Internal error'
@@ -198,6 +205,7 @@ describe('A2AClient Basic Tests', () => {
   describe('Error Handling', () => {
     it('should handle network errors gracefully', async () => {
       const networkErrorFetch = sinon.stub().rejects(new Error('Network error'));
+
       const networkErrorClient = new A2AClient(agentCardUrl, {
         fetchImpl: networkErrorFetch
       });

--- a/test/client/client_auth.spec.ts
+++ b/test/client/client_auth.spec.ts
@@ -5,8 +5,8 @@ import { A2AClient } from '../../src/client/client.js';
 import { AuthenticationHandler, HttpHeaders, createAuthenticatingFetchWithRetry } from '../../src/client/auth-handler.js';
 import {SendMessageResponse, SendMessageSuccessResponse } from '../../src/types.js';
 import { AGENT_CARD_PATH } from '../../src/constants.js';
-import {
-  createMessageParams,
+import { 
+  createMessageParams, 
   createMockFetch
 } from './util.js';
 
@@ -62,7 +62,7 @@ class MockAuthHandler implements AuthenticationHandler {
 
     // Use the ChallengeManager to sign the challenge
     const token = ChallengeManager.signChallenge(challenge);
-
+      
     // have the client try the token, BUT don't save it in case the client doesn't accept it
     return { 'Authorization': `Bearer ${token}` };
   }
@@ -146,6 +146,7 @@ describe('A2AClient Authentication Tests', () => {
         }
       });
       expect(mockFetch.secondCall.args[1].body).to.include('"method":"message/send"');
+
       // Third call: RPC request with auth header
       expect(mockFetch.thirdCall.args[0]).to.equal('https://test-agent.example.com/api');
       expect(mockFetch.thirdCall.args[1]).to.deep.include({
@@ -155,6 +156,7 @@ describe('A2AClient Authentication Tests', () => {
       expect(mockFetch.thirdCall.args[1].headers).to.have.property('Content-Type', 'application/json');
       expect(mockFetch.thirdCall.args[1].headers).to.have.property('Accept', 'application/json');
       expect(mockFetch.thirdCall.args[1].headers).to.have.property('Authorization');
+
       expect(mockFetch.thirdCall.args[1].headers['Authorization']).to.match(/^Bearer .+$/);
       expect(mockFetch.thirdCall.args[1].body).to.include('"method":"message/send"');
 
@@ -173,18 +175,23 @@ describe('A2AClient Authentication Tests', () => {
 
       // First request - should trigger auth flow
       const result1 = await client.sendMessage(messageParams);
+
       // Capture the token from the first request
       const firstRequestAuthCall = mockFetch.getCalls().find(call =>
         call.args[0].includes('/api') &&
         call.args[1]?.headers?.['Authorization']
       );
       const firstRequestToken = firstRequestAuthCall?.args[1]?.headers?.['Authorization'];
+
       // Second request - should use existing token
       const result2 = await client.sendMessage(messageParams);
+
       // Total calls should be 4: 3 for first request + 1 for second request (both agent card and auth token cached)
       expect(mockFetch.callCount).to.equal(4);
+
       // Second request should start from call #4 (after the first 3 calls)
       const secondRequestCalls = mockFetch.getCalls().slice(3);
+
       // Only one call for second request: RPC request with auth header (agent card and token cached)
       expect(secondRequestCalls[0].args[0]).to.equal('https://test-agent.example.com/api');
       expect(secondRequestCalls[0].args[1].headers).to.have.property('Authorization');
@@ -335,6 +342,7 @@ describe('A2AClient Authentication Tests', () => {
 
       // The client should return a JSON-RPC error response rather than throwing an error
       const result = await clientNoAuthHandler.sendMessage(messageParams);
+
       // Verify that the result is a JSON-RPC error response
       expect(result).to.have.property('jsonrpc', '2.0');
       expect(result).to.have.property('error');
@@ -385,6 +393,7 @@ describe('AuthHandlingFetch Tests', () => {
     it('should merge auth headers with provided headers when auth headers exist', async () => {
       // Create an auth handler that has stored authorization headers
       const authHandlerWithHeaders = new MockAuthHandler();
+
       // Simulate a successful authentication by calling onSuccessfulRetry
       // This will store the Authorization header in the auth handler
       await authHandlerWithHeaders.onSuccessfulRetry({
@@ -403,12 +412,14 @@ describe('AuthHandlingFetch Tests', () => {
       // Verify that the fetch was called with merged headers including auth headers
       const fetchCall = mockFetch.getCall(0);
       const headers = fetchCall.args[1]?.headers as Record<string, string>;
+
       // Should include both user headers and auth headers
       expect(headers).to.include({
         'Content-Type': 'application/json',
         'Custom-Header': 'custom-value',
         'Authorization': 'Bearer test-token-123'
       });
+
       // Verify the auth handler's headers method returns the stored authorization
       const storedHeaders = await authHandlerWithHeaders.headers();
       expect(storedHeaders['Authorization']).to.equal('Bearer test-token-123');
@@ -417,7 +428,9 @@ describe('AuthHandlingFetch Tests', () => {
     it('should handle empty headers gracefully', async () => {
       const emptyAuthHandler = new MockAuthHandler();
       const emptyAuthFetch = createAuthenticatingFetchWithRetry(mockFetch, emptyAuthHandler);
+
       await emptyAuthFetch('https://test.example.com/api');
+
       const fetchCall = mockFetch.getCall(0);
       expect(fetchCall.args[1]).to.exist;
     });
@@ -427,6 +440,7 @@ describe('AuthHandlingFetch Tests', () => {
     it('should call onSuccessfulRetry when retry succeeds', async () => {
       const successAuthHandler = new MockAuthHandler();
       const onSuccessSpy = sinon.spy(successAuthHandler, 'onSuccessfulRetry');
+
       // Create a modified version of the existing mockFetch that returns 401 first, then 200
       const successMockFetch = createMockFetch({
         messageConfig: {
@@ -435,8 +449,11 @@ describe('AuthHandlingFetch Tests', () => {
         },
         behavior: 'authRetry'
       });
+
       const successAuthFetch = createAuthenticatingFetchWithRetry(successMockFetch, successAuthHandler);
+
       await successAuthFetch('https://test.example.com/api');
+
       expect(onSuccessSpy.called).to.be.true;
       expect(onSuccessSpy.firstCall.args[0]).to.deep.include({
         'Authorization': 'Bearer challenge123.challenge123'
@@ -446,13 +463,18 @@ describe('AuthHandlingFetch Tests', () => {
     it('should not call onSuccessfulRetry when retry fails', async () => {
       const failAuthHandler = new MockAuthHandler();
       const onSuccessSpy = sinon.spy(failAuthHandler, 'onSuccessfulRetry');
+
       const failFetch = createAuthenticatingFetchWithRetry(mockFetch, failAuthHandler);
+
       // Mock fetch to return 401 first, then 401 again
       const failMockFetch = createMockFetch({
         behavior: 'alwaysFail'
       });
+
       const failAuthFetch = createAuthenticatingFetchWithRetry(failMockFetch, failAuthHandler);
+
       const response = await failAuthFetch('https://test.example.com/api');
+
       expect(onSuccessSpy.called).to.be.false;
       expect(response.status).to.equal(401);
     });
@@ -462,6 +484,7 @@ describe('AuthHandlingFetch Tests', () => {
     it('should propagate fetch errors', async () => {
       const errorFetch = sinon.stub().rejects(new Error('Network error'));
       const errorAuthFetch = createAuthenticatingFetchWithRetry(errorFetch, authHandler);
+
       try {
         await errorAuthFetch('https://test.example.com/api');
         expect.fail('Expected error to be thrown');
@@ -475,7 +498,9 @@ describe('AuthHandlingFetch Tests', () => {
       const errorAuthHandler = new MockAuthHandler();
       const shouldRetrySpy = sinon.stub(errorAuthHandler, 'shouldRetryWithHeaders');
       shouldRetrySpy.rejects(new Error('Auth handler error'));
+
       const errorAuthFetch = createAuthenticatingFetchWithRetry(mockFetch, errorAuthHandler);
+
       try {
         await errorAuthFetch('https://test.example.com/api');
         expect.fail('Expected error to be thrown');

--- a/test/client/client_auth.spec.ts
+++ b/test/client/client_auth.spec.ts
@@ -85,12 +85,13 @@ describe('A2AClient Authentication Tests', () => {
   let authHandler: MockAuthHandler;
   let mockFetch: sinon.SinonStub;
   let originalConsoleError: typeof console.error;
+  const agentCardUrl = `https://test-agent.example.com/${AGENT_CARD_PATH}`;
 
-  beforeEach(() => {    
+  beforeEach(() => {
     // Suppress console.error during tests to avoid noise
     originalConsoleError = console.error;
     console.error = () => {};
-    
+
     // Create a fresh mock fetch for each test
     mockFetch = createMockFetch({
       requiresAuth: true,
@@ -101,11 +102,11 @@ describe('A2AClient Authentication Tests', () => {
         challenge: challengeManager.createChallenge()
       }
     });
-    
+
     authHandler = new MockAuthHandler();
     // Use AuthHandlingFetch to wrap the mock fetch with authentication handling
     const authHandlingFetch = createAuthenticatingFetchWithRetry(mockFetch, authHandler);
-    client = new A2AClient('https://test-agent.example.com', {
+    client = new A2AClient(agentCardUrl, {
       fetchImpl: authHandlingFetch
     });
   });
@@ -128,13 +129,13 @@ describe('A2AClient Authentication Tests', () => {
 
       // Verify fetch was called multiple times
       expect(mockFetch.callCount).to.equal(3);
-      
+
       // First call: agent card fetch
-      expect(mockFetch.firstCall.args[0]).to.equal(`https://test-agent.example.com/${AGENT_CARD_PATH}`);
+      expect(mockFetch.firstCall.args[0]).to.equal(agentCardUrl);
       expect(mockFetch.firstCall.args[1]).to.deep.include({
         headers: { 'Accept': 'application/json' }
       });
-      
+
       // Second call: RPC request without auth header
       expect(mockFetch.secondCall.args[0]).to.equal('https://test-agent.example.com/api');
       expect(mockFetch.secondCall.args[1]).to.deep.include({
@@ -145,7 +146,7 @@ describe('A2AClient Authentication Tests', () => {
         }
       });
       expect(mockFetch.secondCall.args[1].body).to.include('"method":"message/send"');
-      
+
       // Third call: RPC request with auth header
       expect(mockFetch.thirdCall.args[0]).to.equal('https://test-agent.example.com/api');
       expect(mockFetch.thirdCall.args[1]).to.deep.include({
@@ -155,7 +156,7 @@ describe('A2AClient Authentication Tests', () => {
       expect(mockFetch.thirdCall.args[1].headers).to.have.property('Content-Type', 'application/json');
       expect(mockFetch.thirdCall.args[1].headers).to.have.property('Accept', 'application/json');
       expect(mockFetch.thirdCall.args[1].headers).to.have.property('Authorization');
-      
+
       expect(mockFetch.thirdCall.args[1].headers['Authorization']).to.match(/^Bearer .+$/);
       expect(mockFetch.thirdCall.args[1].body).to.include('"method":"message/send"');
 
@@ -174,27 +175,27 @@ describe('A2AClient Authentication Tests', () => {
 
       // First request - should trigger auth flow
       const result1 = await client.sendMessage(messageParams);
-      
+
       // Capture the token from the first request
-      const firstRequestAuthCall = mockFetch.getCalls().find(call => 
-        call.args[0].includes('/api') && 
+      const firstRequestAuthCall = mockFetch.getCalls().find(call =>
+        call.args[0].includes('/api') &&
         call.args[1]?.headers?.['Authorization']
       );
       const firstRequestToken = firstRequestAuthCall?.args[1]?.headers?.['Authorization'];
-      
+
       // Second request - should use existing token
       const result2 = await client.sendMessage(messageParams);
 
       // Total calls should be 4: 3 for first request + 1 for second request (both agent card and auth token cached)
       expect(mockFetch.callCount).to.equal(4);
-      
+
       // Second request should start from call #4 (after the first 3 calls)
       const secondRequestCalls = mockFetch.getCalls().slice(3);
-      
+
       // Only one call for second request: RPC request with auth header (agent card and token cached)
       expect(secondRequestCalls[0].args[0]).to.equal('https://test-agent.example.com/api');
       expect(secondRequestCalls[0].args[1].headers).to.have.property('Authorization');
-      
+
       // Should use the exact same token from the first request
       expect(secondRequestCalls[0].args[1].headers['Authorization']).to.equal(firstRequestToken);
 
@@ -229,7 +230,7 @@ describe('A2AClient Authentication Tests', () => {
       const originalShouldRetry = noRetryHandler.shouldRetryWithHeaders.bind(noRetryHandler);
       noRetryHandler.shouldRetryWithHeaders = sinon.stub().resolves(undefined);
 
-      const clientNoRetry = new A2AClient('https://test-agent.example.com', {
+      const clientNoRetry = new A2AClient(agentCardUrl, {
         fetchImpl: mockFetch
       });
 
@@ -261,7 +262,7 @@ describe('A2AClient Authentication Tests', () => {
       const { capturedAuthHeaders } = authRetryTestFetch;
 
       const authHandlingFetch = createAuthenticatingFetchWithRetry(authRetryTestFetch, authHandler);
-      const clientAuthTest = new A2AClient('https://test-agent.example.com', {
+      const clientAuthTest = new A2AClient(agentCardUrl, {
         fetchImpl: authHandlingFetch
       });
 
@@ -296,7 +297,7 @@ describe('A2AClient Authentication Tests', () => {
       });
       const { capturedAuthHeaders } = noAuthRequiredFetch;
 
-      const clientNoAuth = new A2AClient('https://test-agent.example.com', {
+      const clientNoAuth = new A2AClient(agentCardUrl, {
         fetchImpl: noAuthRequiredFetch
       });
 
@@ -330,7 +331,7 @@ describe('A2AClient Authentication Tests', () => {
       });
 
       // Create client WITHOUT authHandler
-      const clientNoAuthHandler = new A2AClient('https://test-agent.example.com', {
+      const clientNoAuthHandler = new A2AClient(agentCardUrl, {
         fetchImpl: fetchWithApiError
       });
 
@@ -341,7 +342,7 @@ describe('A2AClient Authentication Tests', () => {
 
       // The client should return a JSON-RPC error response rather than throwing an error
       const result = await clientNoAuthHandler.sendMessage(messageParams);
-      
+
       // Verify that the result is a JSON-RPC error response
       expect(result).to.have.property('jsonrpc', '2.0');
       expect(result).to.have.property('error');
@@ -392,15 +393,15 @@ describe('AuthHandlingFetch Tests', () => {
     it('should merge auth headers with provided headers when auth headers exist', async () => {
       // Create an auth handler that has stored authorization headers
       const authHandlerWithHeaders = new MockAuthHandler();
-      
+
       // Simulate a successful authentication by calling onSuccessfulRetry
       // This will store the Authorization header in the auth handler
       await authHandlerWithHeaders.onSuccessfulRetry({
         'Authorization': 'Bearer test-token-123'
       });
-      
+
       const authHandlingFetchWithHeaders = createAuthenticatingFetchWithRetry(mockFetch, authHandlerWithHeaders);
-      
+
       await authHandlingFetchWithHeaders('https://test.example.com/api', {
         headers: {
           'Content-Type': 'application/json',
@@ -411,14 +412,14 @@ describe('AuthHandlingFetch Tests', () => {
       // Verify that the fetch was called with merged headers including auth headers
       const fetchCall = mockFetch.getCall(0);
       const headers = fetchCall.args[1]?.headers as Record<string, string>;
-      
+
       // Should include both user headers and auth headers
       expect(headers).to.include({
         'Content-Type': 'application/json',
         'Custom-Header': 'custom-value',
         'Authorization': 'Bearer test-token-123'
       });
-      
+
       // Verify the auth handler's headers method returns the stored authorization
       const storedHeaders = await authHandlerWithHeaders.headers();
       expect(storedHeaders['Authorization']).to.equal('Bearer test-token-123');
@@ -427,9 +428,9 @@ describe('AuthHandlingFetch Tests', () => {
     it('should handle empty headers gracefully', async () => {
       const emptyAuthHandler = new MockAuthHandler();
       const emptyAuthFetch = createAuthenticatingFetchWithRetry(mockFetch, emptyAuthHandler);
-      
+
       await emptyAuthFetch('https://test.example.com/api');
-      
+
       const fetchCall = mockFetch.getCall(0);
       expect(fetchCall.args[1]).to.exist;
     });
@@ -439,7 +440,7 @@ describe('AuthHandlingFetch Tests', () => {
     it('should call onSuccessfulRetry when retry succeeds', async () => {
       const successAuthHandler = new MockAuthHandler();
       const onSuccessSpy = sinon.spy(successAuthHandler, 'onSuccessfulRetry');
-      
+
       // Create a modified version of the existing mockFetch that returns 401 first, then 200
       const successMockFetch = createMockFetch({
         messageConfig: {
@@ -448,11 +449,11 @@ describe('AuthHandlingFetch Tests', () => {
         },
         behavior: 'authRetry'
       });
-      
+
       const successAuthFetch = createAuthenticatingFetchWithRetry(successMockFetch, successAuthHandler);
-      
+
       await successAuthFetch('https://test.example.com/api');
-      
+
       expect(onSuccessSpy.called).to.be.true;
       expect(onSuccessSpy.firstCall.args[0]).to.deep.include({
         'Authorization': 'Bearer challenge123.challenge123'
@@ -462,18 +463,18 @@ describe('AuthHandlingFetch Tests', () => {
     it('should not call onSuccessfulRetry when retry fails', async () => {
       const failAuthHandler = new MockAuthHandler();
       const onSuccessSpy = sinon.spy(failAuthHandler, 'onSuccessfulRetry');
-      
+
       const failFetch = createAuthenticatingFetchWithRetry(mockFetch, failAuthHandler);
-      
+
       // Mock fetch to return 401 first, then 401 again
       const failMockFetch = createMockFetch({
         behavior: 'alwaysFail'
       });
-      
+
       const failAuthFetch = createAuthenticatingFetchWithRetry(failMockFetch, failAuthHandler);
-      
+
       const response = await failAuthFetch('https://test.example.com/api');
-      
+
       expect(onSuccessSpy.called).to.be.false;
       expect(response.status).to.equal(401);
     });
@@ -483,7 +484,7 @@ describe('AuthHandlingFetch Tests', () => {
     it('should propagate fetch errors', async () => {
       const errorFetch = sinon.stub().rejects(new Error('Network error'));
       const errorAuthFetch = createAuthenticatingFetchWithRetry(errorFetch, authHandler);
-      
+
       try {
         await errorAuthFetch('https://test.example.com/api');
         expect.fail('Expected error to be thrown');
@@ -497,9 +498,9 @@ describe('AuthHandlingFetch Tests', () => {
       const errorAuthHandler = new MockAuthHandler();
       const shouldRetrySpy = sinon.stub(errorAuthHandler, 'shouldRetryWithHeaders');
       shouldRetrySpy.rejects(new Error('Auth handler error'));
-      
+
       const errorAuthFetch = createAuthenticatingFetchWithRetry(mockFetch, errorAuthHandler);
-      
+
       try {
         await errorAuthFetch('https://test.example.com/api');
         expect.fail('Expected error to be thrown');

--- a/test/client/client_auth.spec.ts
+++ b/test/client/client_auth.spec.ts
@@ -5,8 +5,8 @@ import { A2AClient } from '../../src/client/client.js';
 import { AuthenticationHandler, HttpHeaders, createAuthenticatingFetchWithRetry } from '../../src/client/auth-handler.js';
 import {SendMessageResponse, SendMessageSuccessResponse } from '../../src/types.js';
 import { AGENT_CARD_PATH } from '../../src/constants.js';
-import { 
-  createMessageParams, 
+import {
+  createMessageParams,
   createMockFetch
 } from './util.js';
 
@@ -62,7 +62,7 @@ class MockAuthHandler implements AuthenticationHandler {
 
     // Use the ChallengeManager to sign the challenge
     const token = ChallengeManager.signChallenge(challenge);
-      
+
     // have the client try the token, BUT don't save it in case the client doesn't accept it
     return { 'Authorization': `Bearer ${token}` };
   }
@@ -146,7 +146,6 @@ describe('A2AClient Authentication Tests', () => {
         }
       });
       expect(mockFetch.secondCall.args[1].body).to.include('"method":"message/send"');
-
       // Third call: RPC request with auth header
       expect(mockFetch.thirdCall.args[0]).to.equal('https://test-agent.example.com/api');
       expect(mockFetch.thirdCall.args[1]).to.deep.include({
@@ -156,7 +155,6 @@ describe('A2AClient Authentication Tests', () => {
       expect(mockFetch.thirdCall.args[1].headers).to.have.property('Content-Type', 'application/json');
       expect(mockFetch.thirdCall.args[1].headers).to.have.property('Accept', 'application/json');
       expect(mockFetch.thirdCall.args[1].headers).to.have.property('Authorization');
-
       expect(mockFetch.thirdCall.args[1].headers['Authorization']).to.match(/^Bearer .+$/);
       expect(mockFetch.thirdCall.args[1].body).to.include('"method":"message/send"');
 
@@ -175,23 +173,18 @@ describe('A2AClient Authentication Tests', () => {
 
       // First request - should trigger auth flow
       const result1 = await client.sendMessage(messageParams);
-
       // Capture the token from the first request
       const firstRequestAuthCall = mockFetch.getCalls().find(call =>
         call.args[0].includes('/api') &&
         call.args[1]?.headers?.['Authorization']
       );
       const firstRequestToken = firstRequestAuthCall?.args[1]?.headers?.['Authorization'];
-
       // Second request - should use existing token
       const result2 = await client.sendMessage(messageParams);
-
       // Total calls should be 4: 3 for first request + 1 for second request (both agent card and auth token cached)
       expect(mockFetch.callCount).to.equal(4);
-
       // Second request should start from call #4 (after the first 3 calls)
       const secondRequestCalls = mockFetch.getCalls().slice(3);
-
       // Only one call for second request: RPC request with auth header (agent card and token cached)
       expect(secondRequestCalls[0].args[0]).to.equal('https://test-agent.example.com/api');
       expect(secondRequestCalls[0].args[1].headers).to.have.property('Authorization');
@@ -342,7 +335,6 @@ describe('A2AClient Authentication Tests', () => {
 
       // The client should return a JSON-RPC error response rather than throwing an error
       const result = await clientNoAuthHandler.sendMessage(messageParams);
-
       // Verify that the result is a JSON-RPC error response
       expect(result).to.have.property('jsonrpc', '2.0');
       expect(result).to.have.property('error');
@@ -393,7 +385,6 @@ describe('AuthHandlingFetch Tests', () => {
     it('should merge auth headers with provided headers when auth headers exist', async () => {
       // Create an auth handler that has stored authorization headers
       const authHandlerWithHeaders = new MockAuthHandler();
-
       // Simulate a successful authentication by calling onSuccessfulRetry
       // This will store the Authorization header in the auth handler
       await authHandlerWithHeaders.onSuccessfulRetry({
@@ -412,14 +403,12 @@ describe('AuthHandlingFetch Tests', () => {
       // Verify that the fetch was called with merged headers including auth headers
       const fetchCall = mockFetch.getCall(0);
       const headers = fetchCall.args[1]?.headers as Record<string, string>;
-
       // Should include both user headers and auth headers
       expect(headers).to.include({
         'Content-Type': 'application/json',
         'Custom-Header': 'custom-value',
         'Authorization': 'Bearer test-token-123'
       });
-
       // Verify the auth handler's headers method returns the stored authorization
       const storedHeaders = await authHandlerWithHeaders.headers();
       expect(storedHeaders['Authorization']).to.equal('Bearer test-token-123');
@@ -428,9 +417,7 @@ describe('AuthHandlingFetch Tests', () => {
     it('should handle empty headers gracefully', async () => {
       const emptyAuthHandler = new MockAuthHandler();
       const emptyAuthFetch = createAuthenticatingFetchWithRetry(mockFetch, emptyAuthHandler);
-
       await emptyAuthFetch('https://test.example.com/api');
-
       const fetchCall = mockFetch.getCall(0);
       expect(fetchCall.args[1]).to.exist;
     });
@@ -440,7 +427,6 @@ describe('AuthHandlingFetch Tests', () => {
     it('should call onSuccessfulRetry when retry succeeds', async () => {
       const successAuthHandler = new MockAuthHandler();
       const onSuccessSpy = sinon.spy(successAuthHandler, 'onSuccessfulRetry');
-
       // Create a modified version of the existing mockFetch that returns 401 first, then 200
       const successMockFetch = createMockFetch({
         messageConfig: {
@@ -449,11 +435,8 @@ describe('AuthHandlingFetch Tests', () => {
         },
         behavior: 'authRetry'
       });
-
       const successAuthFetch = createAuthenticatingFetchWithRetry(successMockFetch, successAuthHandler);
-
       await successAuthFetch('https://test.example.com/api');
-
       expect(onSuccessSpy.called).to.be.true;
       expect(onSuccessSpy.firstCall.args[0]).to.deep.include({
         'Authorization': 'Bearer challenge123.challenge123'
@@ -463,18 +446,13 @@ describe('AuthHandlingFetch Tests', () => {
     it('should not call onSuccessfulRetry when retry fails', async () => {
       const failAuthHandler = new MockAuthHandler();
       const onSuccessSpy = sinon.spy(failAuthHandler, 'onSuccessfulRetry');
-
       const failFetch = createAuthenticatingFetchWithRetry(mockFetch, failAuthHandler);
-
       // Mock fetch to return 401 first, then 401 again
       const failMockFetch = createMockFetch({
         behavior: 'alwaysFail'
       });
-
       const failAuthFetch = createAuthenticatingFetchWithRetry(failMockFetch, failAuthHandler);
-
       const response = await failAuthFetch('https://test.example.com/api');
-
       expect(onSuccessSpy.called).to.be.false;
       expect(response.status).to.equal(401);
     });
@@ -484,7 +462,6 @@ describe('AuthHandlingFetch Tests', () => {
     it('should propagate fetch errors', async () => {
       const errorFetch = sinon.stub().rejects(new Error('Network error'));
       const errorAuthFetch = createAuthenticatingFetchWithRetry(errorFetch, authHandler);
-
       try {
         await errorAuthFetch('https://test.example.com/api');
         expect.fail('Expected error to be thrown');
@@ -498,9 +475,7 @@ describe('AuthHandlingFetch Tests', () => {
       const errorAuthHandler = new MockAuthHandler();
       const shouldRetrySpy = sinon.stub(errorAuthHandler, 'shouldRetryWithHeaders');
       shouldRetrySpy.rejects(new Error('Auth handler error'));
-
       const errorAuthFetch = createAuthenticatingFetchWithRetry(mockFetch, errorAuthHandler);
-
       try {
         await errorAuthFetch('https://test.example.com/api');
         expect.fail('Expected error to be thrown');

--- a/test/client/client_auth.spec.ts
+++ b/test/client/client_auth.spec.ts
@@ -5,8 +5,8 @@ import { A2AClient } from '../../src/client/client.js';
 import { AuthenticationHandler, HttpHeaders, createAuthenticatingFetchWithRetry } from '../../src/client/auth-handler.js';
 import {SendMessageResponse, SendMessageSuccessResponse } from '../../src/types.js';
 import { AGENT_CARD_PATH } from '../../src/constants.js';
-import { 
-  createMessageParams, 
+import {
+  createMessageParams,
   createMockFetch
 } from './util.js';
 
@@ -62,7 +62,7 @@ class MockAuthHandler implements AuthenticationHandler {
 
     // Use the ChallengeManager to sign the challenge
     const token = ChallengeManager.signChallenge(challenge);
-      
+
     // have the client try the token, BUT don't save it in case the client doesn't accept it
     return { 'Authorization': `Bearer ${token}` };
   }
@@ -87,7 +87,7 @@ describe('A2AClient Authentication Tests', () => {
   let originalConsoleError: typeof console.error;
   const agentCardUrl = `https://test-agent.example.com/${AGENT_CARD_PATH}`;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Suppress console.error during tests to avoid noise
     originalConsoleError = console.error;
     console.error = () => {};
@@ -106,7 +106,7 @@ describe('A2AClient Authentication Tests', () => {
     authHandler = new MockAuthHandler();
     // Use AuthHandlingFetch to wrap the mock fetch with authentication handling
     const authHandlingFetch = createAuthenticatingFetchWithRetry(mockFetch, authHandler);
-    client = new A2AClient(agentCardUrl, {
+    client = await A2AClient.fromCardUrl(agentCardUrl, {
       fetchImpl: authHandlingFetch
     });
   });
@@ -230,7 +230,7 @@ describe('A2AClient Authentication Tests', () => {
       const originalShouldRetry = noRetryHandler.shouldRetryWithHeaders.bind(noRetryHandler);
       noRetryHandler.shouldRetryWithHeaders = sinon.stub().resolves(undefined);
 
-      const clientNoRetry = new A2AClient(agentCardUrl, {
+      const clientNoRetry = await A2AClient.fromCardUrl(agentCardUrl, {
         fetchImpl: mockFetch
       });
 
@@ -262,7 +262,7 @@ describe('A2AClient Authentication Tests', () => {
       const { capturedAuthHeaders } = authRetryTestFetch;
 
       const authHandlingFetch = createAuthenticatingFetchWithRetry(authRetryTestFetch, authHandler);
-      const clientAuthTest = new A2AClient(agentCardUrl, {
+      const clientAuthTest = await A2AClient.fromCardUrl(agentCardUrl, {
         fetchImpl: authHandlingFetch
       });
 
@@ -297,7 +297,7 @@ describe('A2AClient Authentication Tests', () => {
       });
       const { capturedAuthHeaders } = noAuthRequiredFetch;
 
-      const clientNoAuth = new A2AClient(agentCardUrl, {
+      const clientNoAuth = await A2AClient.fromCardUrl(agentCardUrl, {
         fetchImpl: noAuthRequiredFetch
       });
 
@@ -331,7 +331,7 @@ describe('A2AClient Authentication Tests', () => {
       });
 
       // Create client WITHOUT authHandler
-      const clientNoAuthHandler = new A2AClient(agentCardUrl, {
+      const clientNoAuthHandler = await A2AClient.fromCardUrl(agentCardUrl, {
         fetchImpl: fetchWithApiError
       });
 


### PR DESCRIPTION
# Description

- Breaking Change: A2AClient Constructor initialized with full agentCard rather than `baseUrl` and `agent_card_path`. This previously led to an error where the baseUrl had to be the baseUrl of the full agent card, rather than the serviceUrl (which is set by the AgentCard itself). 
- Static Method to load A2AClient from agentCardUrl.
- Cleanup trailing spaces at the start of new lines
