### PR TITLE
ci: add json-summary coverage reporter

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     include: ['test/**/*.spec.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'json', 'html', 'json-summary'],
     },
   },
 });


### PR DESCRIPTION
# Description

This is going to be used to generate a simple coverage delta without third-party actions. Example output produced by this runner:

```json
{
  "total": {
    "lines": {
      "total": 1356,
      "covered": 1105,
      "skipped": 0,
      "pct": 81.48
    },
    "statements": {
      "total": 1371,
      "covered": 1114,
      "skipped": 0,
      "pct": 81.25
    },
    "functions": {
      "total": 281,
      "covered": 245,
      "skipped": 0,
      "pct": 87.18
    },
    "branches": {
      "total": 863,
      "covered": 604,
      "skipped": 0,
      "pct": 69.98
    },
    "branchesTrue": {
      "total": 0,
      "covered": 0,
      "skipped": 0,
      "pct": 100
    }
  },
. . .
```

Re #192
