### PR TITLE
ci: run tests against maintained Node LTS versions

### DIFF
--- a/.github/workflows/run-tck.yaml
+++ b/.github/workflows/run-tck.yaml
@@ -29,13 +29,16 @@ concurrency:
 jobs:
   tck-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20, 22, 24]
     steps:
       - name: Checkout a2a-js
         uses: actions/checkout@v4
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
       - run: |
           npm ci

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,11 +14,15 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [18, 20, 22, 24]
+
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: ${{ matrix.node-version }}
         registry-url: 'https://registry.npmjs.org'
         cache: 'npm'
     - run: npm ci


### PR DESCRIPTION
# Description

Add current LTS versions: 20, 22, 24 keeping 18 as it's declared in `package.json`. Scheduled dropping 18 version for major release (#179).

Fixes #165
