### PR TITLE
feat: Align transport method names with 1.0 spec

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -9,10 +9,10 @@ exports[`TypeScript Strict Mode`] = {
       [248, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"],
       [271, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"]
     ],
-    "src/server/express/rest_handler.ts:1719786474": [
+    "src/server/express/rest_handler.ts:1742627572": [
       [208, 50, 17, "tsc: Argument of type \'unknown\' is not assignable to parameter of type \'Message | Task | TaskArtifactUpdateEvent | TaskStatusUpdateEvent\'.", "3749434707"]
     ],
-    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:3725679759": [
+    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:1270528550": [
       [89, 12, 10, "tsc: Variable \'rpcRequest\' is used before being assigned.", "3927050741"]
     ],
     "src/types/converters/to_proto.ts:1276072555": [

--- a/.betterer.results
+++ b/.betterer.results
@@ -9,7 +9,7 @@ exports[`TypeScript Strict Mode`] = {
       [248, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"],
       [271, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"]
     ],
-    "src/server/express/rest_handler.ts:1742627572": [
+    "src/server/express/rest_handler.ts:1777885052": [
       [208, 50, 17, "tsc: Argument of type \'unknown\' is not assignable to parameter of type \'Message | Task | TaskArtifactUpdateEvent | TaskStatusUpdateEvent\'.", "3749434707"]
     ],
     "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:1270528550": [

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -57,7 +57,7 @@ export class JsonRpcTransport implements Transport {
 
   async getExtendedAgentCard(options?: RequestOptions): Promise<AgentCard> {
     const rpcResponse = await this._sendRpcRequest<undefined, AgentCard>(
-      'agent/getAuthenticatedExtendedCard',
+      'GetExtendedAgentCard',
       undefined,
       options,
       undefined
@@ -70,7 +70,7 @@ export class JsonRpcTransport implements Transport {
     options?: RequestOptions
   ): Promise<SendMessageResult> {
     const rpcResponse = await this._sendRpcRequest<SendMessageRequest, SendMessageResponse>(
-      'message/send',
+      'SendMessage',
       params,
       options,
       SendMessageRequest
@@ -88,7 +88,7 @@ export class JsonRpcTransport implements Transport {
     options?: RequestOptions
   ): AsyncGenerator<A2AStreamEventData, void, undefined> {
     yield* this._sendStreamingRequest<SendMessageRequest>(
-      'message/stream',
+      'SendStreamingMessage',
       params,
       options,
       SendMessageRequest
@@ -102,7 +102,7 @@ export class JsonRpcTransport implements Transport {
     const rpcResponse = await this._sendRpcRequest<
       TaskPushNotificationConfig,
       TaskPushNotificationConfig
-    >('tasks/pushNotificationConfig/create', params, options, TaskPushNotificationConfig);
+    >('CreateTaskPushNotificationConfig', params, options, TaskPushNotificationConfig);
     return TaskPushNotificationConfig.fromJSON(rpcResponse.result);
   }
 
@@ -113,7 +113,7 @@ export class JsonRpcTransport implements Transport {
     const rpcResponse = await this._sendRpcRequest<
       GetTaskPushNotificationConfigRequest,
       TaskPushNotificationConfig
-    >('tasks/pushNotificationConfig/get', params, options, GetTaskPushNotificationConfigRequest);
+    >('GetTaskPushNotificationConfig', params, options, GetTaskPushNotificationConfigRequest);
     return TaskPushNotificationConfig.fromJSON(rpcResponse.result);
   }
 
@@ -124,7 +124,7 @@ export class JsonRpcTransport implements Transport {
     const rpcResponse = await this._sendRpcRequest<
       ListTaskPushNotificationConfigsRequest,
       ListTaskPushNotificationConfigsResponse
-    >('tasks/pushNotificationConfig/list', params, options, ListTaskPushNotificationConfigsRequest);
+    >('ListTaskPushNotificationConfigs', params, options, ListTaskPushNotificationConfigsRequest);
     const configs = rpcResponse.result.configs || [];
     return configs.map((c: unknown) => TaskPushNotificationConfig.fromJSON(c));
   }
@@ -134,7 +134,7 @@ export class JsonRpcTransport implements Transport {
     options?: RequestOptions
   ): Promise<void> {
     await this._sendRpcRequest<DeleteTaskPushNotificationConfigRequest, void>(
-      'tasks/pushNotificationConfig/delete',
+      'DeleteTaskPushNotificationConfig',
       params,
       options,
       DeleteTaskPushNotificationConfigRequest
@@ -143,7 +143,7 @@ export class JsonRpcTransport implements Transport {
 
   async getTask(params: GetTaskRequest, options?: RequestOptions): Promise<Task> {
     const rpcResponse = await this._sendRpcRequest<GetTaskRequest, Task>(
-      'tasks/get',
+      'GetTask',
       params,
       options,
       GetTaskRequest
@@ -153,7 +153,7 @@ export class JsonRpcTransport implements Transport {
 
   async cancelTask(params: CancelTaskRequest, options?: RequestOptions): Promise<Task> {
     const rpcResponse = await this._sendRpcRequest<CancelTaskRequest, Task>(
-      'tasks/cancel',
+      'CancelTask',
       params,
       options,
       CancelTaskRequest
@@ -166,7 +166,7 @@ export class JsonRpcTransport implements Transport {
     options?: RequestOptions
   ): AsyncGenerator<A2AStreamEventData, void, undefined> {
     yield* this._sendStreamingRequest<SubscribeToTaskRequest>(
-      'tasks/resubscribe',
+      'SubscribeToTask',
       params,
       options,
       SubscribeToTaskRequest

--- a/src/client/transports/rest_transport.ts
+++ b/src/client/transports/rest_transport.ts
@@ -63,7 +63,7 @@ export class RestTransport implements Transport {
   async getExtendedAgentCard(options?: RequestOptions): Promise<AgentCard> {
     const response = await this._sendRequest<undefined, AgentCard>(
       'GET',
-      '/v1/card',
+      '/v1/extendedAgentCard',
       undefined,
       options,
       undefined,

--- a/src/client/transports/rest_transport.ts
+++ b/src/client/transports/rest_transport.ts
@@ -63,7 +63,7 @@ export class RestTransport implements Transport {
   async getExtendedAgentCard(options?: RequestOptions): Promise<AgentCard> {
     const response = await this._sendRequest<undefined, AgentCard>(
       'GET',
-      '/v1/extendedAgentCard',
+      '/extendedAgentCard',
       undefined,
       options,
       undefined,
@@ -79,7 +79,7 @@ export class RestTransport implements Transport {
     const requestBody = params;
     const response = await this._sendRequest<SendMessageRequest, SendMessageResponse>(
       'POST',
-      '/v1/message:send',
+      '/message:send',
       requestBody,
       options,
       SendMessageRequest,
@@ -93,7 +93,7 @@ export class RestTransport implements Transport {
     options?: RequestOptions
   ): AsyncGenerator<A2AStreamEventData, void, undefined> {
     const requestBody = SendMessageRequest.toJSON(params);
-    yield* this._sendStreamingRequest('/v1/message:stream', requestBody, options);
+    yield* this._sendStreamingRequest('/message:stream', requestBody, options);
   }
 
   async createTaskPushNotificationConfig(
@@ -105,7 +105,7 @@ export class RestTransport implements Transport {
       TaskPushNotificationConfig
     >(
       'POST',
-      `/v1/tasks/${encodeURIComponent(params.taskId)}/pushNotificationConfigs`,
+      `/tasks/${encodeURIComponent(params.taskId)}/pushNotificationConfigs`,
       params,
       options,
       TaskPushNotificationConfig,
@@ -120,7 +120,7 @@ export class RestTransport implements Transport {
   ): Promise<TaskPushNotificationConfig> {
     const response = await this._sendRequest<undefined, TaskPushNotificationConfig>(
       'GET',
-      `/v1/tasks/${params.taskId}/pushNotificationConfigs/${params.id}`,
+      `/tasks/${params.taskId}/pushNotificationConfigs/${params.id}`,
       undefined,
       options,
       undefined,
@@ -135,7 +135,7 @@ export class RestTransport implements Transport {
   ): Promise<TaskPushNotificationConfig[]> {
     const response = await this._sendRequest<undefined, ListTaskPushNotificationConfigsResponse>(
       'GET',
-      `/v1/tasks/${params.taskId}/pushNotificationConfigs`,
+      `/tasks/${params.taskId}/pushNotificationConfigs`,
       undefined,
       options,
       undefined,
@@ -150,7 +150,7 @@ export class RestTransport implements Transport {
   ): Promise<void> {
     await this._sendRequest<undefined, void>(
       'DELETE',
-      `/v1/tasks/${params.taskId}/pushNotificationConfigs/${params.id}`,
+      `/tasks/${params.taskId}/pushNotificationConfigs/${params.id}`,
       undefined,
       options,
       undefined,
@@ -164,7 +164,7 @@ export class RestTransport implements Transport {
       queryParams.set('historyLength', String(params.historyLength));
     }
     const queryString = queryParams.toString();
-    const path = `/v1/tasks/${params.id}${queryString ? `?${queryString}` : ''}`;
+    const path = `/tasks/${params.id}${queryString ? `?${queryString}` : ''}`;
     const response = await this._sendRequest<undefined, Task>(
       'GET',
       path,
@@ -179,7 +179,7 @@ export class RestTransport implements Transport {
   async cancelTask(params: CancelTaskRequest, options?: RequestOptions): Promise<Task> {
     const response = await this._sendRequest<undefined, Task>(
       'POST',
-      `/v1/tasks/${params.id}:cancel`,
+      `/tasks/${params.id}:cancel`,
       undefined,
       options,
       undefined,
@@ -192,7 +192,7 @@ export class RestTransport implements Transport {
     params: SubscribeToTaskRequest,
     options?: RequestOptions
   ): AsyncGenerator<A2AStreamEventData, void, undefined> {
-    yield* this._sendStreamingRequest(`/v1/tasks/${params.id}:subscribe`, undefined, options);
+    yield* this._sendStreamingRequest(`/tasks/${params.id}:subscribe`, undefined, options);
   }
 
   private _fetch(...args: Parameters<typeof fetch>): ReturnType<typeof fetch> {

--- a/src/samples/cli.ts
+++ b/src/samples/cli.ts
@@ -88,7 +88,7 @@ let fetchImpl: typeof fetch = fetch;
 let agentCardPath = AGENT_CARD_PATH;
 if (process.argv.includes('--agent-engine')) {
   fetchImpl = createAuthenticatingFetchWithRetry(fetch, new ADCHandler());
-  agentCardPath = 'a2a/v1/extendedAgentCard'; // Agent Engine doesn't use well-known public agent card endpoint.
+  agentCardPath = 'a2a/extendedAgentCard'; // Agent Engine doesn't use well-known public agent card endpoint.
 }
 const factory = new ClientFactory(
   ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {

--- a/src/samples/cli.ts
+++ b/src/samples/cli.ts
@@ -88,7 +88,7 @@ let fetchImpl: typeof fetch = fetch;
 let agentCardPath = AGENT_CARD_PATH;
 if (process.argv.includes('--agent-engine')) {
   fetchImpl = createAuthenticatingFetchWithRetry(fetch, new ADCHandler());
-  agentCardPath = 'a2a/v1/card'; // Agent Engine doesn't use well-known public agent card endpoint.
+  agentCardPath = 'a2a/v1/extendedAgentCard'; // Agent Engine doesn't use well-known public agent card endpoint.
 }
 const factory = new ClientFactory(
   ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -79,9 +79,9 @@ type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
  *
  * This handler implements the A2A REST API specification with snake_case
  * field names, providing endpoints for:
- * - Agent card retrieval (GET /v1/extendedAgentCard)
- * - Message sending with optional streaming (POST /v1/message:send|stream)
- * - Task management (GET/POST /v1/tasks/:taskId:cancel|subscribe)
+ * - Agent card retrieval (GET /extendedAgentCard)
+ * - Message sending with optional streaming (POST /message:send|stream)
+ * - Task management (GET/POST /tasks/:taskId:cancel|subscribe)
  * - Push notification configuration
  *
  * The handler acts as an adapter layer, converting between REST format
@@ -268,7 +268,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   // ============================================================================
 
   /**
-   * GET /v1/extendedAgentCard
+   * GET /extendedAgentCard
    *
    * Retrieves the authenticated extended agent card.
    *
@@ -276,7 +276,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 500 Internal Server Error on failure
    */
   router.get(
-    '/v1/extendedAgentCard',
+    '/extendedAgentCard',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await restTransportHandler.getAuthenticatedExtendedAgentCard(context);
@@ -285,7 +285,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * POST /v1/message:send
+   * POST /message:send
    *
    * Sends a message to the agent synchronously.
    * Returns either a Message (for immediate responses) or a Task (for async processing).
@@ -296,7 +296,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 400 Bad Request if message is invalid
    */
   router.post(
-    '/v1/message\\:send',
+    '/message\\:send',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const params = SendMessageRequest.fromJSON(req.body);
@@ -313,7 +313,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * POST /v1/message:stream
+   * POST /message:stream
    *
    * Sends a message to the agent with streaming response.
    * Returns a Server-Sent Events (SSE) stream of updates.
@@ -325,7 +325,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 501 Not Implemented if streaming not supported
    */
   router.post(
-    '/v1/message\\:stream',
+    '/message\\:stream',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const params = SendMessageRequest.fromJSON(req.body);
@@ -335,7 +335,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * GET /v1/tasks/:taskId
+   * GET /tasks/:taskId
    *
    * Retrieves the current status and details of a task.
    *
@@ -346,7 +346,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 404 Not Found if task doesn't exist
    */
   router.get(
-    '/v1/tasks/:taskId',
+    '/tasks/:taskId',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await restTransportHandler.getTask(
@@ -360,7 +360,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * POST /v1/tasks/:taskId:cancel
+   * POST /tasks/:taskId:cancel
    *
    * Attempts to cancel an ongoing task.
    * The task may not be immediately canceled depending on its current state.
@@ -371,7 +371,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 409 Conflict if task cannot be canceled
    */
   router.post(
-    '/v1/tasks/:taskId\\:cancel',
+    '/tasks/:taskId\\:cancel',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await restTransportHandler.cancelTask(req.params.taskId, context);
@@ -380,7 +380,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * GET /v1/tasks
+   * GET /tasks
    *
    * Retrieves a list of tasks with optional filtering and pagination capabilities.
    *
@@ -388,7 +388,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 400 Bad Request if filter or pageSize is invalid
    */
   router.get(
-    '/v1/tasks',
+    '/tasks',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await restTransportHandler.listTasks(req.query, context);
@@ -397,7 +397,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * POST /v1/tasks/:taskId:subscribe
+   * POST /tasks/:taskId:subscribe
    *
    * Resubscribes to an existing task's updates via Server-Sent Events (SSE).
    * Useful for reconnecting to long-running tasks or receiving missed updates.
@@ -408,7 +408,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 501 Not Implemented if streaming not supported
    */
   router.post(
-    '/v1/tasks/:taskId\\:subscribe',
+    '/tasks/:taskId\\:subscribe',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const stream = await restTransportHandler.resubscribe(req.params.taskId, context);
@@ -417,7 +417,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * POST /v1/tasks/:taskId/pushNotificationConfigs
+   * POST /tasks/:taskId/pushNotificationConfigs
    *
    * Creates a push notification configuration for a task.
    * The agent will send task updates to the configured webhook URL.
@@ -428,7 +428,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 501 Not Implemented if push notifications not supported
    */
   router.post(
-    '/v1/tasks/:taskId/pushNotificationConfigs',
+    '/tasks/:taskId/pushNotificationConfigs',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const params = TaskPushNotificationConfig.fromJSON(req.body);
@@ -444,7 +444,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * GET /v1/tasks/:taskId/pushNotificationConfigs
+   * GET /tasks/:taskId/pushNotificationConfigs
    *
    * Lists all push notification configurations for a task.
    *
@@ -453,7 +453,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 404 Not Found if task doesn't exist
    */
   router.get(
-    '/v1/tasks/:taskId/pushNotificationConfigs',
+    '/tasks/:taskId/pushNotificationConfigs',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await restTransportHandler.listTaskPushNotificationConfigs(
@@ -472,7 +472,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * GET /v1/tasks/:taskId/pushNotificationConfigs/:configId
+   * GET /tasks/:taskId/pushNotificationConfigs/:configId
    *
    * Retrieves a specific push notification configuration.
    *
@@ -482,7 +482,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 404 Not Found if task or config doesn't exist
    */
   router.get(
-    '/v1/tasks/:taskId/pushNotificationConfigs/:configId',
+    '/tasks/:taskId/pushNotificationConfigs/:configId',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await restTransportHandler.getTaskPushNotificationConfig(
@@ -501,7 +501,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * DELETE /v1/tasks/:taskId/pushNotificationConfigs/:configId
+   * DELETE /tasks/:taskId/pushNotificationConfigs/:configId
    *
    * Deletes a push notification configuration.
    *
@@ -511,7 +511,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 404 Not Found if task or config doesn't exist
    */
   router.delete(
-    '/v1/tasks/:taskId/pushNotificationConfigs/:configId',
+    '/tasks/:taskId/pushNotificationConfigs/:configId',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       await restTransportHandler.deleteTaskPushNotificationConfig(

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -79,7 +79,7 @@ type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
  *
  * This handler implements the A2A REST API specification with snake_case
  * field names, providing endpoints for:
- * - Agent card retrieval (GET /v1/card)
+ * - Agent card retrieval (GET /v1/extendedAgentCard)
  * - Message sending with optional streaming (POST /v1/message:send|stream)
  * - Task management (GET/POST /v1/tasks/:taskId:cancel|subscribe)
  * - Push notification configuration
@@ -268,7 +268,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   // ============================================================================
 
   /**
-   * GET /v1/card
+   * GET /v1/extendedAgentCard
    *
    * Retrieves the authenticated extended agent card.
    *
@@ -276,7 +276,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @returns 500 Internal Server Error on failure
    */
   router.get(
-    '/v1/card',
+    '/v1/extendedAgentCard',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await restTransportHandler.getAuthenticatedExtendedAgentCard(context);

--- a/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -94,21 +94,18 @@ export class JsonRpcTransportHandler {
 
     const { method, id: requestId = null } = rpcRequest;
     try {
-      if (
-        method !== 'agent/getAuthenticatedExtendedCard' &&
-        !this.paramsAreValid(rpcRequest.params)
-      ) {
+      if (method !== 'GetExtendedAgentCard' && !this.paramsAreValid(rpcRequest.params)) {
         throw new RequestMalformedError(`Invalid method parameters.`);
       }
 
-      if (method === 'message/stream' || method === 'tasks/resubscribe') {
+      if (method === 'SendStreamingMessage' || method === 'SubscribeToTask') {
         const params = rpcRequest.params;
         const agentCard = await this.requestHandler.getAgentCard();
         if (!agentCard.capabilities?.streaming) {
           throw new UnsupportedOperationError(`Method ${method} requires streaming capability.`);
         }
         const agentEventStream =
-          method === 'message/stream'
+          method === 'SendStreamingMessage'
             ? this.requestHandler.sendMessageStream(SendMessageRequest.fromJSON(params), context)
             : this.requestHandler.resubscribe(SubscribeToTaskRequest.fromJSON(params), context);
 
@@ -157,7 +154,7 @@ export class JsonRpcTransportHandler {
         // Handle non-streaming methods
         let result: unknown;
         switch (method) {
-          case 'message/send': {
+          case 'SendMessage': {
             const messageOrTask = await this.requestHandler.sendMessage(
               SendMessageRequest.fromJSON(rpcRequest.params),
               context
@@ -170,51 +167,51 @@ export class JsonRpcTransportHandler {
             };
             break;
           }
-          case 'tasks/get':
+          case 'GetTask':
             result = await this.requestHandler.getTask(
               GetTaskRequest.fromJSON(rpcRequest.params),
               context
             );
             break;
-          case 'tasks/list':
+          case 'ListTasks':
             result = await this.requestHandler.listTasks(
               ListTasksRequest.fromJSON(rpcRequest.params),
               context
             );
             break;
-          case 'tasks/cancel':
+          case 'CancelTask':
             result = await this.requestHandler.cancelTask(
               CancelTaskRequest.fromJSON(rpcRequest.params),
               context
             );
             break;
-          case 'tasks/pushNotificationConfig/create': {
+          case 'CreateTaskPushNotificationConfig': {
             result = await this.requestHandler.createTaskPushNotificationConfig(
               TaskPushNotificationConfig.fromJSON(rpcRequest.params),
               context
             );
             break;
           }
-          case 'tasks/pushNotificationConfig/get':
+          case 'GetTaskPushNotificationConfig':
             result = await this.requestHandler.getTaskPushNotificationConfig(
               GetTaskPushNotificationConfigRequest.fromJSON(rpcRequest.params),
               context
             );
             break;
-          case 'tasks/pushNotificationConfig/delete':
+          case 'DeleteTaskPushNotificationConfig':
             await this.requestHandler.deleteTaskPushNotificationConfig(
               DeleteTaskPushNotificationConfigRequest.fromJSON(rpcRequest.params),
               context
             );
             result = null;
             break;
-          case 'tasks/pushNotificationConfig/list':
+          case 'ListTaskPushNotificationConfigs':
             result = await this.requestHandler.listTaskPushNotificationConfigs(
               ListTaskPushNotificationConfigsRequest.fromJSON(rpcRequest.params),
               context
             );
             break;
-          case 'agent/getAuthenticatedExtendedCard':
+          case 'GetExtendedAgentCard':
             result = await this.requestHandler.getAuthenticatedExtendedAgentCard(context);
             break;
           default:

--- a/test/client/client_auth.spec.ts
+++ b/test/client/client_auth.spec.ts
@@ -126,7 +126,7 @@ describe('JsonRpcTransport Authentication Tests', () => {
           Accept: 'application/json',
         },
       });
-      expect(mockFetch.mock.calls[0][1].body).to.include('"method":"message/send"');
+      expect(mockFetch.mock.calls[0][1].body).to.include('"method":"SendMessage"');
 
       // Second call: RPC request with auth header
       expect(mockFetch.mock.calls[1][0]).to.equal('https://test-agent.example.com/api');
@@ -142,7 +142,7 @@ describe('JsonRpcTransport Authentication Tests', () => {
       expect(mockFetch.mock.calls[1][1].headers).to.have.property('Authorization');
 
       expect(mockFetch.mock.calls[1][1].headers['Authorization']).to.match(/^Bearer .+$/);
-      expect(mockFetch.mock.calls[1][1].body).to.include('"method":"message/send"');
+      expect(mockFetch.mock.calls[1][1].body).to.include('"method":"SendMessage"');
 
       // Verify the result
       expect(result).to.exist;

--- a/test/client/transports/json_rpc_transport.spec.ts
+++ b/test/client/transports/json_rpc_transport.spec.ts
@@ -118,7 +118,7 @@ describe('JsonRpcTransport', () => {
 
       const fetchArgs = mockFetch.mock.calls[0][1];
       const body = JSON.parse(fetchArgs.body as string);
-      expect(body.method).toBe('tasks/pushNotificationConfig/create');
+      expect(body.method).toBe('CreateTaskPushNotificationConfig');
       expect(body.params).toEqual({
         id: 'config1',
         taskId: 'task1',
@@ -159,7 +159,7 @@ describe('JsonRpcTransport', () => {
 
       const fetchArgs = mockFetch.mock.calls[0][1];
       const body = JSON.parse(fetchArgs.body as string);
-      expect(body.method).toBe('tasks/pushNotificationConfig/get');
+      expect(body.method).toBe('GetTaskPushNotificationConfig');
       expect(body.params).toEqual({ id: 'config1', taskId: 'task1' });
       expect(result).toEqual(expectedConfig);
     });
@@ -198,7 +198,7 @@ describe('JsonRpcTransport', () => {
 
       const fetchArgs = mockFetch.mock.calls[0][1];
       const body = JSON.parse(fetchArgs.body as string);
-      expect(body.method).toBe('tasks/pushNotificationConfig/list');
+      expect(body.method).toBe('ListTaskPushNotificationConfigs');
       expect(body.params).toEqual({ taskId: 'task1' });
       expect(result).toHaveLength(1);
       expect(result[0]).toEqual(expectedConfig);

--- a/test/client/transports/rest_transport.spec.ts
+++ b/test/client/transports/rest_transport.spec.ts
@@ -58,7 +58,7 @@ describe('RestTransport', () => {
       await trailingSlashTransport.sendMessage(createMessageParams());
 
       const [url] = mockFetch.mock.calls[0];
-      expect(url).to.equal('https://example.com/a2a/rest/v1/message:send');
+      expect(url).to.equal('https://example.com/a2a/rest/message:send');
     });
 
     it('should trim multiple trailing slashes from endpoint', async () => {
@@ -72,7 +72,7 @@ describe('RestTransport', () => {
       await trailingSlashTransport.sendMessage(createMessageParams());
 
       const [url] = mockFetch.mock.calls[0];
-      expect(url).to.equal('https://example.com/a2a/rest/v1/message:send');
+      expect(url).to.equal('https://example.com/a2a/rest/message:send');
     });
   });
 
@@ -95,7 +95,7 @@ describe('RestTransport', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       const [url, options] = mockFetch.mock.calls[0];
-      expect(url).to.equal(`${endpoint}/v1/message:send`);
+      expect(url).to.equal(`${endpoint}/message:send`);
       expect(options?.method).to.equal('POST');
       expect((options?.headers as Record<string, string>)['Content-Type']).to.equal(
         'application/json'
@@ -138,7 +138,7 @@ describe('RestTransport', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       const [url, options] = mockFetch.mock.calls[0];
-      expect(url).to.equal(`${endpoint}/v1/tasks/${taskId}?historyLength=0`);
+      expect(url).to.equal(`${endpoint}/tasks/${taskId}?historyLength=0`);
       expect(options?.method).to.equal('GET');
     });
 
@@ -155,7 +155,7 @@ describe('RestTransport', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       const [url, options] = mockFetch.mock.calls[0];
-      expect(url).to.equal(`${endpoint}/v1/tasks/${taskId}?historyLength=${historyLength}`);
+      expect(url).to.equal(`${endpoint}/tasks/${taskId}?historyLength=${historyLength}`);
       expect(options?.method).to.equal('GET');
     });
 
@@ -181,7 +181,7 @@ describe('RestTransport', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       const [url, options] = mockFetch.mock.calls[0];
-      expect(url).to.equal(`${endpoint}/v1/tasks/${taskId}:cancel`);
+      expect(url).to.equal(`${endpoint}/tasks/${taskId}:cancel`);
       expect(options?.method).to.equal('POST');
     });
 
@@ -234,7 +234,7 @@ describe('RestTransport', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       const [url, options] = mockFetch.mock.calls[0];
-      expect(url).to.equal(`${endpoint}/v1/extendedAgentCard`);
+      expect(url).to.equal(`${endpoint}/extendedAgentCard`);
       expect(options?.method).to.equal('GET');
     });
   });
@@ -261,7 +261,7 @@ describe('RestTransport', () => {
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
         const [url, options] = mockFetch.mock.calls[0];
-        expect(url).to.equal(`${endpoint}/v1/tasks/${taskId}/pushNotificationConfigs`);
+        expect(url).to.equal(`${endpoint}/tasks/${taskId}/pushNotificationConfigs`);
         expect(options?.method).to.equal('POST');
       });
 
@@ -290,7 +290,7 @@ describe('RestTransport', () => {
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
         const [url, options] = mockFetch.mock.calls[0];
-        expect(url).to.equal(`${endpoint}/v1/tasks/${taskId}/pushNotificationConfigs/${configId}`);
+        expect(url).to.equal(`${endpoint}/tasks/${taskId}/pushNotificationConfigs/${configId}`);
         expect(options?.method).to.equal('GET');
       });
     });
@@ -338,7 +338,7 @@ describe('RestTransport', () => {
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
         const [url, options] = mockFetch.mock.calls[0];
-        expect(url).to.equal(`${endpoint}/v1/tasks/${taskId}/pushNotificationConfigs`);
+        expect(url).to.equal(`${endpoint}/tasks/${taskId}/pushNotificationConfigs`);
         expect(options?.method).to.equal('GET');
       });
     });
@@ -356,7 +356,7 @@ describe('RestTransport', () => {
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
         const [url, options] = mockFetch.mock.calls[0];
-        expect(url).to.equal(`${endpoint}/v1/tasks/${taskId}/pushNotificationConfigs/${configId}`);
+        expect(url).to.equal(`${endpoint}/tasks/${taskId}/pushNotificationConfigs/${configId}`);
         expect(options?.method).to.equal('DELETE');
       });
     });

--- a/test/client/transports/rest_transport.spec.ts
+++ b/test/client/transports/rest_transport.spec.ts
@@ -234,7 +234,7 @@ describe('RestTransport', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
 
       const [url, options] = mockFetch.mock.calls[0];
-      expect(url).to.equal(`${endpoint}/v1/card`);
+      expect(url).to.equal(`${endpoint}/v1/extendedAgentCard`);
       expect(options?.method).to.equal('GET');
     });
   });

--- a/test/client/util.ts
+++ b/test/client/util.ts
@@ -422,7 +422,7 @@ export function createMockFetch(
 
       const requestBody = JSON.parse((options?.body as string) || '{}');
       const wrappedResult =
-        requestBody.method === 'message/send'
+        requestBody.method === 'SendMessage'
           ? {
               payload: {
                 $case: 'msg',

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -22,12 +22,13 @@ import { FromProto } from '../../../src/types/converters/from_proto.js';
  * Test suite for restHandler - HTTP+JSON/REST transport implementation
  *
  * This suite tests the REST API endpoints following the A2A specification:
- * - GET /v1/extendedAgentCard - Agent card retrieval
- * - POST /v1/message:send - Send message (non-streaming)
- * - POST /v1/message:stream - Send message with SSE streaming
- * - GET /v1/tasks/:taskId - Get task status
- * - POST /v1/tasks/:taskId:cancel - Cancel task
- * - POST /v1/tasks/:taskId:subscribe - Resubscribe to task updates
+ * - GET /extendedAgentCard - Agent card retrieval
+ * - POST /message:send - Send message (non-streaming)
+ * - POST /message:stream - Send message with SSE streaming
+ * - GET /tasks/:taskId - Get task status
+ * - GET /tasks - List tasks
+ * - POST /tasks/:taskId:cancel - Cancel task
+ * - POST /tasks/:taskId:subscribe - Resubscribe to task updates
  * - Push notification config CRUD operations
  */
 describe('restHandler', () => {
@@ -118,9 +119,9 @@ describe('restHandler', () => {
     vi.restoreAllMocks();
   });
 
-  describe('GET /v1/extendedAgentCard', () => {
+  describe('GET /extendedAgentCard', () => {
     it('should return the agent card with 200 OK', async () => {
-      const response = await request(app).get('/v1/extendedAgentCard').expect(200);
+      const response = await request(app).get('/extendedAgentCard').expect(200);
 
       // REST API returns data (format checked by handler)
       expect(mockRequestHandler.getAuthenticatedExtendedAgentCard as Mock).toHaveBeenCalledTimes(1);
@@ -132,19 +133,19 @@ describe('restHandler', () => {
         new RequestMalformedError('Card fetch failed')
       );
 
-      const response = await request(app).get('/v1/extendedAgentCard').expect(400);
+      const response = await request(app).get('/extendedAgentCard').expect(400);
 
       assert.property(response.body, 'name');
       assert.property(response.body, 'message');
     });
   });
 
-  describe('POST /v1/message:send', () => {
+  describe('POST /message:send', () => {
     it('should accept camelCase message and return 201 with Task', async () => {
       const message = ProtoMessage.toJSON(testMessage);
       (mockRequestHandler.sendMessage as Mock).mockResolvedValue(testTask);
 
-      const response = await request(app).post('/v1/message:send').send({ message }).expect(201);
+      const response = await request(app).post('/message:send').send({ message }).expect(201);
 
       expect(mockRequestHandler.sendMessage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -168,11 +169,11 @@ describe('restHandler', () => {
         new RequestMalformedError('Message is required')
       );
 
-      await request(app).post('/v1/message:send').send({ request: null }).expect(400);
+      await request(app).post('/message:send').send({ request: null }).expect(400);
     });
   });
 
-  describe('POST /v1/message:stream', () => {
+  describe('POST /message:stream', () => {
     it('should accept camelCase message and stream via SSE', async () => {
       const message = ProtoMessage.toJSON(testMessage);
       async function* mockStream() {
@@ -181,7 +182,7 @@ describe('restHandler', () => {
       }
       (mockRequestHandler.sendMessageStream as Mock).mockResolvedValue(mockStream());
 
-      const response = await request(app).post('/v1/message:stream').send({ message }).expect(200);
+      const response = await request(app).post('/message:stream').send({ message }).expect(200);
 
       assert.equal(response.headers['content-type'], 'text/event-stream');
 
@@ -211,18 +212,15 @@ describe('restHandler', () => {
         })
       );
 
-      await request(noStreamApp)
-        .post('/v1/message:stream')
-        .send({ request: testMessage })
-        .expect(400);
+      await request(noStreamApp).post('/message:stream').send({ request: testMessage }).expect(400);
     });
   });
 
-  describe('GET /v1/tasks/:taskId', () => {
+  describe('GET /tasks/:taskId', () => {
     it('should return task with 200 OK', async () => {
       (mockRequestHandler.getTask as Mock).mockResolvedValue(testTask);
 
-      const response = await request(app).get('/v1/tasks/task-1').expect(200);
+      const response = await request(app).get('/tasks/task-1').expect(200);
 
       assert.deepEqual(response.body.id, testTask.id);
       // Kind is not present in Proto JSON
@@ -238,7 +236,7 @@ describe('restHandler', () => {
     it('should support historyLength query parameter', async () => {
       (mockRequestHandler.getTask as Mock).mockResolvedValue(testTask);
 
-      await request(app).get('/v1/tasks/task-1?historyLength=10').expect(200);
+      await request(app).get('/tasks/task-1?historyLength=10').expect(200);
 
       expect(mockRequestHandler.getTask as Mock).toHaveBeenCalledWith(
         {
@@ -251,20 +249,20 @@ describe('restHandler', () => {
     });
 
     it('should return 400 if historyLength is invalid', async () => {
-      await request(app).get('/v1/tasks/task-1?historyLength=invalid').expect(400);
+      await request(app).get('/tasks/task-1?historyLength=invalid').expect(400);
     });
 
     it('should return 404 if task is not found', async () => {
       (mockRequestHandler.getTask as Mock).mockRejectedValue(new TaskNotFoundError('task-1'));
 
-      const response = await request(app).get('/v1/tasks/task-1').expect(404);
+      const response = await request(app).get('/tasks/task-1').expect(404);
 
       assert.property(response.body, 'name');
       assert.property(response.body, 'message');
     });
   });
 
-  describe('POST /v1/tasks/:taskId:cancel', () => {
+  describe('POST /tasks/:taskId:cancel', () => {
     it('should cancel task and return 202 Accepted', async () => {
       const cancelledTask = {
         ...testTask,
@@ -272,7 +270,7 @@ describe('restHandler', () => {
       };
       (mockRequestHandler.cancelTask as Mock).mockResolvedValue(cancelledTask);
 
-      const response = await request(app).post('/v1/tasks/task-1:cancel').expect(202);
+      const response = await request(app).post('/tasks/task-1:cancel').expect(202);
 
       assert.deepEqual(response.body.id, cancelledTask.id);
       assert.deepEqual(response.body.status.state, 'TASK_STATE_CANCELED');
@@ -285,7 +283,7 @@ describe('restHandler', () => {
     it('should return 404 if task is not found', async () => {
       (mockRequestHandler.cancelTask as Mock).mockRejectedValue(new TaskNotFoundError('task-1'));
 
-      const response = await request(app).post('/v1/tasks/task-1:cancel').expect(404);
+      const response = await request(app).post('/tasks/task-1:cancel').expect(404);
 
       assert.property(response.body, 'name');
       assert.property(response.body, 'message');
@@ -296,19 +294,19 @@ describe('restHandler', () => {
         new TaskNotCancelableError('task-1')
       );
 
-      const response = await request(app).post('/v1/tasks/task-1:cancel').expect(409);
+      const response = await request(app).post('/tasks/task-1:cancel').expect(409);
 
       assert.property(response.body, 'name');
       assert.property(response.body, 'message');
     });
   });
 
-  describe('GET /v1/tasks', () => {
+  describe('GET /tasks', () => {
     it('should list a single task', async () => {
       const tasks = [testTask];
       (mockRequestHandler.listTasks as Mock).mockResolvedValue({ tasks });
 
-      const response = await request(app).get('/v1/tasks').expect(200);
+      const response = await request(app).get('/tasks').expect(200);
 
       const expectedResponse = [
         {
@@ -329,7 +327,7 @@ describe('restHandler', () => {
       const tasks = [testTask, { ...testTask, id: 'task-2' }];
       (mockRequestHandler.listTasks as Mock).mockResolvedValue({ tasks });
 
-      const response = await request(app).get('/v1/tasks').expect(200);
+      const response = await request(app).get('/tasks').expect(200);
 
       const expectedResponse = [
         {
@@ -355,7 +353,7 @@ describe('restHandler', () => {
     });
   });
 
-  describe('POST /v1/tasks/:taskId:subscribe', () => {
+  describe('POST /tasks/:taskId:subscribe', () => {
     it('should resubscribe to task updates via SSE', async () => {
       async function* mockStream() {
         yield testTask;
@@ -363,7 +361,7 @@ describe('restHandler', () => {
 
       (mockRequestHandler.resubscribe as Mock).mockResolvedValue(mockStream());
 
-      const response = await request(app).post('/v1/tasks/task-1:subscribe').expect(200);
+      const response = await request(app).post('/tasks/task-1:subscribe').expect(200);
 
       assert.equal(response.headers['content-type'], 'text/event-stream');
       expect(mockRequestHandler.resubscribe as Mock).toHaveBeenCalledWith(
@@ -389,7 +387,7 @@ describe('restHandler', () => {
         })
       );
 
-      const response = await request(noStreamApp).post('/v1/tasks/task-1:subscribe').expect(400);
+      const response = await request(noStreamApp).post('/tasks/task-1:subscribe').expect(400);
 
       assert.property(response.body, 'name');
       assert.property(response.body, 'message');
@@ -406,7 +404,7 @@ describe('restHandler', () => {
       authentication: undefined,
     };
 
-    describe('POST /v1/tasks/:taskId/pushNotificationConfigs', () => {
+    describe('POST /tasks/:taskId/pushNotificationConfigs', () => {
       it.each([
         {
           name: 'camelCase',
@@ -430,7 +428,7 @@ describe('restHandler', () => {
         (mockRequestHandler.createTaskPushNotificationConfig as Mock).mockResolvedValue(mockConfig);
 
         const response = await request(app)
-          .post('/v1/tasks/task-1/pushNotificationConfigs')
+          .post('/tasks/task-1/pushNotificationConfigs')
           .send(payload)
           .expect(201);
 
@@ -456,7 +454,7 @@ describe('restHandler', () => {
         );
 
         await request(noPNApp)
-          .post('/v1/tasks/task-1/pushNotificationConfigs')
+          .post('/tasks/task-1/pushNotificationConfigs')
           .send({
             pushNotificationConfig: {
               id: 'config-1',
@@ -469,13 +467,13 @@ describe('restHandler', () => {
       });
     });
 
-    describe('GET /v1/tasks/:taskId/pushNotificationConfigs', () => {
+    describe('GET /tasks/:taskId/pushNotificationConfigs', () => {
       it('should list push notification configs and return 200', async () => {
         const configs = [mockConfig];
         (mockRequestHandler.listTaskPushNotificationConfigs as Mock).mockResolvedValue(configs);
 
         const response = await request(app)
-          .get('/v1/tasks/task-1/pushNotificationConfigs')
+          .get('/tasks/task-1/pushNotificationConfigs')
           .expect(200);
 
         const convertedResult = ListTaskPushNotificationConfigsResponse.fromJSON(
@@ -486,12 +484,12 @@ describe('restHandler', () => {
       });
     });
 
-    describe('GET /v1/tasks/:taskId/pushNotificationConfigs/:configId', () => {
+    describe('GET /tasks/:taskId/pushNotificationConfigs/:configId', () => {
       it('should get specific push notification config and return 200', async () => {
         (mockRequestHandler.getTaskPushNotificationConfig as Mock).mockResolvedValue(mockConfig);
 
         const response = await request(app)
-          .get('/v1/tasks/task-1/pushNotificationConfigs/config-1')
+          .get('/tasks/task-1/pushNotificationConfigs/config-1')
           .expect(200);
 
         // REST API returns camelCase
@@ -513,7 +511,7 @@ describe('restHandler', () => {
         );
 
         const response = await request(app)
-          .get('/v1/tasks/task-1/pushNotificationConfigs/config-1')
+          .get('/tasks/task-1/pushNotificationConfigs/config-1')
           .expect(404);
 
         assert.property(response.body, 'name');
@@ -521,11 +519,11 @@ describe('restHandler', () => {
       });
     });
 
-    describe('DELETE /v1/tasks/:taskId/pushNotificationConfigs/:configId', () => {
+    describe('DELETE /tasks/:taskId/pushNotificationConfigs/:configId', () => {
       it('should delete push notification config and return 204', async () => {
         (mockRequestHandler.deleteTaskPushNotificationConfig as Mock).mockResolvedValue(undefined);
 
-        await request(app).delete('/v1/tasks/task-1/pushNotificationConfigs/config-1').expect(204);
+        await request(app).delete('/tasks/task-1/pushNotificationConfigs/config-1').expect(204);
 
         expect(mockRequestHandler.deleteTaskPushNotificationConfig as Mock).toHaveBeenCalledWith(
           {
@@ -543,7 +541,7 @@ describe('restHandler', () => {
         );
 
         const response = await request(app)
-          .delete('/v1/tasks/task-1/pushNotificationConfigs/config-1')
+          .delete('/tasks/task-1/pushNotificationConfigs/config-1')
           .expect(404);
 
         assert.property(response.body, 'name');
@@ -611,7 +609,7 @@ describe('restHandler', () => {
       },
     ])('should accept $name message parts', async ({ payload }) => {
       (mockRequestHandler.sendMessage as Mock).mockResolvedValue(testTask);
-      await request(app).post('/v1/message:send').send(payload).expect(201);
+      await request(app).post('/message:send').send(payload).expect(201);
     });
   });
 
@@ -647,11 +645,11 @@ describe('restHandler', () => {
       },
     ])('should accept $name configuration fields', async ({ payload }) => {
       (mockRequestHandler.sendMessage as Mock).mockResolvedValue(testTask);
-      await request(app).post('/v1/message:send').send(payload).expect(201);
+      await request(app).post('/message:send').send(payload).expect(201);
 
       const protoMessage = ProtoMessage.toJSON(testMessage);
       await request(app)
-        .post('/v1/message:send')
+        .post('/message:send')
         .send({ message: protoMessage, configuration: payload.configuration })
         .expect(201);
     });
@@ -660,12 +658,12 @@ describe('restHandler', () => {
   describe('Error Handling', () => {
     it('should return 404 for unknown message action (route not matched)', async () => {
       // Unknown actions don't match the route pattern, so Express returns default 404
-      await request(app).post('/v1/message:unknown').send({ request: testMessage }).expect(404);
+      await request(app).post('/message:unknown').send({ request: testMessage }).expect(404);
     });
 
     it('should return 404 for unknown task action (route not matched)', async () => {
       // Unknown actions don't match the route pattern, so Express returns default 404
-      await request(app).post('/v1/tasks/task-1:unknown').expect(404);
+      await request(app).post('/tasks/task-1:unknown').expect(404);
     });
 
     it('should handle internal server errors gracefully', async () => {
@@ -675,7 +673,7 @@ describe('restHandler', () => {
 
       const messageProto = ProtoMessage.toJSON(testMessage);
       const response = await request(app)
-        .post('/v1/message:send')
+        .post('/message:send')
         .send({ message: messageProto })
         .expect(500);
 

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -22,7 +22,7 @@ import { FromProto } from '../../../src/types/converters/from_proto.js';
  * Test suite for restHandler - HTTP+JSON/REST transport implementation
  *
  * This suite tests the REST API endpoints following the A2A specification:
- * - GET /v1/card - Agent card retrieval
+ * - GET /v1/extendedAgentCard - Agent card retrieval
  * - POST /v1/message:send - Send message (non-streaming)
  * - POST /v1/message:stream - Send message with SSE streaming
  * - GET /v1/tasks/:taskId - Get task status
@@ -118,9 +118,9 @@ describe('restHandler', () => {
     vi.restoreAllMocks();
   });
 
-  describe('GET /v1/card', () => {
+  describe('GET /v1/extendedAgentCard', () => {
     it('should return the agent card with 200 OK', async () => {
-      const response = await request(app).get('/v1/card').expect(200);
+      const response = await request(app).get('/v1/extendedAgentCard').expect(200);
 
       // REST API returns data (format checked by handler)
       expect(mockRequestHandler.getAuthenticatedExtendedAgentCard as Mock).toHaveBeenCalledTimes(1);
@@ -132,7 +132,7 @@ describe('restHandler', () => {
         new RequestMalformedError('Card fetch failed')
       );
 
-      const response = await request(app).get('/v1/card').expect(400);
+      const response = await request(app).get('/v1/extendedAgentCard').expect(400);
 
       assert.property(response.body, 'name');
       assert.property(response.body, 'message');

--- a/test/server/jsonrpc_transport_handler.spec.ts
+++ b/test/server/jsonrpc_transport_handler.spec.ts
@@ -106,7 +106,7 @@ describe('JsonRpcTransportHandler', () => {
     it('should handle valid request with string id', async () => {
       const request = {
         jsonrpc: '2.0',
-        method: 'message/send',
+        method: 'SendMessage',
         id: 'abc-123',
         params: {},
       };
@@ -117,7 +117,7 @@ describe('JsonRpcTransportHandler', () => {
     it('should handle valid request with integer id', async () => {
       const request = {
         jsonrpc: '2.0',
-        method: 'message/send',
+        method: 'SendMessage',
         id: 456,
         params: {},
       };
@@ -128,7 +128,7 @@ describe('JsonRpcTransportHandler', () => {
     it('should handle valid request with null id', async () => {
       const request = {
         jsonrpc: '2.0',
-        method: 'message/send',
+        method: 'SendMessage',
         id: null,
         params: {},
       } as any;
@@ -151,7 +151,7 @@ describe('JsonRpcTransportHandler', () => {
       it(`should return an invalid params error if params are ${name}`, async () => {
         const request = {
           jsonrpc: '2.0',
-          method: 'message/send',
+          method: 'SendMessage',
           id: 1,
           params,
         };
@@ -165,7 +165,7 @@ describe('JsonRpcTransportHandler', () => {
     it('should handle valid request with params as dict', async () => {
       const request = {
         jsonrpc: '2.0',
-        method: 'message/send',
+        method: 'SendMessage',
         id: 456,
         params: { this: 'is a dict' },
       };


### PR DESCRIPTION
# Description

Align transport method names with 1.0 spec.

Aligning done based on the spec documentation: https://a2a-protocol.org/latest/specification/#53-method-mapping-reference

Fixes:
- #326
- #327
- #328
