### PR TITLE
docs: Add missing required Agent Card fields to Quickstart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ const helloAgentCard: AgentCard = {
   version: '0.1.0',
   url: 'http://localhost:4000/', // The public URL of your agent server
   skills: [{ id: 'chat', name: 'Chat', description: 'Say hello', tags: ['chat'] }],
-  // --- Other AgentCard fields omitted for brevity ---
+  capabilities: {
+    pushNotifications: false,
+  },
+  defaultInputModes: ['text'],
+  defaultOutputModes: ['text'],
 };
 
 // 2. Implement the agent's logic.


### PR DESCRIPTION
# Description

When trying out a new library I always copy the quickstarts from the README of the library, when I did it in this case I got an error since the `capabilities`, `defaultInputModes` and `defaultOutputModes` where missing since the `AgentCard` type requires them.

```bash
if (agentCard.capabilities.pushNotifications) {
                               ^

TypeError: Cannot read properties of undefined (reading 'pushNotifications')
    at new DefaultRequestHandler (/Users/matsfunke/Desktop/tmp/node_modules/@a2a-js/sdk/dist/server/index.cjs:490:32)
    at express (/Users/matsfunke/Desktop/tmp/server.ts:60:24)
    at Object.<anonymous> (/Users/matsfunke/Desktop/tmp/server.ts:71:2)
    at Module._compile (node:internal/modules/cjs/loader:1706:14)
    at Object.transformer (/Users/matsfunke/Desktop/tmp/node_modules/tsx/dist/register-D46fvsV_.cjs:3:1104)
    at Module.load (node:internal/modules/cjs/loader:1441:32)
    at Function._load (node:internal/modules/cjs/loader:1263:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)
    at cjsLoader (node:internal/modules/esm/translators:309:5)
```

**This is in my option bad UX as users have to fix this before they can run the server.**

**Also really sorry for just submitting a docs only PR 🙏** 

Before submitting the PR:
- [X] I read and followed [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-js/blob/main/CONTRIBUTING.md).
- [X] I ensured that the PR title follows the <https://www.conventionalcommits.org/> specification.
- [X] I ensured the tests and linter pass
