### PR TITLE
refactor: extract JSON-RPC specific logic from client

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -18,7 +18,8 @@ import {
   Task,
   TaskArtifactUpdateEvent,
   TaskStatusUpdateEvent,
-  A2ARequest} from '../types.js'; // Assuming schema.ts is in the same directory or appropriately pathed
+  A2ARequest,
+} from '../types.js'; // Assuming schema.ts is in the same directory or appropriately pathed
 import { AGENT_CARD_PATH } from '../constants.js';
 import { JsonRpcTransport } from './transports/json_rpc_transport.js';
 
@@ -39,7 +40,7 @@ export class A2AClient {
   private readonly agentCardPromise: Promise<AgentCard>;
   private readonly customFetchImpl?: typeof fetch;
   private serviceEndpointUrl?: string; // To be populated from AgentCard after fetchin
-  
+
   // A2AClient is built around JSON-RPC types, so it will only support JSON-RPC transport, new client with transport agnostic interface is going to be created for multi-transport.
   // New transport abstraction isn't going to expose individual transport specific fields, so to keep returning JSON-RPC IDs here for compatibility,
   // keep counter here and pass it to JsonRpcTransport via an optional idOverride parameter (which is not visible via transport-agnostic A2ATransport interface).
@@ -147,7 +148,10 @@ export class A2AClient {
    * @returns A Promise resolving to SendMessageResponse, which can be a Message, Task, or an error.
    */
   public async sendMessage(params: MessageSendParams): Promise<SendMessageResponse> {
-    return await this.invokeJsonRpc<MessageSendParams, SendMessageResponse>((t, p, id) => t.sendMessage(p, id), params)
+    return await this.invokeJsonRpc<MessageSendParams, SendMessageResponse>(
+      (t, p, id) => t.sendMessage(p, id),
+      params
+    );
   }
 
   /**
@@ -188,7 +192,10 @@ export class A2AClient {
         'Agent does not support push notifications (AgentCard.capabilities.pushNotifications is not true).'
       );
     }
-    return await this.invokeJsonRpc<TaskPushNotificationConfig, SetTaskPushNotificationConfigResponse>((t, p, id) => t.setTaskPushNotificationConfig(p, id), params)
+    return await this.invokeJsonRpc<
+      TaskPushNotificationConfig,
+      SetTaskPushNotificationConfigResponse
+    >((t, p, id) => t.setTaskPushNotificationConfig(p, id), params);
   }
 
   /**
@@ -196,8 +203,13 @@ export class A2AClient {
    * @param params Parameters containing the taskId.
    * @returns A Promise resolving to GetTaskPushNotificationConfigResponse.
    */
-  public async getTaskPushNotificationConfig(params: TaskIdParams): Promise<GetTaskPushNotificationConfigResponse> {
-    return await this.invokeJsonRpc<TaskIdParams, GetTaskPushNotificationConfigResponse>((t, p, id) => t.getTaskPushNotificationConfig(p, id), params)
+  public async getTaskPushNotificationConfig(
+    params: TaskIdParams
+  ): Promise<GetTaskPushNotificationConfigResponse> {
+    return await this.invokeJsonRpc<TaskIdParams, GetTaskPushNotificationConfigResponse>(
+      (t, p, id) => t.getTaskPushNotificationConfig(p, id),
+      params
+    );
   }
 
   /**
@@ -205,8 +217,13 @@ export class A2AClient {
    * @param params Parameters containing the taskId.
    * @returns A Promise resolving to ListTaskPushNotificationConfigResponse.
    */
-  public async listTaskPushNotificationConfig(params: ListTaskPushNotificationConfigParams): Promise<ListTaskPushNotificationConfigResponse> {
-    return await this.invokeJsonRpc<ListTaskPushNotificationConfigParams, ListTaskPushNotificationConfigResponse>((t, p, id) => t.listTaskPushNotificationConfig(p, id), params)
+  public async listTaskPushNotificationConfig(
+    params: ListTaskPushNotificationConfigParams
+  ): Promise<ListTaskPushNotificationConfigResponse> {
+    return await this.invokeJsonRpc<
+      ListTaskPushNotificationConfigParams,
+      ListTaskPushNotificationConfigResponse
+    >((t, p, id) => t.listTaskPushNotificationConfig(p, id), params);
   }
 
   /**
@@ -214,8 +231,13 @@ export class A2AClient {
    * @param params Parameters containing the taskId and push notification configuration ID.
    * @returns A Promise resolving to DeleteTaskPushNotificationConfigResponse.
    */
-  public async deleteTaskPushNotificationConfig(params: DeleteTaskPushNotificationConfigParams): Promise<DeleteTaskPushNotificationConfigResponse> {
-    return await this.invokeJsonRpc<DeleteTaskPushNotificationConfigParams, DeleteTaskPushNotificationConfigResponse>((t, p, id) => t.deleteTaskPushNotificationConfig(p, id), params)
+  public async deleteTaskPushNotificationConfig(
+    params: DeleteTaskPushNotificationConfigParams
+  ): Promise<DeleteTaskPushNotificationConfigResponse> {
+    return await this.invokeJsonRpc<
+      DeleteTaskPushNotificationConfigParams,
+      DeleteTaskPushNotificationConfigResponse
+    >((t, p, id) => t.deleteTaskPushNotificationConfig(p, id), params);
   }
 
   /**
@@ -224,7 +246,10 @@ export class A2AClient {
    * @returns A Promise resolving to GetTaskResponse, which contains the Task object or an error.
    */
   public async getTask(params: TaskQueryParams): Promise<GetTaskResponse> {
-    return await this.invokeJsonRpc<TaskQueryParams, GetTaskResponse>((t, p, id) => t.getTask(p, id), params)
+    return await this.invokeJsonRpc<TaskQueryParams, GetTaskResponse>(
+      (t, p, id) => t.getTask(p, id),
+      params
+    );
   }
 
   /**
@@ -233,7 +258,10 @@ export class A2AClient {
    * @returns A Promise resolving to CancelTaskResponse, which contains the updated Task object or an error.
    */
   public async cancelTask(params: TaskIdParams): Promise<CancelTaskResponse> {
-    return await this.invokeJsonRpc<TaskIdParams, CancelTaskResponse>((t, p, id) => t.cancelTask(p, id), params)
+    return await this.invokeJsonRpc<TaskIdParams, CancelTaskResponse>(
+      (t, p, id) => t.cancelTask(p, id),
+      params
+    );
   }
 
   /**
@@ -244,10 +272,17 @@ export class A2AClient {
    * @param params Extension paramters defined in the AgentCard's extensions.
    * @returns A Promise that resolves to the RPC response.
    */
-  public async callExtensionMethod<TExtensionParams, TExtensionResponse extends JSONRPCResponse>(method: string, params: TExtensionParams) {
+  public async callExtensionMethod<TExtensionParams, TExtensionResponse extends JSONRPCResponse>(
+    method: string,
+    params: TExtensionParams
+  ) {
     const transport = await this._getOrCreateTransport();
     try {
-      return await transport.callExtensionMethod<TExtensionParams, TExtensionResponse>(method, params, this.requestIdCounter++);
+      return await transport.callExtensionMethod<TExtensionParams, TExtensionResponse>(
+        method,
+        params,
+        this.requestIdCounter++
+      );
     } catch (e: any) {
       // For compatibility, return JSON-RPC errors as errors instead of throwing transport-agnostic errors
       // produced by JsonRpcTransport.
@@ -277,17 +312,17 @@ export class A2AClient {
     yield* transport.resubscribeTask(params);
   }
 
-////////////////////////////////////////////////////////////////////////////////
-// Functions used to support old A2AClient Constructor to be deprecated soon
-// TODOs:
-// * remove `agentCardPromise`, and just use agentCard initialized
-// * _getServiceEndpoint can be made synchronous or deleted and accessed via
-//   agentCard.url
-// * getAgentCard changed to this.agentCard
-// * delete resolveAgentCardUrl(), _fetchAndCacheAgentCard(),
-//   agentCardPath from A2AClientOptions
-// * delete _getOrCreateTransport
-////////////////////////////////////////////////////////////////////////////////
+  ////////////////////////////////////////////////////////////////////////////////
+  // Functions used to support old A2AClient Constructor to be deprecated soon
+  // TODOs:
+  // * remove `agentCardPromise`, and just use agentCard initialized
+  // * _getServiceEndpoint can be made synchronous or deleted and accessed via
+  //   agentCard.url
+  // * getAgentCard changed to this.agentCard
+  // * delete resolveAgentCardUrl(), _fetchAndCacheAgentCard(),
+  //   agentCardPath from A2AClientOptions
+  // * delete _getOrCreateTransport
+  ////////////////////////////////////////////////////////////////////////////////
 
   private async _getOrCreateTransport(): Promise<JsonRpcTransport> {
     if (this.transport) {
@@ -295,7 +330,7 @@ export class A2AClient {
     }
 
     const endpoint = await this._getServiceEndpoint();
-    this.transport = new JsonRpcTransport({fetchImpl: this.customFetchImpl, endpoint: endpoint});
+    this.transport = new JsonRpcTransport({ fetchImpl: this.customFetchImpl, endpoint: endpoint });
     return this.transport;
   }
 
@@ -306,7 +341,10 @@ export class A2AClient {
    * @param agentCardPath path to the agent card, defaults to .well-known/agent-card.json
    * @returns A Promise that resolves to the AgentCard.
    */
-  private async _fetchAndCacheAgentCard(agentBaseUrl: string, agentCardPath?: string): Promise<AgentCard> {
+  private async _fetchAndCacheAgentCard(
+    agentBaseUrl: string,
+    agentCardPath?: string
+  ): Promise<AgentCard> {
     try {
       const agentCardUrl = this.resolveAgentCardUrl(agentBaseUrl, agentCardPath);
       const response = await this._fetch(agentCardUrl, {
@@ -391,33 +429,45 @@ export class A2AClient {
     return this.serviceEndpointUrl;
   }
 
-  private async invokeJsonRpc<TParams extends JsonRpcParams, TResponse extends JSONRPCResponse>(caller: JsonRpcCaller<TParams, TResponse>, params?: TParams): Promise<TResponse> {
+  private async invokeJsonRpc<TParams extends JsonRpcParams, TResponse extends JSONRPCResponse>(
+    caller: JsonRpcCaller<TParams, TResponse>,
+    params?: TParams
+  ): Promise<TResponse> {
     const transport = await this._getOrCreateTransport();
     const requestId = this.requestIdCounter++;
     try {
       const result = await caller(transport, params, requestId);
       return {
-        'id': requestId,
-        'jsonrpc': '2.0',
-        'result': result ?? null, // JSON-RPC requires result property on success, it will be null for "void" methods.
-      } as TResponse
+        id: requestId,
+        jsonrpc: '2.0',
+        result: result ?? null, // JSON-RPC requires result property on success, it will be null for "void" methods.
+      } as TResponse;
     } catch (e: any) {
       // For compatibility, return JSON-RPC errors as response objects instead of throwing transport-agnostic errors
       // produced by JsonRpcTransport.
       if (isJSONRPCError(e)) {
         return e.errorResponse as TResponse;
       }
-      throw e; 
+      throw e;
     }
   }
 }
 
 function isJSONRPCError(error: any): boolean {
-  return 'errorResponse' in error && error.errorResponse && error.errorResponse.jsonrpc === '2.0' && error.errorResponse.error;
+  return (
+    'errorResponse' in error &&
+    error.errorResponse &&
+    error.errorResponse.jsonrpc === '2.0' &&
+    error.errorResponse.error
+  );
 }
 
 // Utility unexported types to properly factor out common "compatibility" logic via invokeJsonRpc.
 type ParamsOf<T> = T extends { params: unknown } ? T['params'] : undefined;
 type ResultOf<T> = T extends { result: unknown } ? T['result'] : void;
 type JsonRpcParams = ParamsOf<A2ARequest>;
-type JsonRpcCaller<TParams extends JsonRpcParams, TResponse extends JSONRPCResponse> = (transport: JsonRpcTransport, params: TParams, idOverride: number) => Promise<ResultOf<TResponse>>
+type JsonRpcCaller<TParams extends JsonRpcParams, TResponse extends JSONRPCResponse> = (
+  transport: JsonRpcTransport,
+  params: TParams,
+  idOverride: number
+) => Promise<ResultOf<TResponse>>;

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -1,4 +1,12 @@
-import { AuthenticatedExtendedCardNotConfiguredError, ContentTypeNotSupportedError, InvalidAgentResponseError, PushNotificationNotSupportedError, TaskNotCancelableError, TaskNotFoundError, UnsupportedOperationError } from '../../errors.js';
+import {
+  AuthenticatedExtendedCardNotConfiguredError,
+  ContentTypeNotSupportedError,
+  InvalidAgentResponseError,
+  PushNotificationNotSupportedError,
+  TaskNotCancelableError,
+  TaskNotFoundError,
+  UnsupportedOperationError,
+} from '../../errors.js';
 import {
   JSONRPCRequest,
   JSONRPCResponse,
@@ -28,7 +36,7 @@ export interface JsonRpcTransportOptions {
 
 export class JsonRpcTransport implements A2ATransport {
   private readonly customFetchImpl?: typeof fetch;
-  private readonly endpoint: string
+  private readonly endpoint: string;
   private requestIdCounter: number = 1;
 
   constructor(options: JsonRpcTransportOptions) {
@@ -37,49 +45,97 @@ export class JsonRpcTransport implements A2ATransport {
   }
 
   async sendMessage(params: MessageSendParams, idOverride?: number): Promise<SendMessageResult> {
-    const rpcResponse = await this._sendRpcRequest<MessageSendParams, SendMessageSuccessResponse>("message/send", params, idOverride);
+    const rpcResponse = await this._sendRpcRequest<MessageSendParams, SendMessageSuccessResponse>(
+      'message/send',
+      params,
+      idOverride
+    );
     return rpcResponse.result;
   }
 
-  async *sendMessageStream(params: MessageSendParams): AsyncGenerator<A2AStreamEventData, void, undefined> {
-    yield* this._sendStreamingRequest("message/stream", params);
+  async *sendMessageStream(
+    params: MessageSendParams
+  ): AsyncGenerator<A2AStreamEventData, void, undefined> {
+    yield* this._sendStreamingRequest('message/stream', params);
   }
 
-  async setTaskPushNotificationConfig(params: TaskPushNotificationConfig, idOverride?: number): Promise<TaskPushNotificationConfig> {
-    const rpcResponse = await this._sendRpcRequest<TaskPushNotificationConfig, SetTaskPushNotificationConfigSuccessResponse>("tasks/pushNotificationConfig/set", params, idOverride);
+  async setTaskPushNotificationConfig(
+    params: TaskPushNotificationConfig,
+    idOverride?: number
+  ): Promise<TaskPushNotificationConfig> {
+    const rpcResponse = await this._sendRpcRequest<
+      TaskPushNotificationConfig,
+      SetTaskPushNotificationConfigSuccessResponse
+    >('tasks/pushNotificationConfig/set', params, idOverride);
     return rpcResponse.result;
   }
 
-  async getTaskPushNotificationConfig(params: TaskIdParams, idOverride?: number): Promise<TaskPushNotificationConfig> {
-    const rpcResponse = await this._sendRpcRequest<TaskIdParams, GetTaskPushNotificationConfigSuccessResponse>("tasks/pushNotificationConfig/get", params, idOverride);
+  async getTaskPushNotificationConfig(
+    params: TaskIdParams,
+    idOverride?: number
+  ): Promise<TaskPushNotificationConfig> {
+    const rpcResponse = await this._sendRpcRequest<
+      TaskIdParams,
+      GetTaskPushNotificationConfigSuccessResponse
+    >('tasks/pushNotificationConfig/get', params, idOverride);
     return rpcResponse.result;
   }
 
-  async listTaskPushNotificationConfig(params: ListTaskPushNotificationConfigParams, idOverride?: number): Promise<TaskPushNotificationConfig[]> {
-    const rpcResponse = await this._sendRpcRequest<ListTaskPushNotificationConfigParams, ListTaskPushNotificationConfigSuccessResponse>("tasks/pushNotificationConfig/list", params, idOverride);
+  async listTaskPushNotificationConfig(
+    params: ListTaskPushNotificationConfigParams,
+    idOverride?: number
+  ): Promise<TaskPushNotificationConfig[]> {
+    const rpcResponse = await this._sendRpcRequest<
+      ListTaskPushNotificationConfigParams,
+      ListTaskPushNotificationConfigSuccessResponse
+    >('tasks/pushNotificationConfig/list', params, idOverride);
     return rpcResponse.result;
   }
 
-  async deleteTaskPushNotificationConfig(params: DeleteTaskPushNotificationConfigParams, idOverride?: number): Promise<void> {
-    await this._sendRpcRequest<DeleteTaskPushNotificationConfigParams, DeleteTaskPushNotificationConfigResponse>("tasks/pushNotificationConfig/delete", params, idOverride);
+  async deleteTaskPushNotificationConfig(
+    params: DeleteTaskPushNotificationConfigParams,
+    idOverride?: number
+  ): Promise<void> {
+    await this._sendRpcRequest<
+      DeleteTaskPushNotificationConfigParams,
+      DeleteTaskPushNotificationConfigResponse
+    >('tasks/pushNotificationConfig/delete', params, idOverride);
   }
 
   async getTask(params: TaskQueryParams, idOverride?: number): Promise<Task> {
-    const rpcResponse = await this._sendRpcRequest<TaskQueryParams, GetTaskSuccessResponse>("tasks/get", params, idOverride);
+    const rpcResponse = await this._sendRpcRequest<TaskQueryParams, GetTaskSuccessResponse>(
+      'tasks/get',
+      params,
+      idOverride
+    );
     return rpcResponse.result;
   }
 
   async cancelTask(params: TaskIdParams, idOverride?: number): Promise<Task> {
-    const rpcResponse = await this._sendRpcRequest<TaskIdParams, CancelTaskSuccessResponse>("tasks/cancel", params, idOverride);
+    const rpcResponse = await this._sendRpcRequest<TaskIdParams, CancelTaskSuccessResponse>(
+      'tasks/cancel',
+      params,
+      idOverride
+    );
     return rpcResponse.result;
   }
 
-  async *resubscribeTask(params: TaskIdParams): AsyncGenerator<A2AStreamEventData, void, undefined> {
-    yield* this._sendStreamingRequest("tasks/resubscribe", params);
+  async *resubscribeTask(
+    params: TaskIdParams
+  ): AsyncGenerator<A2AStreamEventData, void, undefined> {
+    yield* this._sendStreamingRequest('tasks/resubscribe', params);
   }
 
-  async callExtensionMethod<TExtensionParams, TExtensionResponse extends JSONRPCResponse>(method: string, params: TExtensionParams, idOverride: number) {
-    return await this._sendRpcRequest<TExtensionParams, TExtensionResponse>(method, params, idOverride);
+  async callExtensionMethod<TExtensionParams, TExtensionResponse extends JSONRPCResponse>(
+    method: string,
+    params: TExtensionParams,
+    idOverride: number
+  ) {
+    return await this._sendRpcRequest<TExtensionParams, TExtensionResponse>(
+      method,
+      params,
+      idOverride
+    );
   }
 
   private _fetch(...args: Parameters<typeof fetch>): ReturnType<typeof fetch> {
@@ -91,19 +147,18 @@ export class JsonRpcTransport implements A2ATransport {
     }
     throw new Error(
       'A `fetch` implementation was not provided and is not available in the global scope. ' +
-      'Please provide a `fetchImpl` in the A2ATransportOptions. '
+        'Please provide a `fetchImpl` in the A2ATransportOptions. '
     );
   }
 
-  private async _sendRpcRequest<TParams extends { [key: string]: any; }, TResponse extends JSONRPCResponse>(
-    method: string,
-    params: TParams,
-    idOverride: number | undefined,
-  ): Promise<TResponse> {
+  private async _sendRpcRequest<
+    TParams extends { [key: string]: any },
+    TResponse extends JSONRPCResponse,
+  >(method: string, params: TParams, idOverride: number | undefined): Promise<TResponse> {
     const requestId = idOverride ?? this.requestIdCounter++;
-    
+
     const rpcRequest: JSONRPCRequest = {
-      jsonrpc: "2.0",
+      jsonrpc: '2.0',
       method,
       params: params,
       id: requestId,
@@ -118,35 +173,45 @@ export class JsonRpcTransport implements A2ATransport {
         errorBodyText = await httpResponse.text();
         errorJson = JSON.parse(errorBodyText);
       } catch (e: any) {
-        throw new Error(`HTTP error for ${method}! Status: ${httpResponse.status} ${httpResponse.statusText}. Response: ${errorBodyText}`, {cause: e});
+        throw new Error(
+          `HTTP error for ${method}! Status: ${httpResponse.status} ${httpResponse.statusText}. Response: ${errorBodyText}`,
+          { cause: e }
+        );
       }
       if (errorJson.jsonrpc && errorJson.error) {
         throw JsonRpcTransport.mapToError(errorJson);
       } else {
-        throw new Error(`HTTP error for ${method}! Status: ${httpResponse.status} ${httpResponse.statusText}. Response: ${errorBodyText}`);
+        throw new Error(
+          `HTTP error for ${method}! Status: ${httpResponse.status} ${httpResponse.statusText}. Response: ${errorBodyText}`
+        );
       }
     }
 
     const rpcResponse: JSONRPCResponse = await httpResponse.json();
     if (rpcResponse.id !== requestId) {
-      console.error(`CRITICAL: RPC response ID mismatch for method ${method}. Expected ${requestId}, got ${rpcResponse.id}.`);
+      console.error(
+        `CRITICAL: RPC response ID mismatch for method ${method}. Expected ${requestId}, got ${rpcResponse.id}.`
+      );
     }
 
     if ('error' in rpcResponse) {
-        throw JsonRpcTransport.mapToError(rpcResponse);
+      throw JsonRpcTransport.mapToError(rpcResponse);
     }
 
     return rpcResponse as TResponse;
   }
 
-  private async _fetchRpc(rpcRequest: JSONRPCRequest, acceptHeader: string = "application/json"): Promise<Response> {
+  private async _fetchRpc(
+    rpcRequest: JSONRPCRequest,
+    acceptHeader: string = 'application/json'
+  ): Promise<Response> {
     const requestInit: RequestInit = {
-      method: "POST",
+      method: 'POST',
       headers: {
-        "Content-Type": "application/json",
-        "Accept": acceptHeader,
+        'Content-Type': 'application/json',
+        Accept: acceptHeader,
       },
-      body: JSON.stringify(rpcRequest)
+      body: JSON.stringify(rpcRequest),
     };
     return this._fetch(this.endpoint, requestInit);
   }
@@ -157,30 +222,39 @@ export class JsonRpcTransport implements A2ATransport {
   ): AsyncGenerator<A2AStreamEventData, void, undefined> {
     const clientRequestId = this.requestIdCounter++;
     const rpcRequest: JSONRPCRequest = {
-      jsonrpc: "2.0",
+      jsonrpc: '2.0',
       method,
-      params: params as { [key: string]: any; },
+      params: params as { [key: string]: any },
       id: clientRequestId,
     };
 
-    const response = await this._fetchRpc(rpcRequest, "text/event-stream");
+    const response = await this._fetchRpc(rpcRequest, 'text/event-stream');
 
     if (!response.ok) {
-      let errorBody = "";
+      let errorBody = '';
       let errorJson: any = {};
       try {
         errorBody = await response.text();
         errorJson = JSON.parse(errorBody);
       } catch (e: any) {
-        throw new Error(`HTTP error establishing stream for ${method}: ${response.status} ${response.statusText}. Response: ${errorBody || '(empty)'}`, {cause: e});
+        throw new Error(
+          `HTTP error establishing stream for ${method}: ${response.status} ${response.statusText}. Response: ${errorBody || '(empty)'}`,
+          { cause: e }
+        );
       }
       if (errorJson.error) {
-        throw new Error(`HTTP error establishing stream for ${method}: ${response.status} ${response.statusText}. RPC Error: ${errorJson.error.message} (Code: ${errorJson.error.code})`);
-      }      
-      throw new Error(`HTTP error establishing stream for ${method}: ${response.status} ${response.statusText}`);
+        throw new Error(
+          `HTTP error establishing stream for ${method}: ${response.status} ${response.statusText}. RPC Error: ${errorJson.error.message} (Code: ${errorJson.error.code})`
+        );
+      }
+      throw new Error(
+        `HTTP error establishing stream for ${method}: ${response.status} ${response.statusText}`
+      );
     }
-    if (!response.headers.get("Content-Type")?.startsWith("text/event-stream")) {
-      throw new Error(`Invalid response Content-Type for SSE stream for ${method}. Expected 'text/event-stream'.`);
+    if (!response.headers.get('Content-Type')?.startsWith('text/event-stream')) {
+      throw new Error(
+        `Invalid response Content-Type for SSE stream for ${method}. Expected 'text/event-stream'.`
+      );
     }
 
     yield* this._parseA2ASseStream<A2AStreamEventData>(response, clientRequestId);
@@ -191,18 +265,21 @@ export class JsonRpcTransport implements A2ATransport {
     originalRequestId: number | string | null
   ): AsyncGenerator<TStreamItem, void, undefined> {
     if (!response.body) {
-      throw new Error("SSE response body is undefined. Cannot read stream.");
+      throw new Error('SSE response body is undefined. Cannot read stream.');
     }
     const reader = response.body.pipeThrough(new TextDecoderStream()).getReader();
-    let buffer = "";
-    let eventDataBuffer = "";
+    let buffer = '';
+    let eventDataBuffer = '';
 
     try {
       while (true) {
         const { done, value } = await reader.read();
         if (done) {
           if (eventDataBuffer.trim()) {
-            const result = this._processSseEventData<TStreamItem>(eventDataBuffer, originalRequestId);
+            const result = this._processSseEventData<TStreamItem>(
+              eventDataBuffer,
+              originalRequestId
+            );
             yield result;
           }
           break;
@@ -214,19 +291,22 @@ export class JsonRpcTransport implements A2ATransport {
           const line = buffer.substring(0, lineEndIndex).trim();
           buffer = buffer.substring(lineEndIndex + 1);
 
-          if (line === "") {
+          if (line === '') {
             if (eventDataBuffer) {
-              const result = this._processSseEventData<TStreamItem>(eventDataBuffer, originalRequestId);
+              const result = this._processSseEventData<TStreamItem>(
+                eventDataBuffer,
+                originalRequestId
+              );
               yield result;
-              eventDataBuffer = "";
+              eventDataBuffer = '';
             }
-          } else if (line.startsWith("data:")) {
-            eventDataBuffer += line.substring(5).trimStart() + "\n";
+          } else if (line.startsWith('data:')) {
+            eventDataBuffer += line.substring(5).trimStart() + '\n';
           }
         }
       }
     } catch (error: any) {
-      console.error("Error reading or parsing SSE stream:", error.message);
+      console.error('Error reading or parsing SSE stream:', error.message);
       throw error;
     } finally {
       reader.releaseLock();
@@ -238,19 +318,23 @@ export class JsonRpcTransport implements A2ATransport {
     originalRequestId: number | string | null
   ): TStreamItem {
     if (!jsonData.trim()) {
-      throw new Error("Attempted to process empty SSE event data.");
+      throw new Error('Attempted to process empty SSE event data.');
     }
     try {
       const sseJsonRpcResponse = JSON.parse(jsonData.replace(/\n$/, ''));
       const a2aStreamResponse: JSONRPCResponse = sseJsonRpcResponse as JSONRPCResponse;
 
       if (a2aStreamResponse.id !== originalRequestId) {
-        console.warn(`SSE Event's JSON-RPC response ID mismatch. Client request ID: ${originalRequestId}, event response ID: ${a2aStreamResponse.id}.`);
+        console.warn(
+          `SSE Event's JSON-RPC response ID mismatch. Client request ID: ${originalRequestId}, event response ID: ${a2aStreamResponse.id}.`
+        );
       }
 
-      if ("error" in a2aStreamResponse) {
+      if ('error' in a2aStreamResponse) {
         const err = a2aStreamResponse.error;
-        throw new Error(`SSE event contained an error: ${err.message} (Code: ${err.code}) Data: ${JSON.stringify(err.data || {})}`);
+        throw new Error(
+          `SSE event contained an error: ${err.message} (Code: ${err.code}) Data: ${JSON.stringify(err.data || {})}`
+        );
       }
 
       if (!('result' in a2aStreamResponse) || typeof a2aStreamResponse.result === 'undefined') {
@@ -259,11 +343,20 @@ export class JsonRpcTransport implements A2ATransport {
 
       return a2aStreamResponse.result as TStreamItem;
     } catch (e: any) {
-      if (e.message.startsWith("SSE event contained an error") || e.message.startsWith("SSE event JSON-RPC response is missing 'result' field")) {
+      if (
+        e.message.startsWith('SSE event contained an error') ||
+        e.message.startsWith("SSE event JSON-RPC response is missing 'result' field")
+      ) {
         throw e;
       }
-      console.error("Failed to parse SSE event data string or unexpected JSON-RPC structure:", jsonData, e);
-      throw new Error(`Failed to parse SSE event data: "${jsonData.substring(0, 100)}...". Original error: ${e.message}`);
+      console.error(
+        'Failed to parse SSE event data string or unexpected JSON-RPC structure:',
+        jsonData,
+        e
+      );
+      throw new Error(
+        `Failed to parse SSE event data: "${jsonData.substring(0, 100)}...". Original error: ${e.message}`
+      );
     }
   }
 
@@ -291,7 +384,9 @@ export class JsonRpcTransport implements A2ATransport {
 
 export class JSONRPCTransportError extends Error {
   constructor(public errorResponse: JSONRPCErrorResponse) {
-    super(`JSON-RPC error: ${errorResponse.error.message} (Code: ${errorResponse.error.code}) Data: ${JSON.stringify(errorResponse.error.data || {})}`);
+    super(
+      `JSON-RPC error: ${errorResponse.error.message} (Code: ${errorResponse.error.code}) Data: ${JSON.stringify(errorResponse.error.data || {})}`
+    );
   }
 }
 
@@ -300,42 +395,42 @@ export class JSONRPCTransportError extends Error {
 
 export class TaskNotFoundJSONRPCError extends TaskNotFoundError {
   constructor(public errorResponse: JSONRPCErrorResponse) {
-    super()
+    super();
   }
 }
 
 export class TaskNotCancelableJSONRPCError extends TaskNotCancelableError {
   constructor(public errorResponse: JSONRPCErrorResponse) {
-    super()
+    super();
   }
 }
 
 export class PushNotificationNotSupportedJSONRPCError extends PushNotificationNotSupportedError {
   constructor(public errorResponse: JSONRPCErrorResponse) {
-    super()
+    super();
   }
 }
 
 export class UnsupportedOperationJSONRPCError extends UnsupportedOperationError {
   constructor(public errorResponse: JSONRPCErrorResponse) {
-    super()
+    super();
   }
 }
 
 export class ContentTypeNotSupportedJSONRPCError extends ContentTypeNotSupportedError {
   constructor(public errorResponse: JSONRPCErrorResponse) {
-    super()
+    super();
   }
 }
 
 export class InvalidAgentResponseJSONRPCError extends InvalidAgentResponseError {
   constructor(public errorResponse: JSONRPCErrorResponse) {
-    super()
+    super();
   }
 }
 
 export class AuthenticatedExtendedCardNotConfiguredJSONRPCError extends AuthenticatedExtendedCardNotConfiguredError {
   constructor(public errorResponse: JSONRPCErrorResponse) {
-    super()
+    super();
   }
 }

--- a/src/client/transports/transport.ts
+++ b/src/client/transports/transport.ts
@@ -1,22 +1,26 @@
 import {
-    MessageSendParams,
-    TaskPushNotificationConfig,
-    TaskIdParams,
-    ListTaskPushNotificationConfigParams,
-    DeleteTaskPushNotificationConfigParams,
-    TaskQueryParams,
-    Task
-} from "../../types.js";
-import { A2AStreamEventData, SendMessageResult } from "../client.js";
+  MessageSendParams,
+  TaskPushNotificationConfig,
+  TaskIdParams,
+  ListTaskPushNotificationConfigParams,
+  DeleteTaskPushNotificationConfigParams,
+  TaskQueryParams,
+  Task,
+} from '../../types.js';
+import { A2AStreamEventData, SendMessageResult } from '../client.js';
 
 export interface A2ATransport {
-    sendMessage(params: MessageSendParams): Promise<SendMessageResult>;
-    sendMessageStream(params: MessageSendParams): AsyncGenerator<A2AStreamEventData, void, undefined>;
-    setTaskPushNotificationConfig(params: TaskPushNotificationConfig): Promise<TaskPushNotificationConfig>;
-    getTaskPushNotificationConfig(params: TaskIdParams): Promise<TaskPushNotificationConfig>;
-    listTaskPushNotificationConfig(params: ListTaskPushNotificationConfigParams): Promise<TaskPushNotificationConfig[]>;
-    deleteTaskPushNotificationConfig(params: DeleteTaskPushNotificationConfigParams): Promise<void>;
-    getTask(params: TaskQueryParams): Promise<Task>;
-    cancelTask(params: TaskIdParams): Promise<Task>;
-    resubscribeTask(params: TaskIdParams): AsyncGenerator<A2AStreamEventData, void, undefined>;
+  sendMessage(params: MessageSendParams): Promise<SendMessageResult>;
+  sendMessageStream(params: MessageSendParams): AsyncGenerator<A2AStreamEventData, void, undefined>;
+  setTaskPushNotificationConfig(
+    params: TaskPushNotificationConfig
+  ): Promise<TaskPushNotificationConfig>;
+  getTaskPushNotificationConfig(params: TaskIdParams): Promise<TaskPushNotificationConfig>;
+  listTaskPushNotificationConfig(
+    params: ListTaskPushNotificationConfigParams
+  ): Promise<TaskPushNotificationConfig[]>;
+  deleteTaskPushNotificationConfig(params: DeleteTaskPushNotificationConfigParams): Promise<void>;
+  getTask(params: TaskQueryParams): Promise<Task>;
+  cancelTask(params: TaskIdParams): Promise<Task>;
+  resubscribeTask(params: TaskIdParams): AsyncGenerator<A2AStreamEventData, void, undefined>;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -2,49 +2,49 @@
 
 export class TaskNotFoundError extends Error {
   constructor(message?: string) {
-    super(message ?? "Task not found");
-    this.name = "TaskNotFoundError";
+    super(message ?? 'Task not found');
+    this.name = 'TaskNotFoundError';
   }
 }
 
-export class TaskNotCancelableError	extends Error {
+export class TaskNotCancelableError extends Error {
   constructor(message?: string) {
-    super(message ?? "Task cannot be canceled");
-    this.name = "TaskNotCancelableError";
+    super(message ?? 'Task cannot be canceled');
+    this.name = 'TaskNotCancelableError';
   }
 }
 
 export class PushNotificationNotSupportedError extends Error {
   constructor(message?: string) {
-    super(message ?? "Push Notification is not supported");
-    this.name = "PushNotificationNotSupportedError";
+    super(message ?? 'Push Notification is not supported');
+    this.name = 'PushNotificationNotSupportedError';
   }
 }
 
 export class UnsupportedOperationError extends Error {
   constructor(message?: string) {
-    super(message ?? "This operation is not supported");
-    this.name = "UnsupportedOperationError";
+    super(message ?? 'This operation is not supported');
+    this.name = 'UnsupportedOperationError';
   }
 }
 
 export class ContentTypeNotSupportedError extends Error {
   constructor(message?: string) {
-    super(message ?? "Incompatible content types");
-    this.name = "ContentTypeNotSupportedError";
+    super(message ?? 'Incompatible content types');
+    this.name = 'ContentTypeNotSupportedError';
   }
 }
 
 export class InvalidAgentResponseError extends Error {
   constructor(message?: string) {
-    super(message ?? "Invalid agent response type");
-    this.name = "InvalidAgentResponseError";
+    super(message ?? 'Invalid agent response type');
+    this.name = 'InvalidAgentResponseError';
   }
 }
 
 export class AuthenticatedExtendedCardNotConfiguredError extends Error {
   constructor(message?: string) {
-    super(message ?? "Authenticated Extended Card not configured");
-    this.name = "AuthenticatedExtendedCardNotConfiguredError";
+    super(message ?? 'Authenticated Extended Card not configured');
+    this.name = 'AuthenticatedExtendedCardNotConfiguredError';
   }
 }


### PR DESCRIPTION
# Description

Currently `A2AClient` defined in `client.ts` uses JSON-RPC types in its interface, i.e. `sendMessage` uses [`SendMessageResponse`](https://github.com/a2aproject/a2a-js/blob/e7e8f35d5d5356d30a13131dea0caff97be8cd53/src/client/client.ts#L207) which contains [JSON-RPC fields like `id` and `jsonrpc` version](https://github.com/a2aproject/a2a-js/blob/e7e8f35d5d5356d30a13131dea0caff97be8cd53/src/types.ts#L2177-L2190). It was also the case for Python SDK which required introducing a new [client.py](https://github.com/a2aproject/a2a-python/blob/main/src/a2a/client/client.py) keeping the old one as [legacy.py](https://github.com/a2aproject/a2a-python/blob/main/src/a2a/client/legacy.py) for backward compatibility (see [#348](https://github.com/a2aproject/a2a-python/pull/348)).

As a first step of introducing a transport-agnostic client, extract JSON-RPC specific logic into a transport abstraction and switch existing `A2AClient` to it in a backward compatible way to take advantage of existing tests.

**Note:** new types are not exported from `index.ts`, this will be done once new client is ready.

# Changes

1. Define `A2ATransport` abstraction without using JSON-RPC types.
2. Implement `JsonRpcTransport` from existing `A2AClient`.
3. Use new `JsonRpcTransport` from `A2AClient` - new transports are **not going** to be added into this client as it uses JSON-RPC types. This is done in a backward compatible way, existing behavior is preserved: returning JSON-RPC errors as objects, populating JSON-RPC specific fields.
4. Define shared transport-agnostic errors for A2A specific errors defined in [the spec](https://a2a-protocol.org/latest/specification/#82-a2a-specific-errors).

Re #137, #142