### PR TITLE
refactor: rename const objects properties to camelCase

### DIFF
--- a/src/client/card-resolver.ts
+++ b/src/client/card-resolver.ts
@@ -41,5 +41,5 @@ export class DefaultAgentCardResolver implements AgentCardResolver {
 }
 
 export const AgentCardResolver = {
-  Default: new DefaultAgentCardResolver(),
+  default: new DefaultAgentCardResolver(),
 };

--- a/src/client/factory.ts
+++ b/src/client/factory.ts
@@ -30,7 +30,7 @@ export interface ClientFactoryOptions {
 }
 
 export const ClientFactoryOptions = {
-  Default: {
+  default: {
     transports: [new JsonRpcTransportFactory()],
   },
 };
@@ -39,7 +39,7 @@ export class ClientFactory {
   private readonly transportsByName = new Map<string, TransportFactory>();
   private readonly agentCardResolver: AgentCardResolver;
 
-  constructor(public readonly options: ClientFactoryOptions = ClientFactoryOptions.Default) {
+  constructor(public readonly options: ClientFactoryOptions = ClientFactoryOptions.default) {
     if (!options.transports || options.transports.length === 0) {
       throw new Error('No transports provided');
     }
@@ -57,7 +57,7 @@ export class ClientFactory {
         );
       }
     }
-    this.agentCardResolver = options.cardResolver ?? AgentCardResolver.Default;
+    this.agentCardResolver = options.cardResolver ?? AgentCardResolver.default;
   }
 
   /**

--- a/src/server/express/a2a_express_app.ts
+++ b/src/server/express/a2a_express_app.ts
@@ -12,7 +12,7 @@ export class A2AExpressApp {
 
   constructor(
     requestHandler: A2ARequestHandler,
-    userBuilder: UserBuilder = UserBuilder.NoAuthentication
+    userBuilder: UserBuilder = UserBuilder.noAuthentication
   ) {
     this.requestHandler = requestHandler;
     this.userBuilder = userBuilder;

--- a/src/server/express/common.ts
+++ b/src/server/express/common.ts
@@ -4,5 +4,5 @@ import { UnauthenticatedUser, User } from '../authentication/user.js';
 export type UserBuilder = (req: Request) => Promise<User>;
 
 export const UserBuilder = {
-  NoAuthentication: () => Promise.resolve(new UnauthenticatedUser()),
+  noAuthentication: () => Promise.resolve(new UnauthenticatedUser()),
 };

--- a/test/client/factory.spec.ts
+++ b/test/client/factory.spec.ts
@@ -41,7 +41,7 @@ describe('ClientFactory', () => {
   describe('constructor', () => {
     it('should initialize with default options', () => {
       const factory = new ClientFactory();
-      expect(factory.options).to.deep.equal(ClientFactoryOptions.Default);
+      expect(factory.options).to.deep.equal(ClientFactoryOptions.default);
     });
 
     it('should throw error if preferred transport is unknown', () => {

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -69,7 +69,7 @@ describe('Client E2E tests', () => {
 
     app.use(
       '/a2a/rpc',
-      jsonRpcHandler({ requestHandler: requestHandler, userBuilder: UserBuilder.NoAuthentication })
+      jsonRpcHandler({ requestHandler: requestHandler, userBuilder: UserBuilder.noAuthentication })
     );
 
     server = app.listen();


### PR DESCRIPTION
# Description

Those types were not released, so renaming to use JS/TS common style of camelCase.
