### PR TITLE
fix: change `context` parameter in `RequestOptions` from mandatory to optional

### DIFF
--- a/src/client/multitransport-client.ts
+++ b/src/client/multitransport-client.ts
@@ -55,7 +55,7 @@ export interface RequestOptions {
   /**
    * Arbitrary data available to interceptors and transport implementation.
    */
-  context: Map<string, unknown>;
+  context?: Map<string, unknown>;
 }
 
 export class Client {


### PR DESCRIPTION
# Description

This PR changes the `context` parameter in `RequestOptions` from mandatory to optional.

Fix for #223  which is not yet released, so overriding changelog entry below to avoid extra message for unreleased functionality.

BEGIN_COMMIT_OVERRIDE
refactor: change `context` parameter in `RequestOptions` from mandatory to optional
END_COMMIT_OVERRIDE
