### PR TITLE
fix: preserve typed error as cause in SSE errors

### DIFF
--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -329,7 +329,8 @@ export class JsonRpcTransport implements Transport {
       if ('error' in a2aStreamResponse) {
         const err = a2aStreamResponse.error;
         throw new Error(
-          `SSE event contained an error: ${err.message} (Code: ${err.code}) Data: ${JSON.stringify(err.data || {})}`
+          `SSE event contained an error: ${err.message} (Code: ${err.code}) Data: ${JSON.stringify(err.data || {})}`,
+          { cause: JsonRpcTransport.mapToError(a2aStreamResponse) }
         );
       }
 


### PR DESCRIPTION
## What

Wrap the typed error from `mapToError()` as the `cause` when throwing SSE stream errors.

## Why

When an SSE stream contains a JSON-RPC error, we throw an Error with a formatted message string. The structured error data (code, message, data) is serialized into that string and lost. Consumers who need the structured data have to parse it back out with regex.

## Implementation details

Use the standard JS error `cause` option to preserve the typed error:

```typescript
throw new Error(
  `SSE event contained an error: ${err.message} (Code: ${err.code}) Data: ${JSON.stringify(err.data || {})}`,
  { cause: JsonRpcTransport.mapToError(a2aStreamResponse as JSONRPCErrorResponse) }
);
```

Backward compatible - the message string is unchanged. Consumers can access structured data via:

```typescript
const cause = error.cause as JSONRPCTransportError;
const { code, message, data } = cause.errorResponse.error;
```