### PR TITLE
ci: fix lint.yml syntax

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,4 +26,4 @@ jobs:
           package-lock.json
           src/samples/package-lock.json
     - run: npm ci && (cd src/samples && npm ci)
-  - run: npm run lint:ci
+    - run: npm run lint:ci


### PR DESCRIPTION
Was broken in #329 accidentially.

<img width="1738" height="1916" alt="image" src="https://github.com/user-attachments/assets/a1db333d-37a3-4a9c-b1e4-9f98754477b9" />


i.e. https://github.com/a2aproject/a2a-js/actions/runs/21979649269
