### PR TITLE
ci: run TCK capabilities tests for REST

### DIFF
--- a/.github/workflows/run-tck.yaml
+++ b/.github/workflows/run-tck.yaml
@@ -13,9 +13,7 @@ on:
 
 
 env:
-  # TODO once we have the TCK for 0.4.0 we will need to look at the branch to decide which TCK version to run.
   # Tag of the TCK
-  # Temporary set to this commit sha because of this issue https://github.com/a2aproject/a2a-js/pull/142#issuecomment-3558892334 
   TCK_VERSION: 0.3.0.beta3
   # Tells uv to not need a venv, and instead use system
   UV_SYSTEM_PYTHON: 1
@@ -107,7 +105,6 @@ jobs:
         run: |
           ./run_tck.py --sut-url ${{ env.SUT_JSONRPC_URL }} --category mandatory --transports jsonrpc,rest
         working-directory: tck/a2a-tck
-        # TODO: Add back the transports jsonrpc,rest once the TCK supports REST, linked to https://github.com/a2aproject/a2a-tck/issues/99
       - name: Run TCK (capabilities)
         id: run-tck-capabilities
         timeout-minutes: 5


### PR DESCRIPTION
# Description

Bring back TCK capabilities tests for REST and use [0.3.0.beta3](https://github.com/a2aproject/a2a-tck/releases/tag/0.3.0.beta3) tag, both work now after #292.
