### PR TITLE
ci: set timeout for tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [18, 20, 22, 24]
@@ -30,6 +31,7 @@ jobs:
   # works correctly in non-Node.js server environments.
   test-edge:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
@@ -57,6 +59,7 @@ jobs:
         ref: main
 
     - name: Install & Test (Main)
+      timeout-minutes: 10
       run: |
         npm ci
         npm run coverage
@@ -68,6 +71,7 @@ jobs:
         clean: true
 
     - name: Install & Test (PR)
+      timeout-minutes: 10
       run: |
         npm ci
         npm run coverage


### PR DESCRIPTION
# Description

There are some instances of tests hanging for 6h (the default timeout), while it's being investigated, set lower timeout.

Re #265.
