### PR TITLE
refactor: remove the type Message from the possible return type of resubscribe API

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -26,6 +26,7 @@ import { JsonRpcTransport } from './transports/json_rpc_transport.js';
 import { RequestOptions } from './multitransport-client.js';
 
 export type A2AStreamEventData = Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent;
+export type A2AStreamEventDataResubscribe = Omit<A2AStreamEventData, 'Message'>;
 
 export type SendMessageResult = Message | Task;
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -308,7 +308,7 @@ export class A2AClient {
    */
   public async *resubscribeTask(
     params: TaskIdParams
-  ): AsyncGenerator<A2AStreamEventDataResubscribe, void, undefined> {
+  ): AsyncGenerator<A2AStreamEventData, void, undefined> {
     const agentCard = await this.agentCardPromise;
     if (!agentCard.capabilities?.streaming) {
       throw new Error('Agent does not support streaming (required for tasks/resubscribe).');

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -26,7 +26,7 @@ import { JsonRpcTransport } from './transports/json_rpc_transport.js';
 import { RequestOptions } from './multitransport-client.js';
 
 export type A2AStreamEventData = Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent;
-export type A2AStreamEventDataResubscribe = Omit<A2AStreamEventData, 'Message'>;
+export type A2AStreamEventDataResubscribe = Exclude<A2AStreamEventData, Message>;
 
 export type SendMessageResult = Message | Task;
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -308,7 +308,7 @@ export class A2AClient {
    */
   public async *resubscribeTask(
     params: TaskIdParams
-  ): AsyncGenerator<A2AStreamEventData, void, undefined> {
+  ): AsyncGenerator<A2AStreamEventDataResubscribe, void, undefined> {
     const agentCard = await this.agentCardPromise;
     if (!agentCard.capabilities?.streaming) {
       throw new Error('Agent does not support streaming (required for tasks/resubscribe).');

--- a/src/client/interceptors.ts
+++ b/src/client/interceptors.ts
@@ -1,5 +1,5 @@
 import { AgentCard } from '../types.js';
-import { A2AStreamEventData } from './client.js';
+import { A2AStreamEventData, A2AStreamEventDataResubscribe } from './client.js';
 import { Client } from './multitransport-client.js';
 import { RequestOptions } from './multitransport-client.js';
 
@@ -130,5 +130,5 @@ interface ResultsOverrides {
   // sendMessageStream and resubscribeTask return async iterators and are intercepted on each item,
   // which requires custom handling.
   sendMessageStream: A2AStreamEventData;
-  resubscribeTask: A2AStreamEventData;
+  resubscribeTask: A2AStreamEventDataResubscribe;
 }

--- a/src/client/multitransport-client.ts
+++ b/src/client/multitransport-client.ts
@@ -10,7 +10,7 @@ import {
   PushNotificationConfig,
   AgentCard,
 } from '../types.js';
-import { A2AStreamEventData, SendMessageResult } from './client.js';
+import { A2AStreamEventData, A2AStreamEventDataResubscribe, SendMessageResult } from './client.js';
 import { ClientCallContext } from './context.js';
 import {
   CallInterceptor,
@@ -261,7 +261,7 @@ export class Client {
   async *resubscribeTask(
     params: TaskIdParams,
     options?: RequestOptions
-  ): AsyncGenerator<A2AStreamEventData, void, undefined> {
+  ): AsyncGenerator<A2AStreamEventDataResubscribe, void, undefined> {
     const method = 'resubscribeTask';
 
     const beforeArgs: BeforeArgs<'resubscribeTask'> = {

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -261,11 +261,11 @@ export class JsonRpcTransport implements Transport {
     return this._fetch(this.endpoint, requestInit);
   }
 
-  private async *_sendStreamingRequest(
+  private async *_sendStreamingRequest<T>(
     method: string,
     params: unknown,
     options?: RequestOptions
-  ): AsyncGenerator<A2AStreamEventData, void, undefined> {
+  ): AsyncGenerator<T, void, undefined> {
     const clientRequestId = this.requestIdCounter++;
     const rpcRequest: JSONRPCRequest = {
       jsonrpc: '2.0',
@@ -303,7 +303,7 @@ export class JsonRpcTransport implements Transport {
       );
     }
 
-    yield* this._parseA2ASseStream<A2AStreamEventData>(response, clientRequestId);
+    yield* this._parseA2ASseStream<T>(response, clientRequestId);
   }
 
   private async *_parseA2ASseStream<TStreamItem>(

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -261,7 +261,7 @@ export class JsonRpcTransport implements Transport {
     return this._fetch(this.endpoint, requestInit);
   }
 
-  private async *_sendStreamingRequest<T>(
+  private async *_sendStreamingRequest<T extends A2AStreamEventData>(
     method: string,
     params: unknown,
     options?: RequestOptions

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -30,7 +30,7 @@ import {
   GetTaskPushNotificationConfigParams,
   GetAuthenticatedExtendedCardSuccessResponse,
 } from '../../types.js';
-import { A2AStreamEventData, SendMessageResult } from '../client.js';
+import { A2AStreamEventData, A2AStreamEventDataResubscribe, SendMessageResult } from '../client.js';
 import { RequestOptions } from '../multitransport-client.js';
 import { Transport, TransportFactory } from './transport.js';
 
@@ -156,7 +156,7 @@ export class JsonRpcTransport implements Transport {
   async *resubscribeTask(
     params: TaskIdParams,
     options?: RequestOptions
-  ): AsyncGenerator<A2AStreamEventData, void, undefined> {
+  ): AsyncGenerator<A2AStreamEventDataResubscribe, void, undefined> {
     yield* this._sendStreamingRequest('tasks/resubscribe', params, options);
   }
 

--- a/src/client/transports/transport.ts
+++ b/src/client/transports/transport.ts
@@ -9,7 +9,7 @@ import {
   AgentCard,
   GetTaskPushNotificationConfigParams,
 } from '../../types.js';
-import { A2AStreamEventData, SendMessageResult } from '../client.js';
+import { A2AStreamEventData, A2AStreamEventDataResubscribe, SendMessageResult } from '../client.js';
 import { RequestOptions } from '../multitransport-client.js';
 
 export interface Transport {
@@ -49,7 +49,7 @@ export interface Transport {
   resubscribeTask(
     params: TaskIdParams,
     options?: RequestOptions
-  ): AsyncGenerator<A2AStreamEventData, void, undefined>;
+  ): AsyncGenerator<A2AStreamEventDataResubscribe, void, undefined>;
 }
 
 export interface TransportFactory {

--- a/test/client/multitransport-client.spec.ts
+++ b/test/client/multitransport-client.spec.ts
@@ -16,7 +16,7 @@ import {
   AgentCard,
   GetTaskPushNotificationConfigParams,
 } from '../../src/types.js';
-import { A2AStreamEventData } from '../../src/client/client.js';
+import { A2AStreamEventData, A2AStreamEventDataResubscribe } from '../../src/client/client.js';
 import { ClientCallResult } from '../../src/client/interceptors.js';
 
 describe('Client', () => {
@@ -747,7 +747,7 @@ describe('Client', () => {
         name: 'resubscribeTask',
         transportStubGetter: (t: sinon.SinonStubbedInstance<Transport>): sinon.SinonStub =>
           t.resubscribeTask,
-        caller: (c: Client): AsyncGenerator<A2AStreamEventData> => c.resubscribeTask({ id: '123' }),
+        caller: (c: Client): AsyncGenerator<A2AStreamEventDataResubscribe> => c.resubscribeTask({ id: '123' }),
       },
     ];
 

--- a/test/client/multitransport-client.spec.ts
+++ b/test/client/multitransport-client.spec.ts
@@ -747,7 +747,8 @@ describe('Client', () => {
         name: 'resubscribeTask',
         transportStubGetter: (t: sinon.SinonStubbedInstance<Transport>): sinon.SinonStub =>
           t.resubscribeTask,
-        caller: (c: Client): AsyncGenerator<A2AStreamEventDataResubscribe> => c.resubscribeTask({ id: '123' }),
+        caller: (c: Client): AsyncGenerator<A2AStreamEventDataResubscribe> =>
+          c.resubscribeTask({ id: '123' }),
       },
     ];
 


### PR DESCRIPTION
# Description

ResubscribeTask should not support the type Message as a Response.

