### PR TITLE
feat: add `DatabaseTaskStore` with Drizzle ORM support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@types/supertest": "^6.0.3",
         "c8": "^10.1.3",
         "chai": "^5.2.0",
+        "drizzle-orm": "^0.44.7",
         "eslint": "^9.39.1",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
@@ -42,9 +43,13 @@
         "node": ">=18"
       },
       "peerDependencies": {
+        "drizzle-orm": ">=0.30.0",
         "express": "^4.21.2 || ^5.1.0"
       },
       "peerDependenciesMeta": {
+        "drizzle-orm": {
+          "optional": true
+        },
         "express": {
           "optional": true
         }
@@ -1750,6 +1755,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
         "@google-cloud/projectify": "^4.0.0",
@@ -1778,6 +1784,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2141,7 +2148,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2241,7 +2247,6 @@
       "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.25.1"
       },
@@ -3501,7 +3506,6 @@
       "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/semantic-conventions": "1.25.1"
@@ -3547,7 +3551,6 @@
       "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/resources": "1.25.1",
@@ -3604,7 +3607,6 @@
       "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.25.1",
         "@opentelemetry/resources": "1.25.1",
@@ -4644,7 +4646,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -4897,7 +4898,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5142,6 +5142,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "retry": "0.13.1"
       }
@@ -5983,6 +5984,132 @@
         "yaml": "^2.8.0"
       }
     },
+    "node_modules/drizzle-orm": {
+      "version": "0.44.7",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.7.tgz",
+      "integrity": "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -6146,7 +6273,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6218,7 +6344,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6279,7 +6404,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6776,6 +6900,7 @@
       ],
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "strnum": "^1.1.1"
       },
@@ -6951,7 +7076,6 @@
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "^2.0.0",
@@ -7201,7 +7325,8 @@
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/gaxios": {
       "version": "6.7.1",
@@ -7276,7 +7401,6 @@
       "integrity": "sha512-8BOpwt40Yqadc6shvfcKk4fTzrtlIV8ntv9Mqx3Yul9BbM4kRXW+h6nYMaPMKT4ZdErzZgnfxU7e6t1lXFFP4A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@genkit-ai/ai": "1.23.0",
         "@genkit-ai/core": "1.23.0",
@@ -7767,7 +7891,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -7930,7 +8053,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7987,7 +8109,6 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -8148,7 +8269,6 @@
       "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9481,6 +9601,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -10279,7 +10400,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10415,7 +10535,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10955,6 +11074,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -11598,7 +11718,8 @@
         }
       ],
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/stubs": {
       "version": "3.0.0",
@@ -12139,7 +12260,6 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -12695,7 +12815,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12934,7 +13053,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@colors/colors": "^1.6.0",
         "@dabh/diagnostics": "^2.0.8",
@@ -13271,7 +13389,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,11 @@
       "import": "./dist/server/express/index.js",
       "require": "./dist/server/express/index.cjs"
     },
+    "./server/drizzle": {
+      "types": "./dist/server/drizzle/index.d.ts",
+      "import": "./dist/server/drizzle/index.js",
+      "require": "./dist/server/drizzle/index.cjs"
+    },
     "./client": {
       "types": "./dist/client/index.d.ts",
       "import": "./dist/client/index.js",
@@ -51,6 +56,7 @@
     "@types/supertest": "^6.0.3",
     "c8": "^10.1.3",
     "chai": "^5.2.0",
+    "drizzle-orm": "^0.44.7",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
@@ -86,10 +92,14 @@
     "uuid": "^11.1.0"
   },
   "peerDependencies": {
+    "drizzle-orm": ">=0.30.0",
     "express": "^4.21.2 || ^5.1.0"
   },
   "peerDependenciesMeta": {
     "express": {
+      "optional": true
+    },
+    "drizzle-orm": {
       "optional": true
     }
   },

--- a/src/server/drizzle/database_task_store.ts
+++ b/src/server/drizzle/database_task_store.ts
@@ -1,0 +1,218 @@
+/**
+ * DatabaseTaskStore - A persistent task store implementation using Drizzle ORM.
+ *
+ * This module provides a database-backed implementation of the TaskStore interface,
+ * supporting PostgreSQL, MySQL, and SQLite databases through Drizzle ORM.
+ *
+ * @example
+ * ```typescript
+ * import { drizzle } from 'drizzle-orm/better-sqlite3';
+ * import Database from 'better-sqlite3';
+ * import { DatabaseTaskStore, sqliteTasks } from '@a2a-js/sdk/server/drizzle';
+ *
+ * const sqlite = new Database('tasks.db');
+ * const db = drizzle(sqlite);
+ *
+ * const taskStore = new DatabaseTaskStore(db, sqliteTasks);
+ * ```
+ */
+import { eq, type InferSelectModel } from 'drizzle-orm';
+import type { Task } from '../../types.js';
+import type { TaskStore } from '../store.js';
+import type { SqliteTasksTable, PgTasksTable, MysqlTasksTable } from './schema.js';
+
+/**
+ * Union type for all supported Drizzle database instances.
+ * Supports any Drizzle database that has select, insert, and delete methods.
+ *
+ * This type is intentionally broad to accommodate different Drizzle dialects
+ * (SQLite, PostgreSQL, MySQL) which have slightly different method signatures.
+ */
+export type DrizzleDatabase = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  select: () => SelectQueryBuilder<any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  insert: <TTable = any>(table: TTable) => InsertQueryBuilder;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete: <TTable = any>(table: TTable) => DeleteQueryBuilder;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type SelectQueryBuilder<TTable = any> = {
+  from: (table: TTable) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    where: <TCondition>(condition: TCondition) => Promise<any[]>;
+  };
+};
+
+type InsertQueryBuilder = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  values: <TValues = any>(values: TValues) => InsertValuesQueryBuilder;
+};
+
+type InsertValuesQueryBuilder = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onConflictDoUpdate?: <TConfig = any>(config: TConfig) => Promise<void>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onDuplicateKeyUpdate?: <TConfig = any>(config: TConfig) => Promise<void>;
+};
+
+type DeleteQueryBuilder = {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  where: <TCondition = any>(condition: TCondition) => Promise<void>;
+};
+
+/**
+ * Configuration options for DatabaseTaskStore.
+ */
+export interface DatabaseTaskStoreOptions<
+  T extends SqliteTasksTable | PgTasksTable | MysqlTasksTable,
+> {
+  /**
+   * The Drizzle database instance to use for storage.
+   */
+  db: DrizzleDatabase;
+
+  /**
+   * The tasks table schema to use.
+   * Use sqliteTasks, pgTasks, or mysqlTasks from the schema module.
+   */
+  table: T;
+
+  /**
+   * The database dialect. Used to determine the correct upsert strategy.
+   * Required to ensure correct SQL generation for your database.
+   *
+   * @example 'sqlite' for SQLite databases
+   * @example 'postgresql' for PostgreSQL databases
+   * @example 'mysql' for MySQL/MariaDB databases
+   */
+  dialect: T extends SqliteTasksTable
+    ? 'sqlite'
+    : T extends PgTasksTable
+      ? 'postgresql'
+      : T extends MysqlTasksTable
+        ? 'mysql'
+        : 'sqlite' | 'postgresql' | 'mysql';
+}
+
+type TaskRow =
+  | InferSelectModel<SqliteTasksTable>
+  | InferSelectModel<PgTasksTable>
+  | InferSelectModel<MysqlTasksTable>;
+
+/**
+ * A persistent task store implementation using Drizzle ORM.
+ *
+ * Supports PostgreSQL, MySQL, and SQLite databases through Drizzle ORM.
+ * Tasks are stored in a single table with JSON columns for complex nested data.
+ */
+export class DatabaseTaskStore<T extends SqliteTasksTable | PgTasksTable | MysqlTasksTable>
+  implements TaskStore
+{
+  private db: DrizzleDatabase;
+  private table: T;
+  private dialect: 'sqlite' | 'postgresql' | 'mysql';
+
+  constructor(options: DatabaseTaskStoreOptions<T>) {
+    this.db = options.db;
+    this.table = options.table;
+    this.dialect = options.dialect;
+  }
+
+  /**
+   * Saves a task to the database.
+   * If a task with the same ID exists, it will be updated.
+   * The updatedAt timestamp is automatically set by the database schema.
+   *
+   * @param task The task to save.
+   */
+  async save(task: Task): Promise<void> {
+    const row = this.taskToRow(task);
+    const insertQuery = this.db.insert(this.table).values(row);
+
+    const updateFields = {
+      contextId: row.contextId,
+      kind: row.kind,
+      status: row.status,
+      artifacts: row.artifacts,
+      history: row.history,
+      metadata: row.metadata,
+    };
+
+    if (this.dialect === 'mysql') {
+      // MySQL uses ON DUPLICATE KEY UPDATE
+      if (!insertQuery.onDuplicateKeyUpdate) {
+        throw new Error('Database does not support onDuplicateKeyUpdate');
+      }
+      await insertQuery.onDuplicateKeyUpdate({ set: updateFields });
+    } else {
+      // SQLite and PostgreSQL use ON CONFLICT DO UPDATE
+      if (!insertQuery.onConflictDoUpdate) {
+        throw new Error('Database does not support onConflictDoUpdate');
+      }
+      await insertQuery.onConflictDoUpdate({
+        target: this.table.id,
+        set: updateFields,
+      });
+    }
+  }
+
+  /**
+   * Loads a task from the database by ID.
+   *
+   * @param taskId The ID of the task to load.
+   * @returns The task if found, or undefined if not found.
+   */
+  async load(taskId: string): Promise<Task | undefined> {
+    const results = (await this.db
+      .select()
+      .from(this.table)
+      .where(eq(this.table.id, taskId))) as TaskRow[];
+
+    if (results.length === 0) {
+      return undefined;
+    }
+
+    return this.rowToTask(results[0]);
+  }
+
+  /**
+   * Deletes a task from the database by ID.
+   *
+   * @param taskId The ID of the task to delete.
+   */
+  async delete(taskId: string): Promise<void> {
+    await this.db.delete(this.table).where(eq(this.table.id, taskId));
+  }
+
+  /**
+   * Converts a Task object to a database row.
+   */
+  private taskToRow(task: Task) {
+    return {
+      id: task.id,
+      contextId: task.contextId,
+      kind: task.kind,
+      status: task.status,
+      artifacts: task.artifacts ?? null,
+      history: task.history ?? null,
+      metadata: task.metadata ?? null,
+    };
+  }
+
+  /**
+   * Converts a database row to a Task object.
+   */
+  private rowToTask(row: TaskRow): Task {
+    return {
+      id: row.id,
+      contextId: row.contextId,
+      kind: row.kind as 'task',
+      status: row.status,
+      ...(row.artifacts && { artifacts: row.artifacts }),
+      ...(row.history && { history: row.history }),
+      ...(row.metadata && { metadata: row.metadata }),
+    };
+  }
+}

--- a/src/server/drizzle/index.ts
+++ b/src/server/drizzle/index.ts
@@ -1,0 +1,46 @@
+/**
+ * Drizzle ORM integration for persistent task storage.
+ *
+ * This module provides a database-backed implementation of the TaskStore interface
+ * using Drizzle ORM, supporting PostgreSQL, MySQL, and SQLite databases.
+ *
+ * @example
+ * ```typescript
+ * // SQLite example
+ * import { drizzle } from 'drizzle-orm/better-sqlite3';
+ * import Database from 'better-sqlite3';
+ * import { DatabaseTaskStore, sqliteTasks } from '@a2a-js/sdk/server/drizzle';
+ *
+ * const sqlite = new Database('tasks.db');
+ * const db = drizzle(sqlite);
+ *
+ * const taskStore = new DatabaseTaskStore({
+ *   db,
+ *   table: sqliteTasks,
+ *   dialect: 'sqlite',
+ * });
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // PostgreSQL example
+ * import { drizzle } from 'drizzle-orm/node-postgres';
+ * import { Pool } from 'pg';
+ * import { DatabaseTaskStore, pgTasks } from '@a2a-js/sdk/server/drizzle';
+ *
+ * const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+ * const db = drizzle(pool);
+ *
+ * const taskStore = new DatabaseTaskStore({
+ *   db,
+ *   table: pgTasks,
+ *   dialect: 'postgresql',
+ * });
+ * ```
+ */
+
+export { DatabaseTaskStore } from './database_task_store.js';
+export type { DrizzleDatabase, DatabaseTaskStoreOptions } from './database_task_store.js';
+
+export { sqliteTasks, pgTasks, mysqlTasks } from './schema.js';
+export type { SqliteTasksTable, PgTasksTable, MysqlTasksTable, TasksTable } from './schema.js';

--- a/src/server/drizzle/schema.ts
+++ b/src/server/drizzle/schema.ts
@@ -1,0 +1,72 @@
+/**
+ * Drizzle ORM schema for persistent task storage.
+ * This schema defines the tasks table used by DatabaseTaskStore.
+ */
+import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
+import { pgTable, text as pgText, jsonb, timestamp } from 'drizzle-orm/pg-core';
+import { mysqlTable, text as mysqlText, json, timestamp as mysqlTimestamp } from 'drizzle-orm/mysql-core';
+import type { TaskStatus, Artifact, Message1 } from '../../types.js';
+
+/**
+ * SQLite tasks table schema.
+ * Stores task data with JSON columns for complex nested objects.
+ */
+export const sqliteTasks = sqliteTable('tasks', {
+  id: text('id').primaryKey(),
+  contextId: text('context_id').notNull(),
+  kind: text('kind').notNull().$type<'task'>(),
+  status: text('status', { mode: 'json' }).notNull().$type<TaskStatus>(),
+  artifacts: text('artifacts', { mode: 'json' }).$type<Artifact[] | null>(),
+  history: text('history', { mode: 'json' }).$type<Message1[] | null>(),
+  metadata: text('metadata', { mode: 'json' }).$type<Record<string, unknown> | null>(),
+  createdAt: integer('created_at', { mode: 'timestamp_ms' })
+    .notNull()
+    .$defaultFn(() => new Date()),
+  updatedAt: integer('updated_at', { mode: 'timestamp_ms' })
+    .notNull()
+    .$defaultFn(() => new Date())
+    .$onUpdate(() => new Date()),
+});
+
+/**
+ * PostgreSQL tasks table schema.
+ * Uses JSONB for efficient JSON storage and querying.
+ */
+export const pgTasks = pgTable('tasks', {
+  id: pgText('id').primaryKey(),
+  contextId: pgText('context_id').notNull(),
+  kind: pgText('kind').notNull().$type<'task'>(),
+  status: jsonb('status').notNull().$type<TaskStatus>(),
+  artifacts: jsonb('artifacts').$type<Artifact[] | null>(),
+  history: jsonb('history').$type<Message1[] | null>(),
+  metadata: jsonb('metadata').$type<Record<string, unknown> | null>(),
+  createdAt: timestamp('created_at', { mode: 'date' }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { mode: 'date' })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+/**
+ * MySQL tasks table schema.
+ * Uses JSON columns for complex nested objects.
+ */
+export const mysqlTasks = mysqlTable('tasks', {
+  id: mysqlText('id').primaryKey(),
+  contextId: mysqlText('context_id').notNull(),
+  kind: mysqlText('kind').notNull().$type<'task'>(),
+  status: json('status').notNull().$type<TaskStatus>(),
+  artifacts: json('artifacts').$type<Artifact[] | null>(),
+  history: json('history').$type<Message1[] | null>(),
+  metadata: json('metadata').$type<Record<string, unknown> | null>(),
+  createdAt: mysqlTimestamp('created_at', { mode: 'date' }).notNull().defaultNow(),
+  updatedAt: mysqlTimestamp('updated_at', { mode: 'date' })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+export type SqliteTasksTable = typeof sqliteTasks;
+export type PgTasksTable = typeof pgTasks;
+export type MysqlTasksTable = typeof mysqlTasks;
+export type TasksTable = SqliteTasksTable | PgTasksTable | MysqlTasksTable;

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -19,6 +19,13 @@ export interface TaskStore {
    * @returns A promise resolving to an object containing the Task, or undefined if not found.
    */
   load(taskId: string): Promise<Task | undefined>;
+
+  /**
+   * Deletes a task by task ID.
+   * @param taskId The ID of the task to delete.
+   * @returns A promise resolving when the delete operation is complete.
+   */
+  delete(taskId: string): Promise<void>;
 }
 
 // ========================
@@ -38,5 +45,9 @@ export class InMemoryTaskStore implements TaskStore {
   async save(task: Task): Promise<void> {
     // Store copies to prevent internal mutation if caller reuses objects
     this.store.set(task.id, { ...task });
+  }
+
+  async delete(taskId: string): Promise<void> {
+    this.store.delete(taskId);
   }
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     'src/index.ts',
     'src/server/index.ts',
     'src/server/express/index.ts',
+    'src/server/drizzle/index.ts',
     'src/client/index.ts',
   ],
   format: ['esm', 'cjs'],


### PR DESCRIPTION
- Add `delete` method to TaskStore interface and InMemoryTaskStore
- Add DatabaseTaskStore for persistent task storage using Drizzle ORM
- Support SQLite, PostgreSQL, and MySQL databases
- Export via new entry point `@a2a-js/sdk/server/drizzle`
- Add drizzle-orm as optional peer dependency
- Update README with installation and usage examples

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-js/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

Fixes #114 🦕
