### PR TITLE
docs: remove Google references from contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,27 +2,6 @@
 
 We'd love to accept your patches and contributions to this project.
 
-## Before you begin
-
-### Sign our Contributor License Agreement
-
-Contributions to this project must be accompanied by a
-[Contributor License Agreement](https://cla.developers.google.com/about) (CLA).
-You (or your employer) retain the copyright to your contribution; this simply
-gives us permission to use and redistribute your contributions as part of the
-project.
-
-If you or your current employer have already signed the Google CLA (even if it
-was for a different project), you probably don't need to do it again.
-
-Visit <https://cla.developers.google.com/> to see your current agreements or to
-sign a new one.
-
-### Review our community guidelines
-
-This project follows
-[Google's Open Source Community Guidelines](https://opensource.google/conduct/).
-
 ## Contribution process
 
 ### Code reviews
@@ -47,11 +26,3 @@ Here are some additional things to keep in mind during the process:
 
 - **Test your changes.** Before you submit a pull request, make sure that your changes work as expected.
 - **Be patient.** It may take some time for your pull request to be reviewed and merged.
-
----
-
-## For Google Employees
-
-Complete the following steps to register your GitHub account and be added as a contributor to this repository.
-
-1. Register your GitHub account at [go/GitHub](http://go/github)


### PR DESCRIPTION
# Description

Align `CONTRIBUTING.md` with other official SDKs and remove Google internal leftovers. 