### PR TITLE
ci: enable groups for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directories:
+      - '/'
+      - '/src/samples'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    groups:
+      security-patches:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
Bring back the previous behavior of only having security updates.
