### PR TITLE
fix: pass ServerCallContext to getAuthenticatedExtendedAgentCard for REST

### DIFF
--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -268,7 +268,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
     '/v1/card',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
-      const result = await restTransportHandler.getAuthenticatedExtendedAgentCard();
+      const result = await restTransportHandler.getAuthenticatedExtendedAgentCard(context);
       sendResponse(res, HTTP_STATUS.OK, context, result);
     })
   );

--- a/src/server/transports/rest/rest_transport_handler.ts
+++ b/src/server/transports/rest/rest_transport_handler.ts
@@ -146,8 +146,8 @@ export class RestTransportHandler {
   /**
    * Gets the authenticated extended agent card.
    */
-  async getAuthenticatedExtendedAgentCard(): Promise<AgentCard> {
-    return this.requestHandler.getAuthenticatedExtendedAgentCard();
+  async getAuthenticatedExtendedAgentCard(context: ServerCallContext): Promise<AgentCard> {
+    return this.requestHandler.getAuthenticatedExtendedAgentCard(context);
   }
 
   /**


### PR DESCRIPTION
# Description

Follow-up for #142: authenticated agent card logic relies on context to determine authentication status.

`src/server/transports/rest/rest_transport_handler.ts` is not exported, so adding a required parameter is fine.

Re #137