### PR TITLE
refactor: allow undefined as value passed to after interceptor

### DIFF
--- a/src/client/interceptors.ts
+++ b/src/client/interceptors.ts
@@ -119,10 +119,10 @@ type MethodInput<T, TMembers extends keyof T = keyof T> = {
  */
 type MethodResult<T, TMembers extends keyof T = keyof T, TOverrides = object> = {
   [M in TMembers]: M extends keyof TOverrides // If there is an override, use it directly.
-    ? { readonly method: M; value: TOverrides[M] }
+    ? { readonly method: M; value: TOverrides[M] | undefined }
     : // Infer result, unwrap it from Promise and pack with method name.
       T[M] extends (payload: unknown) => infer R
-      ? { readonly method: M; value: Awaited<R> }
+      ? { readonly method: M; value: Awaited<R> | undefined }
       : never;
 }[TMembers];
 


### PR DESCRIPTION
# Description

Having this allows adding error handling in the future without breaking changes: new `error` field can be added in which case `value` won't be set. 
