### PR TITLE
refactor: do not string match error message thrown in the same block

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -252,7 +252,7 @@ export class A2AClient {
         errorBody = await response.text();
         errorJson = JSON.parse(errorBody);
       } catch (e: any) {
-        throw new Error(`HTTP error establishing stream for message/stream: ${response.status} ${response.statusText}. Response: ${errorBody || '(empty)'}`);
+        throw new Error(`HTTP error establishing stream for message/stream: ${response.status} ${response.statusText}. Response: ${errorBody || '(empty)'}`, {cause: e});
       }
       if (errorJson.error) {
         throw new Error(`HTTP error establishing stream for message/stream: ${response.status} ${response.statusText}. RPC Error: ${errorJson.error.message} (Code: ${errorJson.error.code})`);
@@ -395,7 +395,7 @@ export class A2AClient {
         errorJson = JSON.parse(errorBody);
       } catch (e: any) {
         if (e.message.startsWith('HTTP error establishing stream')) throw e;
-        throw new Error(`HTTP error establishing stream for tasks/resubscribe: ${response.status} ${response.statusText}. Response: ${errorBody || '(empty)'}`);
+        throw new Error(`HTTP error establishing stream for tasks/resubscribe: ${response.status} ${response.statusText}. Response: ${errorBody || '(empty)'}`, {cause: e});
       }
       if (errorJson.error) {
         throw new Error(`HTTP error establishing stream for tasks/resubscribe: ${response.status} ${response.statusText}. RPC Error: ${errorJson.error.message} (Code: ${errorJson.error.code})`);


### PR DESCRIPTION
# Description

Minor fix in `client.ts` error handling: avoid checking an error thrown within the same block via a string match. Include `cause` into rethrown error.