### PR TITLE
feat: expose HTTP status code and headers on SDK error classes

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -45,3 +45,4 @@ export {
   TaskNotFoundError,
   UnsupportedOperationError,
 } from '../errors.js';
+export type { A2AErrorHttpDetails } from '../errors.js';

--- a/src/client/transports/rest_transport.ts
+++ b/src/client/transports/rest_transport.ts
@@ -340,11 +340,10 @@ export class RestTransport implements Transport {
   }
 
   private static extractHttpDetails(response: Response): A2AErrorHttpDetails {
-    const headers: Record<string, string> = {};
-    response.headers.forEach((value, key) => {
-      headers[key] = value;
-    });
-    return { statusCode: response.status, headers };
+    return {
+      statusCode: response.status,
+      headers: Object.fromEntries(response.headers),
+    };
   }
 
   private static mapToError(error: RestErrorResponse, httpDetails?: A2AErrorHttpDetails): Error {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,56 +14,116 @@ export const A2A_ERROR_CODE = {
   AUTHENTICATED_EXTENDED_CARD_NOT_CONFIGURED: -32007,
 } as const;
 
+/**
+ * Optional HTTP transport details that can be attached to any A2A error
+ * originating from an HTTP response.
+ */
+export interface A2AErrorHttpDetails {
+  /** The HTTP status code from the response (e.g. 401, 404, 429, 503). */
+  statusCode?: number;
+  /** Selected HTTP response headers, if available. */
+  headers?: Record<string, string>;
+}
+
 // Transport-agnostic errors according to https://a2a-protocol.org/v0.3.0/specification/#82-a2a-specific-errors.
 // Due to a name conflict with legacy JSON-RPC types reexported from src/index.ts
 // below errors are going to be exported via src/client/index.ts to allow usage
 // from external transport implementations.
 
 export class TaskNotFoundError extends Error {
-  constructor(message?: string) {
+  /** The HTTP status code from the response, if the error originated from an HTTP transport. */
+  statusCode?: number;
+  /** Selected HTTP response headers, if the error originated from an HTTP transport. */
+  headers?: Record<string, string>;
+
+  constructor(message?: string, httpDetails?: A2AErrorHttpDetails) {
     super(message ?? 'Task not found');
     this.name = 'TaskNotFoundError';
+    this.statusCode = httpDetails?.statusCode;
+    this.headers = httpDetails?.headers;
   }
 }
 
 export class TaskNotCancelableError extends Error {
-  constructor(message?: string) {
+  /** The HTTP status code from the response, if the error originated from an HTTP transport. */
+  statusCode?: number;
+  /** Selected HTTP response headers, if the error originated from an HTTP transport. */
+  headers?: Record<string, string>;
+
+  constructor(message?: string, httpDetails?: A2AErrorHttpDetails) {
     super(message ?? 'Task cannot be canceled');
     this.name = 'TaskNotCancelableError';
+    this.statusCode = httpDetails?.statusCode;
+    this.headers = httpDetails?.headers;
   }
 }
 
 export class PushNotificationNotSupportedError extends Error {
-  constructor(message?: string) {
+  /** The HTTP status code from the response, if the error originated from an HTTP transport. */
+  statusCode?: number;
+  /** Selected HTTP response headers, if the error originated from an HTTP transport. */
+  headers?: Record<string, string>;
+
+  constructor(message?: string, httpDetails?: A2AErrorHttpDetails) {
     super(message ?? 'Push Notification is not supported');
     this.name = 'PushNotificationNotSupportedError';
+    this.statusCode = httpDetails?.statusCode;
+    this.headers = httpDetails?.headers;
   }
 }
 
 export class UnsupportedOperationError extends Error {
-  constructor(message?: string) {
+  /** The HTTP status code from the response, if the error originated from an HTTP transport. */
+  statusCode?: number;
+  /** Selected HTTP response headers, if the error originated from an HTTP transport. */
+  headers?: Record<string, string>;
+
+  constructor(message?: string, httpDetails?: A2AErrorHttpDetails) {
     super(message ?? 'This operation is not supported');
     this.name = 'UnsupportedOperationError';
+    this.statusCode = httpDetails?.statusCode;
+    this.headers = httpDetails?.headers;
   }
 }
 
 export class ContentTypeNotSupportedError extends Error {
-  constructor(message?: string) {
+  /** The HTTP status code from the response, if the error originated from an HTTP transport. */
+  statusCode?: number;
+  /** Selected HTTP response headers, if the error originated from an HTTP transport. */
+  headers?: Record<string, string>;
+
+  constructor(message?: string, httpDetails?: A2AErrorHttpDetails) {
     super(message ?? 'Incompatible content types');
     this.name = 'ContentTypeNotSupportedError';
+    this.statusCode = httpDetails?.statusCode;
+    this.headers = httpDetails?.headers;
   }
 }
 
 export class InvalidAgentResponseError extends Error {
-  constructor(message?: string) {
+  /** The HTTP status code from the response, if the error originated from an HTTP transport. */
+  statusCode?: number;
+  /** Selected HTTP response headers, if the error originated from an HTTP transport. */
+  headers?: Record<string, string>;
+
+  constructor(message?: string, httpDetails?: A2AErrorHttpDetails) {
     super(message ?? 'Invalid agent response type');
     this.name = 'InvalidAgentResponseError';
+    this.statusCode = httpDetails?.statusCode;
+    this.headers = httpDetails?.headers;
   }
 }
 
 export class AuthenticatedExtendedCardNotConfiguredError extends Error {
-  constructor(message?: string) {
+  /** The HTTP status code from the response, if the error originated from an HTTP transport. */
+  statusCode?: number;
+  /** Selected HTTP response headers, if the error originated from an HTTP transport. */
+  headers?: Record<string, string>;
+
+  constructor(message?: string, httpDetails?: A2AErrorHttpDetails) {
     super(message ?? 'Authenticated Extended Card not configured');
     this.name = 'AuthenticatedExtendedCardNotConfiguredError';
+    this.statusCode = httpDetails?.statusCode;
+    this.headers = httpDetails?.headers;
   }
 }

--- a/test/client/transports/rest_transport.spec.ts
+++ b/test/client/transports/rest_transport.spec.ts
@@ -389,9 +389,7 @@ describe('RestTransport', () => {
     });
 
     it('should include HTTP statusCode on TaskNotCancelableError', async () => {
-      mockFetch.mockResolvedValue(
-        createRestErrorResponse(-32002, 'Task cannot be canceled', 409)
-      );
+      mockFetch.mockResolvedValue(createRestErrorResponse(-32002, 'Task cannot be canceled', 409));
 
       try {
         await transport.cancelTask({ id: 'task-123' });


### PR DESCRIPTION
## Summary
- Adds optional `statusCode` and `headers` properties to all A2A SDK error classes (`TaskNotFoundError`, `TaskNotCancelableError`, `PushNotificationNotSupportedError`, `UnsupportedOperationError`, `ContentTypeNotSupportedError`, `InvalidAgentResponseError`, `AuthenticatedExtendedCardNotConfiguredError`) so that consumers can implement HTTP-aware error handling.
- Updates the REST transport (`RestTransport`) to extract HTTP status code and response headers from the `Response` object and pass them through when constructing error instances via `mapToError`.
- Exports the new `A2AErrorHttpDetails` interface from the client entry point for use by consumers.
- Adds comprehensive tests covering all error types, verifying that `statusCode` and `headers` are correctly populated on errors thrown by the REST transport.

Closes #317

## Test plan
- [x] All 414 existing tests pass (no regressions)
- [x] New tests verify `statusCode` is set on `TaskNotFoundError` (404), `TaskNotCancelableError` (409), `PushNotificationNotSupportedError` (400), `UnsupportedOperationError` (405), `ContentTypeNotSupportedError` (415), `InvalidAgentResponseError` (502), and `AuthenticatedExtendedCardNotConfiguredError` (401)
- [x] New test verifies that response headers (e.g. `Retry-After`, `X-RateLimit-Remaining`) are available on errors for rate-limiting / backoff strategies
- [x] Backward compatibility verified: constructor changes are additive (second parameter is optional), so existing code including JSON-RPC error subclasses continues to work without modification
- [x] TypeScript lint passes with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)