### PR TITLE
chore: properly configure license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@a2a-js/sdk",
   "version": "0.3.5",
   "description": "Server & Client SDK for Agent2Agent protocol",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/a2aproject/a2a-js.git"


### PR DESCRIPTION
# Description


Currently license is shown as `none` on npm: https://www.npmjs.com/package/@a2a-js/sdk.