### PR TITLE
ci: fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*   @google-a2a/googlers
+*   @a2aproject/google-a2a-js


### PR DESCRIPTION
# Description

Update CODEOWNERS to automatically assign maintainers for reviews.

[Current version](https://github.com/a2aproject/a2a-js/blob/a206d13c512e0239406e2c96a8746935b63437aa/.github/CODEOWNERS) shows the following error:

```
Unknown owner on line 7: make sure the team @google-a2a/googlers exists, is publicly visible, and has write access to the repository
*   @google-a2a/googlers
```
