### PR TITLE
feat: add state bag and ServerCallContextBuilder to ServerCallContext

### DIFF
--- a/src/samples/authentication/server_call_context.ts
+++ b/src/samples/authentication/server_call_context.ts
@@ -1,0 +1,192 @@
+/**
+ * Sample: ServerCallContext state headers
+ *
+ * Demonstrates two patterns for reading request headers inside an AgentExecutor:
+ *
+ * 1. AUTOMATIC (default builder) - `defaultServerCallContextBuilder` stores all
+ *    request headers in `context.state` under `STATE_HEADERS_KEY` with no extra
+ *    configuration needed.
+ *
+ * 2. CUSTOM BUILDER - supply a `contextBuilder` to `jsonRpcHandler` to extract
+ *    specific headers and store them in `state` under your own keys, so the
+ *    AgentExecutor receives clean, typed values without coupling to raw headers.
+ *
+ * Run:
+ *   cd src/samples && npx tsx authentication/server_call_context.ts
+ *
+ * Then send a request with a custom header:
+ *   curl -X POST http://localhost:41242 \
+ *     -H "Content-Type: application/json" \
+ *     -H "x-tenant-id: acme-corp" \
+ *     -d '{"jsonrpc":"2.0","id":"1","method":"SendMessage","params":{"message":{"messageId":"m1","role":"user","parts":[{"kind":"text","text":"hello"}]}}}'
+ */
+
+import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
+import { AgentCard } from '../../index.js';
+import { Role } from '../../index.js';
+import {
+  AgentEvent,
+  AgentExecutor,
+  DefaultRequestHandler,
+  ExecutionEventBus,
+  InMemoryTaskStore,
+  RequestContext,
+  ServerCallContext,
+  ServerCallContextBuilder,
+  STATE_HEADERS_KEY,
+  RequestHeaders,
+  UnauthenticatedUser,
+} from '../../server/index.js';
+import { jsonRpcHandler } from '../../server/express/index.js';
+import { Message } from '../../index.js';
+
+// --- Custom state keys ---
+
+const STATE_TENANT_ID_KEY = 'tenantId';
+const STATE_REQUEST_ID_KEY = 'requestId';
+
+// --- Custom context builder ---
+
+/**
+ * Reads well-known headers and stores them as clean typed values in state,
+ * alongside the full raw headers stored automatically under STATE_HEADERS_KEY.
+ */
+const tenantContextBuilder: ServerCallContextBuilder = ({
+  extensions,
+  user,
+  headers,
+  requestedVersion,
+  tenant,
+}): ServerCallContext => {
+  const state = new Map<string, unknown>([
+    // Always include raw headers (mirrors defaultServerCallContextBuilder)
+    [STATE_HEADERS_KEY, headers],
+    // Extract specific headers into typed state entries
+    [STATE_TENANT_ID_KEY, headers['x-tenant-id'] ?? tenant ?? 'unknown'],
+    [STATE_REQUEST_ID_KEY, headers['x-request-id'] ?? uuidv4()],
+  ]);
+  return new ServerCallContext({
+    requestedExtensions: extensions,
+    user,
+    state,
+    requestedVersion,
+    tenant,
+  });
+};
+
+// --- AgentExecutor ---
+
+class StateHeadersAgentExecutor implements AgentExecutor {
+  public cancelTask = async (): Promise<void> => {};
+
+  async execute(requestContext: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
+    const state = requestContext.context?.state;
+
+    // Pattern 1: read a typed value stored by the custom builder
+    const tenantId = state?.get(STATE_TENANT_ID_KEY) as string | undefined;
+    const requestId = state?.get(STATE_REQUEST_ID_KEY) as string | undefined;
+
+    // Pattern 2: read a specific header directly from the raw headers map
+    const rawHeaders = state?.get(STATE_HEADERS_KEY) as RequestHeaders | undefined;
+    const userAgent = rawHeaders?.['user-agent'];
+
+    const lines = [
+      `Tenant ID  : ${tenantId ?? '(not set)'}`,
+      `Request ID : ${requestId ?? '(not set)'}`,
+      `User-Agent : ${userAgent ?? '(not set)'}`,
+    ];
+
+    const finalMessage: Message = {
+      messageId: uuidv4(),
+      contextId: '',
+      taskId: '',
+      role: Role.ROLE_AGENT,
+      parts: [
+        {
+          content: { $case: 'text', value: lines.join('\n') },
+          metadata: undefined,
+          filename: '',
+          mediaType: '',
+        },
+      ],
+      metadata: undefined,
+      extensions: [],
+      referenceTaskIds: [],
+    };
+
+    eventBus.publish(AgentEvent.message(finalMessage));
+  }
+}
+
+// --- Server setup ---
+
+const agentCard: AgentCard = {
+  name: 'ServerCallContext State Headers Sample',
+  description: 'Demonstrates reading request headers from ServerCallContext.state',
+  supportedInterfaces: [
+    {
+      url: 'http://localhost:41242/',
+      protocolBinding: 'JSONRPC',
+      tenant: '',
+      protocolVersion: '0.3',
+    },
+  ],
+  provider: { organization: 'A2A Samples', url: 'https://example.com' },
+  version: '1.0.0',
+  documentationUrl: '',
+  capabilities: { streaming: false, pushNotifications: false, extensions: [] },
+  securitySchemes: {},
+  securityRequirements: [],
+  defaultInputModes: ['text'],
+  defaultOutputModes: ['text'],
+  signatures: [],
+  skills: [
+    {
+      id: 'echo_headers',
+      name: 'Echo Headers',
+      description: 'Echoes x-tenant-id, x-request-id and User-Agent from request headers.',
+      tags: ['sample'],
+      examples: ['hello'],
+      inputModes: ['text'],
+      outputModes: ['text'],
+      securityRequirements: [],
+    },
+  ],
+};
+
+async function main() {
+  const requestHandler = new DefaultRequestHandler(
+    agentCard,
+    new InMemoryTaskStore(),
+    new StateHeadersAgentExecutor()
+  );
+
+  const app = express();
+  app.use(express.json());
+  app.use(
+    jsonRpcHandler({
+      requestHandler,
+      userBuilder: async () => new UnauthenticatedUser(),
+      // Swap contextBuilder to see the difference between custom and default:
+      //   custom  → tenantId and requestId are extracted into typed state entries
+      //   default → only raw headers are stored under STATE_HEADERS_KEY
+      contextBuilder: tenantContextBuilder,
+    })
+  );
+
+  const PORT = 41242;
+  app.listen(PORT, () => {
+    console.log(`[StateHeadersSample] Listening on http://localhost:${PORT}`);
+    console.log(`[StateHeadersSample] Try:`);
+    console.log(
+      `  curl -X POST http://localhost:${PORT}` +
+        ` -H "Content-Type: application/json"` +
+        ` -H "x-tenant-id: acme-corp"` +
+        ` -H "x-request-id: req-123"` +
+        ` -d '{"jsonrpc":"2.0","id":"1","method":"SendMessage","params":{"message":{"messageId":"m1","role":"user","parts":[{"kind":"text","text":"hello"}]}}}'`
+    );
+  });
+}
+
+main().catch(console.error);

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -5,17 +5,86 @@ import { User } from './authentication/user.js';
 // header as a v0.3 request.
 const ABSENT_HEADER_VERSION = '0.3';
 
+/**
+ * Transport-agnostic representation of request headers.
+ * Express passes `req.headers`; gRPC passes metadata converted to this shape.
+ */
+export type RequestHeaders = Record<string, string | string[] | undefined>;
+
+/**
+ * Options passed to a {@link ServerCallContextBuilder}.
+ */
+export interface ServerCallContextBuilderOptions {
+  /** Protocol extensions parsed from the request headers. */
+  extensions: Extensions | undefined;
+  /** Authenticated user extracted from the request. */
+  user: User | undefined;
+  /** Raw request headers (transport-agnostic). */
+  headers: RequestHeaders;
+  /** A2A protocol version from the A2A-Version header. Absent means '0.3'. */
+  requestedVersion?: string;
+  /** Tenant identifier extracted from the request path or metadata. */
+  tenant?: string;
+}
+
+/**
+ * Factory function type for creating {@link ServerCallContext} instances.
+ *
+ * Provide a custom implementation to inject additional state or produce a
+ * subclass of `ServerCallContext` (e.g. to mirror the Python A2A SDK's
+ * `state` pattern used by operator SDKs).
+ *
+ * @param options - All data available at request time.
+ * @returns A `ServerCallContext` (or subclass) for the current call.
+ */
+export type ServerCallContextBuilder = (
+  options: ServerCallContextBuilderOptions
+) => ServerCallContext;
+
+/**
+ * Key under which request headers are stored in {@link ServerCallContext.state}
+ * by the default builder. Mirrors Python SDK's `state['headers']`.
+ */
+export const STATE_HEADERS_KEY = 'headers';
+
 export interface ServerCallContextOptions {
   requestedExtensions?: Extensions;
   user?: User;
   tenant?: string;
-
   /**
    * The A2A protocol version requested by the client via the A2A-Version
    * service parameter. Defaults to `'0.3'` when the header is absent.
    */
   requestedVersion?: string;
+  /**
+   * Arbitrary key/value state bag for carrying custom data
+   * (e.g. request headers, tenant IDs) through the call pipeline.
+   */
+  state?: Map<string, unknown>;
 }
+
+/**
+ * The default {@link ServerCallContextBuilder}. Creates a `ServerCallContext`
+ * with the raw request headers pre-populated in {@link ServerCallContext.state}
+ * under the {@link STATE_HEADERS_KEY} key, mirroring the Python SDK's
+ * `DefaultCallContextBuilder`.
+ */
+export const defaultServerCallContextBuilder: ServerCallContextBuilder = ({
+  extensions,
+  user,
+  headers,
+  requestedVersion,
+  tenant,
+}: ServerCallContextBuilderOptions): ServerCallContext => {
+  const state = new Map<string, unknown>([[STATE_HEADERS_KEY, headers]]);
+  return new ServerCallContext({
+    requestedExtensions: extensions,
+    user,
+    state,
+    requestedVersion,
+    tenant,
+  });
+};
 
 export class ServerCallContext {
   private _requestedExtensions?: Extensions;
@@ -23,12 +92,14 @@ export class ServerCallContext {
   private readonly _requestedVersion: string;
   private readonly _tenant?: string;
   private _activatedExtensions?: Extensions;
+  private readonly _state: Map<string, unknown>;
 
   constructor(options?: ServerCallContextOptions) {
     this._requestedExtensions = options?.requestedExtensions;
     this._user = options?.user;
     this._tenant = options?.tenant;
     this._requestedVersion = options?.requestedVersion || ABSENT_HEADER_VERSION;
+    this._state = options?.state ?? new Map();
   }
 
   get tenant(): string | undefined {
@@ -49,6 +120,15 @@ export class ServerCallContext {
 
   get requestedVersion(): string {
     return this._requestedVersion;
+  }
+
+  /**
+   * Arbitrary key/value state bag, equivalent to the `state` field on the
+   * Python A2A SDK's `ServerCallContext`. Use this to carry custom data
+   * (e.g. request headers, tenant IDs) through the call pipeline.
+   */
+  get state(): Map<string, unknown> {
+    return this._state;
   }
 
   public addActivatedExtension(uri: string) {

--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -9,7 +9,7 @@ import { JSONRPCErrorResponse } from '../../core.js';
 import { JSONRPCResponse } from '../transports/jsonrpc/jsonrpc_transport_handler.js';
 import { A2ARequestHandler } from '../request_handler/a2a_request_handler.js';
 import { JsonRpcTransportHandler } from '../transports/jsonrpc/jsonrpc_transport_handler.js';
-import { ServerCallContext } from '../context.js';
+import { ServerCallContextBuilder, defaultServerCallContextBuilder } from '../context.js';
 import { A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER, JSON_CONTENT_TYPE } from '../../constants.js';
 import { UserBuilder, delegateAsyncIterator } from './common.js';
 import { SSE_HEADERS, formatSSEEvent, formatSSEErrorEvent } from '../../sse_utils.js';
@@ -38,6 +38,7 @@ export interface JsonRpcHandlerOptions {
    * as JSON-RPC `method not found` (-32601).
    */
   legacyCompat?: { enabled: boolean };
+  contextBuilder?: ServerCallContextBuilder;
 }
 
 /**
@@ -101,9 +102,11 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
       const requestedExtensionsHeader = useLegacy
         ? (req.header(LEGACY_HTTP_EXTENSION_HEADER) ?? req.header(HTTP_EXTENSION_HEADER))
         : req.header(HTTP_EXTENSION_HEADER);
-      const context = new ServerCallContext({
-        requestedExtensions: Extensions.parseServiceParameter(requestedExtensionsHeader),
+      const ctxBuilder = options.contextBuilder ?? defaultServerCallContextBuilder;
+      const context = ctxBuilder({
+        extensions: Extensions.parseServiceParameter(requestedExtensionsHeader),
         user,
+        headers: req.headers,
         requestedVersion,
       });
       const agentCard = await options.requestHandler.getAgentCard();

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -13,7 +13,11 @@ import {
   mapErrorToStatus,
   toHTTPError,
 } from '../transports/rest/rest_transport_handler.js';
-import { ServerCallContext } from '../context.js';
+import {
+  ServerCallContext,
+  ServerCallContextBuilder,
+  defaultServerCallContextBuilder,
+} from '../context.js';
 import {
   JSON_CONTENT_TYPE,
   A2A_CONTENT_TYPE,
@@ -53,6 +57,7 @@ export interface RestHandlerOptions {
    * Default: omitted (disabled).
    */
   legacyCompat?: { enabled: boolean };
+  contextBuilder?: ServerCallContextBuilder;
 }
 
 /** Catches JSON parse errors from `express.json()` and maps them to A2A. */
@@ -140,10 +145,11 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
     const user = await options.userBuilder(req);
     const tenant = (req.params.tenant as string) || undefined;
     const requestedVersion = req.header(A2A_VERSION_HEADER) || undefined;
-
-    const context = new ServerCallContext({
-      requestedExtensions: Extensions.parseServiceParameter(req.header(HTTP_EXTENSION_HEADER)),
+    const ctxBuilder = options.contextBuilder ?? defaultServerCallContextBuilder;
+    const context = ctxBuilder({
+      extensions: Extensions.parseServiceParameter(req.header(HTTP_EXTENSION_HEADER)),
       user,
+      headers: req.headers,
       requestedVersion,
       tenant,
     });
@@ -422,7 +428,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   registerRoute('get', '/tasks/:taskId', async (req, res) => {
     const context = await buildContext(req);
     const result = await restTransportHandler.getTask(
-      req.params.taskId,
+      req.params.taskId as string,
       context,
       req.query.historyLength,
       (req.query.tenant as string) || ''
@@ -480,7 +486,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   registerRoute('get', '/tasks/:taskId/pushNotificationConfigs', async (req, res) => {
     const context = await buildContext(req);
     const result = await restTransportHandler.listTaskPushNotificationConfigs(
-      req.params.taskId,
+      req.params.taskId as string,
       context,
       (req.query.tenant as string) || ''
     );
@@ -506,8 +512,8 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   registerRoute('get', '/tasks/:taskId/pushNotificationConfigs/:configId', async (req, res) => {
     const context = await buildContext(req);
     const result = await restTransportHandler.getTaskPushNotificationConfig(
-      req.params.taskId,
-      req.params.configId,
+      req.params.taskId as string,
+      req.params.configId as string,
       context,
       (req.query.tenant as string) || ''
     );
@@ -533,8 +539,8 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   registerRoute('delete', '/tasks/:taskId/pushNotificationConfigs/:configId', async (req, res) => {
     const context = await buildContext(req);
     await restTransportHandler.deleteTaskPushNotificationConfig(
-      req.params.taskId,
-      req.params.configId,
+      req.params.taskId as string,
+      req.params.configId as string,
       context,
       (req.query.tenant as string) || ''
     );

--- a/src/server/grpc/grpc_service.ts
+++ b/src/server/grpc/grpc_service.ts
@@ -21,7 +21,11 @@ import {
 import { Empty } from '../../grpc/pb/google/protobuf/empty.js';
 import { A2ARequestHandler } from '../request_handler/a2a_request_handler.js';
 import { ToProto } from '../../types/converters/to_proto.js';
-import { ServerCallContext } from '../context.js';
+import {
+  ServerCallContext,
+  ServerCallContextBuilder,
+  defaultServerCallContextBuilder,
+} from '../context.js';
 import { Extensions } from '../../extensions.js';
 import { buildGrpcErrorMetadata } from './error_details.js';
 import { UserBuilder } from './common.js';
@@ -45,6 +49,7 @@ import { validateVersion } from '../version.js';
 export interface GrpcServiceOptions {
   requestHandler: A2ARequestHandler;
   userBuilder: UserBuilder;
+  contextBuilder?: ServerCallContextBuilder;
 }
 
 /**
@@ -69,7 +74,12 @@ export function grpcService(options: GrpcServiceOptions): A2AServiceServer {
     converter: (res: TResult) => TRes
   ) => {
     try {
-      const context = await _buildContext(call, options.userBuilder, requestHandler);
+      const context = await _buildContext(
+        call,
+        options.userBuilder,
+        requestHandler,
+        options.contextBuilder
+      );
       const result = await handler(call.request, context);
       call.sendMetadata(buildMetadata(context));
       callback(null, converter(result));
@@ -91,7 +101,12 @@ export function grpcService(options: GrpcServiceOptions): A2AServiceServer {
     handler: (req: TReq, ctx: ServerCallContext) => AsyncGenerator<TRes>
   ) => {
     try {
-      const context = await _buildContext(call, options.userBuilder, requestHandler);
+      const context = await _buildContext(
+        call,
+        options.userBuilder,
+        requestHandler,
+        options.contextBuilder
+      );
       const stream = await handler(call.request, context);
       call.sendMetadata(buildMetadata(context));
       for await (const responsePart of stream) {
@@ -250,20 +265,29 @@ const mapToError = (error: unknown): Partial<grpc.ServiceError> => {
 const _buildContext = async (
   call: grpc.ServerUnaryCall<unknown, unknown> | grpc.ServerWritableStream<unknown, unknown>,
   userBuilder: UserBuilder,
-  requestHandler: A2ARequestHandler
+  requestHandler: A2ARequestHandler,
+  contextBuilder?: ServerCallContextBuilder
 ): Promise<ServerCallContext> => {
   const user = await userBuilder(call);
   const extensionHeaders = call.metadata.get(HTTP_EXTENSION_HEADER);
   const extensionString = extensionHeaders.map((v) => v.toString()).join(',');
 
-  // gRPC metadata keys are normalized to lowercase.
+  // Convert gRPC metadata to the transport-agnostic RequestHeaders shape.
+  const headers: Record<string, string | string[] | undefined> = {};
+  for (const [key, value] of Object.entries(call.metadata.getMap())) {
+    headers[key] = value.toString();
+  }
+
+  // gRPC metadata keys are normalized to lowercase per gRPC conventions (§10.2).
   const versionHeaders = call.metadata.get(A2A_VERSION_HEADER.toLowerCase());
   const requestedVersion = versionHeaders.length > 0 ? versionHeaders[0].toString() : undefined;
   const tenant = (call.request as Record<string, unknown>)?.tenant as string | undefined;
 
-  const context = new ServerCallContext({
-    requestedExtensions: Extensions.parseServiceParameter(extensionString),
+  const ctxBuilder = contextBuilder ?? defaultServerCallContextBuilder;
+  const context = ctxBuilder({
+    extensions: Extensions.parseServiceParameter(extensionString),
     user,
+    headers,
     requestedVersion,
     tenant,
   });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -30,8 +30,17 @@ export type { TaskStore } from './store.js';
 export { InMemoryTaskStore } from './store.js';
 
 export { JsonRpcTransportHandler } from './transports/jsonrpc/jsonrpc_transport_handler.js';
-export { ServerCallContext } from './context.js';
-export type { ServerCallContextOptions } from './context.js';
+export {
+  ServerCallContext,
+  defaultServerCallContextBuilder,
+  STATE_HEADERS_KEY,
+} from './context.js';
+export type {
+  ServerCallContextOptions,
+  ServerCallContextBuilder,
+  ServerCallContextBuilderOptions,
+  RequestHeaders,
+} from './context.js';
 export { validateVersion, getSupportedVersions } from './version.js';
 export {
   RequestMalformedError,

--- a/test/server/context.spec.ts
+++ b/test/server/context.spec.ts
@@ -1,41 +1,180 @@
 import { describe, it, expect } from 'vitest';
+import {
+  ServerCallContext,
+  defaultServerCallContextBuilder,
+  STATE_HEADERS_KEY,
+  RequestHeaders,
+} from '../../src/server/context.js';
+import { Extensions } from '../../src/extensions.js';
+import { UnauthenticatedUser } from '../../src/server/authentication/user.js';
 
-import { ServerCallContext } from '../../src/server/context.js';
-
-describe('ServerCallContext.setRequestedExtensions', () => {
-  it('mutates the existing instance so an alias held elsewhere observes later activations', () => {
-    // Regression guard for the response-header echo bug:
-    // `_createRequestContext` previously replaced the context with a fresh
-    // instance after narrowing requested extensions (the "SHOULD ignore"
-    // rule for unknown extensions). The Express / gRPC transport layer
-    // held a reference to the original, so `addActivatedExtension(...)`
-    // calls from the executor landed on an orphaned object and the
-    // response-side `A2A-Extensions` echo emitted nothing.
-    // `aliasHeldByTransport` simulates that retained reference — it MUST
-    // observe both the narrowed requested set and any subsequent
-    // activations.
-    const ctx = new ServerCallContext({
-      requestedExtensions: ['ext-a', 'ext-b', 'ext-c'],
-      tenant: 't1',
-      requestedVersion: '1.0',
+describe('ServerCallContext', () => {
+  describe('constructor', () => {
+    it('initializes with no arguments', () => {
+      const ctx = new ServerCallContext();
+      expect(ctx.user).toBeUndefined();
+      expect(ctx.requestedExtensions).toBeUndefined();
+      expect(ctx.activatedExtensions).toBeUndefined();
+      expect(ctx.state).toBeInstanceOf(Map);
+      expect(ctx.state.size).toBe(0);
     });
-    const aliasHeldByTransport = ctx;
 
-    ctx.setRequestedExtensions(['ext-a', 'ext-c']);
-    ctx.addActivatedExtension('ext-a');
+    it('stores requestedExtensions and user', () => {
+      const user = new UnauthenticatedUser();
+      const extensions = Extensions.parseServiceParameter('ext1,ext2');
+      const ctx = new ServerCallContext({ requestedExtensions: extensions, user });
+      expect(ctx.user).toBe(user);
+      expect(ctx.requestedExtensions).toBe(extensions);
+    });
 
-    expect(aliasHeldByTransport.requestedExtensions).toEqual(['ext-a', 'ext-c']);
-    expect(aliasHeldByTransport.activatedExtensions).toEqual(['ext-a']);
-    expect(aliasHeldByTransport.tenant).toBe('t1');
-    expect(aliasHeldByTransport.requestedVersion).toBe('1.0');
+    it('uses provided state map', () => {
+      const state = new Map<string, unknown>([['key', 'value']]);
+      const ctx = new ServerCallContext({ state });
+      expect(ctx.state.get('key')).toBe('value');
+    });
+
+    it('stores tenant', () => {
+      const ctx = new ServerCallContext({ tenant: 'acme' });
+      expect(ctx.tenant).toBe('acme');
+    });
+
+    it('tenant is undefined when not provided', () => {
+      const ctx = new ServerCallContext();
+      expect(ctx.tenant).toBeUndefined();
+    });
+
+    it('stores requestedVersion', () => {
+      const ctx = new ServerCallContext({ requestedVersion: '1.0' });
+      expect(ctx.requestedVersion).toBe('1.0');
+    });
+
+    it('defaults requestedVersion to 0.3 when absent', () => {
+      const ctx = new ServerCallContext();
+      expect(ctx.requestedVersion).toBe('0.3');
+    });
   });
 
-  it('accepts `undefined` to reset the requested set back to its initial unset state', () => {
-    // `_requestedExtensions` is `Extensions | undefined`, so the setter
-    // must accept `undefined` — otherwise a caller can never restore
-    // the field to its "no header was sent" state.
-    const ctx = new ServerCallContext({ requestedExtensions: ['ext-a'] });
-    ctx.setRequestedExtensions(undefined);
-    expect(ctx.requestedExtensions).toBeUndefined();
+  describe('addActivatedExtension', () => {
+    it('adds a single extension', () => {
+      const ctx = new ServerCallContext();
+      ctx.addActivatedExtension('ext://foo');
+      expect(Array.from(ctx.activatedExtensions!)).toContain('ext://foo');
+    });
+
+    it('accumulates multiple extensions', () => {
+      const ctx = new ServerCallContext();
+      ctx.addActivatedExtension('ext://foo');
+      ctx.addActivatedExtension('ext://bar');
+      expect(Array.from(ctx.activatedExtensions!)).toEqual(['ext://foo', 'ext://bar']);
+    });
+  });
+
+  describe('setRequestedExtensions', () => {
+    it('mutates the existing instance so an alias held elsewhere observes later activations', () => {
+      // Regression guard for the response-header echo bug:
+      // `_createRequestContext` previously replaced the context with a fresh
+      // instance after narrowing requested extensions (the "SHOULD ignore"
+      // rule for unknown extensions). The Express / gRPC transport layer
+      // held a reference to the original, so `addActivatedExtension(...)`
+      // calls from the executor landed on an orphaned object and the
+      // response-side `A2A-Extensions` echo emitted nothing.
+      // `aliasHeldByTransport` simulates that retained reference — it MUST
+      // observe both the narrowed requested set and any subsequent
+      // activations.
+      const ctx = new ServerCallContext({
+        requestedExtensions: ['ext-a', 'ext-b', 'ext-c'],
+        tenant: 't1',
+        requestedVersion: '1.0',
+      });
+      const aliasHeldByTransport = ctx;
+
+      ctx.setRequestedExtensions(['ext-a', 'ext-c']);
+      ctx.addActivatedExtension('ext-a');
+
+      expect(aliasHeldByTransport.requestedExtensions).toEqual(['ext-a', 'ext-c']);
+      expect(aliasHeldByTransport.activatedExtensions).toEqual(['ext-a']);
+      expect(aliasHeldByTransport.tenant).toBe('t1');
+      expect(aliasHeldByTransport.requestedVersion).toBe('1.0');
+    });
+
+    it('accepts `undefined` to reset the requested set back to its initial unset state', () => {
+      // `_requestedExtensions` is `Extensions | undefined`, so the setter
+      // must accept `undefined` — otherwise a caller can never restore
+      // the field to its "no header was sent" state.
+      const ctx = new ServerCallContext({ requestedExtensions: ['ext-a'] });
+      ctx.setRequestedExtensions(undefined);
+      expect(ctx.requestedExtensions).toBeUndefined();
+    });
+  });
+});
+
+describe('defaultServerCallContextBuilder', () => {
+  it('stores headers in state under STATE_HEADERS_KEY', () => {
+    const headers: RequestHeaders = { 'x-tenant-id': 'tenant-1', authorization: 'Bearer tok' };
+    const ctx = defaultServerCallContextBuilder({
+      extensions: undefined,
+      user: undefined,
+      headers,
+    });
+    expect(ctx.state.get(STATE_HEADERS_KEY)).toBe(headers);
+  });
+
+  it('sets requestedExtensions from the first argument', () => {
+    const extensions = Extensions.parseServiceParameter('ext://foo');
+    const ctx = defaultServerCallContextBuilder({ extensions, user: undefined, headers: {} });
+    expect(Array.from(ctx.requestedExtensions!)).toEqual(Array.from(extensions));
+  });
+
+  it('sets user from the second argument', () => {
+    const user = new UnauthenticatedUser();
+    const ctx = defaultServerCallContextBuilder({ extensions: undefined, user, headers: {} });
+    expect(ctx.user).toBe(user);
+  });
+
+  it('produces an empty state entry for empty headers', () => {
+    const ctx = defaultServerCallContextBuilder({
+      extensions: undefined,
+      user: undefined,
+      headers: {},
+    });
+    expect(ctx.state.get(STATE_HEADERS_KEY)).toEqual({});
+  });
+
+  it('passes tenant to the context', () => {
+    const ctx = defaultServerCallContextBuilder({
+      extensions: undefined,
+      user: undefined,
+      headers: {},
+      tenant: 'acme',
+    });
+    expect(ctx.tenant).toBe('acme');
+  });
+
+  it('tenant is undefined when not provided', () => {
+    const ctx = defaultServerCallContextBuilder({
+      extensions: undefined,
+      user: undefined,
+      headers: {},
+    });
+    expect(ctx.tenant).toBeUndefined();
+  });
+
+  it('passes requestedVersion to the context', () => {
+    const ctx = defaultServerCallContextBuilder({
+      extensions: undefined,
+      user: undefined,
+      headers: {},
+      requestedVersion: '1.0',
+    });
+    expect(ctx.requestedVersion).toBe('1.0');
+  });
+
+  it('defaults requestedVersion to 0.3 when not provided', () => {
+    const ctx = defaultServerCallContextBuilder({
+      extensions: undefined,
+      user: undefined,
+      headers: {},
+    });
+    expect(ctx.requestedVersion).toBe('0.3');
   });
 });


### PR DESCRIPTION
# Description

## Motivation

The [Python A2A SDK](https://github.com/a2aproject/a2a-python) exposes a `state` property
on [`ServerCallContext`](https://github.com/a2aproject/a2a-python/blob/main/src/a2a/server/context.py#L22)
— an arbitrary `MutableMapping[str, Any]` used to pass metadata through the call pipeline.
The Python app layer actively uses it (e.g.
[`call_context.state['method'] = method`](https://github.com/a2aproject/a2a-python/blob/main/src/a2a/server/apps/jsonrpc/jsonrpc_app.py#L149-L153)),
and op-SDK implementations rely on it to carry request-scoped data such as tenant IDs,
auth tokens, or raw headers.

The TypeScript SDK was missing this capability, making it impossible to faithfully port
Python-based agent implementations to TypeScript without architectural workarounds.

## Changes

### `ServerCallContext`
- Added a `state` property — a `Map<string, unknown>` key/value bag, directly mirroring
  Python's `state: MutableMapping[str, Any]`.
- Added `withRequestedExtensions()` method that returns a new context with updated extensions
  while preserving `user`, `state`, and `activatedExtensions`.
- Extended the constructor to accept an optional `state` map.

### `ServerCallContextBuilder`
- Added `ServerCallContextBuilder` factory function type, mirroring Python's abstract
  `CallContextBuilder.build(request)` pattern.
- Added `defaultServerCallContextBuilder` — the default implementation that pre-populates
  `state` with raw request headers under the `headers` key, mirroring Python's
  `DefaultCallContextBuilder`.
- Added `STATE_HEADERS_KEY` constant for the headers key.
- Added `RequestHeaders` type — transport-agnostic representation of request headers.

### Express handlers (`jsonRpcHandler`, `restHandler`)
- Added optional `contextBuilder?: ServerCallContextBuilder` to `JsonRpcHandlerOptions`
  and `RestHandlerOptions`, falling back to `defaultServerCallContextBuilder`.
- Both handlers now pass raw `req.headers` into the context builder.

### gRPC handler
- Updated `grpc_service.ts` to pass request metadata as headers into the context builder.

### Exports
- `ServerCallContextBuilder`, `RequestHeaders`, `defaultServerCallContextBuilder`,
  and `STATE_HEADERS_KEY` are now exported from `@a2a-js/sdk/server`.

### Tests & samples
- Added unit tests for the new `ServerCallContext` API in `test/server/context.spec.ts`.
- Added `src/samples/authentication/server_call_context.ts` demonstrating custom context usage.

## Impact

This change enables direct migration of Python A2A agent implementations to TypeScript —
any code relying on `context.state` in the Python SDK will have a direct equivalent in the
TypeScript SDK with the same semantics.

## Checklist
- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-js/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the https://www.conventionalcommits.org/ specification.
- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)