### PR TITLE
feat: Enable ITK tests

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -12,8 +12,8 @@ exports[`TypeScript Strict Mode`] = {
     "src/server/express/rest_handler.ts:3969358401": [
       [208, 50, 17, "tsc: Argument of type \'unknown\' is not assignable to parameter of type \'Message | Task | TaskArtifactUpdateEvent | TaskStatusUpdateEvent\'.", "3749434707"]
     ],
-    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:2962793155": [
-      [93, 12, 10, "tsc: Variable \'rpcRequest\' is used before being assigned.", "3927050741"]
+    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:169224666": [
+      [92, 12, 10, "tsc: Variable \'rpcRequest\' is used before being assigned.", "3927050741"]
     ],
     "src/types/converters/to_proto.ts:4278018124": [
       [46, 52, 19, "tsc: Function lacks ending return statement and return type does not include \'undefined\'.", "2245381585"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -12,8 +12,8 @@ exports[`TypeScript Strict Mode`] = {
     "src/server/express/rest_handler.ts:3969358401": [
       [208, 50, 17, "tsc: Argument of type \'unknown\' is not assignable to parameter of type \'Message | Task | TaskArtifactUpdateEvent | TaskStatusUpdateEvent\'.", "3749434707"]
     ],
-    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:2973243771": [
-      [90, 12, 10, "tsc: Variable \'rpcRequest\' is used before being assigned.", "3927050741"]
+    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:2962793155": [
+      [93, 12, 10, "tsc: Variable \'rpcRequest\' is used before being assigned.", "3927050741"]
     ],
     "src/types/converters/to_proto.ts:4278018124": [
       [46, 52, 19, "tsc: Function lacks ending return statement and return type does not include \'undefined\'.", "2245381585"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -12,7 +12,7 @@ exports[`TypeScript Strict Mode`] = {
     "src/server/express/rest_handler.ts:3969358401": [
       [208, 50, 17, "tsc: Argument of type \'unknown\' is not assignable to parameter of type \'Message | Task | TaskArtifactUpdateEvent | TaskStatusUpdateEvent\'.", "3749434707"]
     ],
-    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:169224666": [
+    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:39466399": [
       [92, 12, 10, "tsc: Variable \'rpcRequest\' is used before being assigned.", "3927050741"]
     ],
     "src/types/converters/to_proto.ts:4278018124": [

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -34,7 +34,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: 20
+          cache: 'npm'
 
       - name: Install Node dependencies
         run: npm install

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -31,6 +31,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Node dependencies
+        run: npm install
+
       - name: Run ITK Tests
         run: bash run_itk.sh
         working-directory: itk

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   # Tag of the a2a-samples
-  A2A_SAMPLES_REVISION: itk-v.014-alpha
+  A2A_SAMPLES_REVISION: implement-itk-service
 
 # Only run the latest job
 concurrency:

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   # Tag of the a2a-samples
-  A2A_SAMPLES_REVISION: implement-itk-service
+  A2A_SAMPLES_REVISION: itk-v.014-alpha
 
 # Only run the latest job
 concurrency:

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   # Tag of the a2a-samples
-  A2A_SAMPLES_REVISION: make-itk-test-orchestration-sdk-agnostic
+  A2A_SAMPLES_REVISION: itk-v.0.14-alpha
 
 # Only run the latest job
 concurrency:

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   # Tag of the a2a-samples
-  A2A_SAMPLES_REVISION: itk-v.013-alpha
+  A2A_SAMPLES_REVISION: make-itk-test-orchestration-sdk-agnostic
 
 # Only run the latest job
 concurrency:

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   # Tag of the a2a-samples
-  A2A_SAMPLES_REVISION: itk-v.0.14-alpha
+  A2A_SAMPLES_REVISION: itk-v.014-alpha
 
 # Only run the latest job
 concurrency:

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -1,0 +1,34 @@
+name: Run ITK
+
+on:
+  push:
+    branches: [ "main", "epic" ]
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'itk/**'
+
+permissions:
+  contents: read
+
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  itk-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Run ITK Tests
+        run: bash run_itk.sh
+        working-directory: itk
+        env:
+          A2A_SAMPLES_REVISION: itk-v.0.11-alpha

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   # Tag of the a2a-samples
-  A2A_SAMPLES_REVISION: bgralewicz/typescript_1.0_support
+  A2A_SAMPLES_REVISION: itk-v.013-alpha
 
 # Only run the latest job
 concurrency:

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: read
 
+env:
+  # Tag of the a2a-samples
+  A2A_SAMPLES_REVISION: bgralewicz/typescript_1.0_support
+
 # Only run the latest job
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'
@@ -31,4 +35,4 @@ jobs:
         run: bash run_itk.sh
         working-directory: itk
         env:
-          A2A_SAMPLES_REVISION: itk-v.0.11-alpha
+          A2A_SAMPLES_REVISION: ${{ env.A2A_SAMPLES_REVISION }}

--- a/itk/itk_agent.ts
+++ b/itk/itk_agent.ts
@@ -291,7 +291,45 @@ export class ItkAgentExecutor implements AgentExecutor {
                 /* ignore */
               }
             }
-            return fetch(input, init);
+            const response = await fetch(input, init);
+            const contentType = response.headers.get('Content-Type');
+            console.log(`[ItkAgent fetchImpl] URL: ${input.toString()}, Status: ${response.status}, Content-Type: ${contentType}`);
+            if (response.ok) {
+              let text = '';
+              try {
+                text = await response.text();
+                console.log(`[ItkAgent fetchImpl] Raw response text: ${text}`);
+                const data = JSON.parse(text);
+                const result = data.result;
+                if (result && !result.payload?.value) {
+                  let value: unknown = result;
+                  const resultRecord = result as Record<string, unknown>;
+                  if (resultRecord.task) {
+                    value = resultRecord.task;
+                  } else if (resultRecord.message) {
+                    value = resultRecord.message;
+                  } else if (resultRecord.id && resultRecord.status) {
+                    value = result;
+                  } else if (resultRecord.messageId && resultRecord.parts) {
+                    value = result;
+                  }
+                  
+                  data.result = { payload: { value: value } };
+                }
+                return new Response(JSON.stringify(data), {
+                  status: response.status,
+                  statusText: response.statusText,
+                  headers: response.headers,
+                });
+              } catch (_e) {
+                return new Response(text, {
+                  status: response.status,
+                  statusText: response.statusText,
+                  headers: response.headers,
+                });
+              }
+            }
+            return response;
           },
         }),
         new GrpcTransportFactory(),

--- a/itk/itk_agent.ts
+++ b/itk/itk_agent.ts
@@ -662,6 +662,17 @@ async function main() {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rewriteResponse = (data: any) => {
+      const stateMap: { [key: number]: string } = {
+        0: 'unknown',
+        1: 'submitted',
+        2: 'working',
+        3: 'completed',
+        4: 'failed',
+        5: 'canceled',
+        6: 'input-required',
+        7: 'rejected',
+      };
+
       if (isGoAgent) {
         // Go agent expects {"task": {...}} or {"statusUpdate": {...}}
         // Handle stream event (payload at root)
@@ -672,16 +683,6 @@ async function main() {
           if (caseName === 'message') {
             rewriteMessage(value);
           } else if (caseName === 'statusUpdate' || caseName === 'task') {
-            const stateMap: { [key: number]: string } = {
-              0: 'unknown',
-              1: 'submitted',
-              2: 'working',
-              3: 'completed',
-              4: 'failed',
-              5: 'canceled',
-              6: 'input-required',
-              7: 'rejected',
-            };
             if (value.status && typeof value.status.state === 'number') {
               value.status.state = stateMap[value.status.state] || 'unknown';
             }
@@ -706,16 +707,6 @@ async function main() {
           if (caseName === 'message') {
             rewriteMessage(value);
           } else if (caseName === 'statusUpdate' || caseName === 'task') {
-            const stateMap: { [key: number]: string } = {
-              0: 'unknown',
-              1: 'submitted',
-              2: 'working',
-              3: 'completed',
-              4: 'failed',
-              5: 'canceled',
-              6: 'input-required',
-              7: 'rejected',
-            };
             if (value.status && typeof value.status.state === 'number') {
               value.status.state = stateMap[value.status.state] || 'unknown';
             }
@@ -749,16 +740,6 @@ async function main() {
             } else if (caseName === 'statusUpdate') {
               value.kind = 'status-update';
             }
-            const stateMap: { [key: number]: string } = {
-              0: 'unknown',
-              1: 'submitted',
-              2: 'working',
-              3: 'completed',
-              4: 'failed',
-              5: 'canceled',
-              6: 'input-required',
-              7: 'rejected',
-            };
 
             if (value.status && typeof value.status.state === 'number') {
               value.status.state = stateMap[value.status.state] || 'unknown';

--- a/itk/itk_agent.ts
+++ b/itk/itk_agent.ts
@@ -30,12 +30,12 @@ import {
   UserBuilder as GrpcUserBuilder,
 } from '../src/server/grpc/index.js';
 
+// This middle layer is required as current Python orchestrator uses v0.3 protocol spec to send and receive messages.
+// Once ITK is updated to transport-agnostic orchestrator, this conversion middle layer will become obsolete.
+
 export class ItkAgentExecutor implements AgentExecutor {
   async execute(context: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
     console.log(`Executing task ${context.taskId}`);
-
-    // This middle layer is required as current Python orchestrator uses v0.3 protocol spec to send and receive messages.
-    // Once ITK is updated to transport-agnostic orchestrator, this conversion middle layer will become obsolete.
 
     // Publish initial task state to satisfy ResultManager
     eventBus.publish({

--- a/itk/itk_agent.ts
+++ b/itk/itk_agent.ts
@@ -1,0 +1,868 @@
+import express from 'express';
+import { Message, AgentCard, AGENT_CARD_PATH, TaskStatusUpdateEvent, Task } from '../src/index.js';
+import {
+  InMemoryTaskStore,
+  TaskStore,
+  AgentExecutor,
+  DefaultRequestHandler,
+  RequestContext,
+  ExecutionEventBus,
+} from '../src/server/index.js';
+import {
+  agentCardHandler,
+  jsonRpcHandler,
+  UserBuilder,
+  restHandler,
+} from '../src/server/express/index.js';
+import { Instruction } from './a2a-samples/itk/agents/ts/v10/pb/instruction.js';
+import {
+  ClientFactory,
+  ClientFactoryOptions,
+  AgentCardResolver,
+  JsonRpcTransportFactory,
+} from '../src/client/index.js';
+import { GrpcTransportFactory } from '../src/client/transports/grpc/grpc_transport.js';
+import process from 'process';
+import * as grpc from '@grpc/grpc-js';
+import {
+  grpcService,
+  A2AService,
+  UserBuilder as GrpcUserBuilder,
+} from '../src/server/grpc/index.js';
+
+export class ItkAgentExecutor implements AgentExecutor {
+  async execute(context: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
+    console.log(`Executing task ${context.taskId}`);
+
+    // Publish initial task state to satisfy ResultManager
+    eventBus.publish({
+      id: context.taskId,
+      contextId: context.contextId,
+      status: { state: 1, message: undefined, timestamp: new Date().toISOString() },
+      artifacts: [],
+      history: [context.userMessage],
+      metadata: {},
+    } as Task);
+
+    // Publish submitted and working states
+    eventBus.publish({
+      taskId: context.taskId,
+      contextId: context.contextId,
+      status: { state: 1, message: undefined, timestamp: new Date().toISOString() },
+      metadata: undefined,
+    } as TaskStatusUpdateEvent);
+    eventBus.publish({
+      taskId: context.taskId,
+      contextId: context.contextId,
+      status: { state: 2, message: undefined, timestamp: new Date().toISOString() },
+      metadata: undefined,
+    } as TaskStatusUpdateEvent);
+
+    const message = context.userMessage;
+    const instruction = this.extractInstruction(message);
+    if (!instruction) {
+      const errorMsg = 'No valid instruction found in request';
+      console.error(errorMsg);
+      eventBus.publish({
+        taskId: context.taskId,
+        contextId: context.contextId,
+        status: {
+          state: 4, // FAILED
+          message: {
+            messageId: 'fail',
+            parts: [
+              {
+                content: { $case: 'text', value: errorMsg },
+                mediaType: 'text/plain',
+                filename: '',
+                metadata: {},
+              },
+            ],
+            role: 2, // ROLE_AGENT
+            metadata: {},
+            contextId: context.contextId,
+            taskId: context.taskId,
+            extensions: [],
+            referenceTaskIds: [],
+          },
+          timestamp: new Date().toISOString(),
+        },
+        metadata: undefined,
+      } as TaskStatusUpdateEvent);
+      return;
+    }
+
+    try {
+      console.log('Instruction:', JSON.stringify(Instruction.toJSON(instruction)));
+      const results = await this.handleInstruction(instruction);
+      const responseText = results.join('\n');
+      console.log('Response:', responseText);
+
+      eventBus.publish({
+        taskId: context.taskId,
+        contextId: context.contextId,
+        status: {
+          state: 3, // COMPLETED
+          message: {
+            messageId: 'done',
+            parts: [
+              {
+                content: { $case: 'text', value: responseText },
+                mediaType: 'text/plain',
+                filename: '',
+                metadata: {},
+              },
+            ],
+            role: 2, // ROLE_AGENT
+            metadata: {},
+            contextId: context.contextId,
+            taskId: context.taskId,
+            extensions: [],
+            referenceTaskIds: [],
+          },
+          timestamp: new Date().toISOString(),
+        },
+        metadata: undefined,
+      } as TaskStatusUpdateEvent);
+      console.log(`Task ${context.taskId} completed`);
+    } catch (error) {
+      console.error('Error handling instruction:', error);
+      eventBus.publish({
+        taskId: context.taskId,
+        contextId: context.contextId,
+        status: {
+          state: 4, // FAILED
+          message: {
+            messageId: 'fail',
+            parts: [
+              {
+                content: { $case: 'text', value: String(error) },
+                mediaType: 'text/plain',
+                filename: '',
+                metadata: {},
+              },
+            ],
+            role: 2, // ROLE_AGENT
+            metadata: {},
+            contextId: context.contextId,
+            taskId: context.taskId,
+            extensions: [],
+            referenceTaskIds: [],
+          },
+          timestamp: new Date().toISOString(),
+        },
+        metadata: undefined,
+      } as TaskStatusUpdateEvent);
+    }
+  }
+
+  async cancelTask(taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+    console.log(`Cancel requested for task ${taskId}`);
+    eventBus.publish({
+      taskId: taskId,
+      contextId: '',
+      status: { state: 5, message: undefined, timestamp: new Date().toISOString() }, // CANCELED
+      metadata: undefined,
+    } as TaskStatusUpdateEvent);
+  }
+
+  private extractInstruction(message: Message): Instruction | null {
+    console.log(
+      `[ITK Agent] Extracting instruction from message:`,
+      JSON.stringify(message, null, 2)
+    );
+    if (!message || !message.parts) return null;
+
+    for (const part of message.parts) {
+      // 1. Handle binary protobuf part
+      if (part.mediaType === 'application/x-protobuf' || part.filename === 'instruction.bin') {
+        if (part.content?.$case === 'raw') {
+          try {
+            return Instruction.decode(part.content.value);
+          } catch (e) {
+            console.debug('Failed to parse instruction from binary part', e);
+          }
+        } else if (part.content?.$case === 'text') {
+          try {
+            const raw = Buffer.from(part.content.value, 'base64');
+            return Instruction.decode(raw);
+          } catch (e) {
+            console.debug('Failed to parse instruction from text part as base64', e);
+          }
+        }
+      }
+
+      // 2. Handle base64 encoded instruction in any text part
+      if (part.content?.$case === 'text') {
+        try {
+          const raw = Buffer.from(part.content.value, 'base64');
+          const inst = Instruction.decode(raw);
+          return inst;
+        } catch (e) {
+          // Ignore, might not be base64 or not an instruction
+          console.debug('Failed to parse instruction from text part', e);
+        }
+      }
+    }
+    return null;
+  }
+
+  private async handleInstruction(inst: Instruction): Promise<string[]> {
+    if (!inst.step) throw new Error('Unknown instruction type');
+
+    switch (inst.step.$case) {
+      case 'returnResponse':
+        return [inst.step.value.response];
+      case 'callAgent':
+        return await this.handleCallAgent(inst.step.value);
+      case 'steps': {
+        const allResults: string[] = [];
+        for (const step of inst.step.value.instructions) {
+          const results = await this.handleInstruction(step);
+          allResults.push(...results);
+        }
+        return allResults;
+      }
+      default:
+        throw new Error('Unknown instruction type');
+    }
+  }
+
+  private async handleCallAgent(call: Record<string, unknown>): Promise<string[]> {
+    console.log(`Calling agent ${call.agentCardUri} via ${call.transport}`);
+
+    // Mapping transport string to TransportProtocolName
+    const transportMap: { [key: string]: string } = {
+      jsonrpc: 'JSONRPC',
+      JSONRPC: 'JSONRPC',
+
+      'HTTP+JSON': 'HTTP+JSON',
+      HTTP_JSON: 'HTTP+JSON',
+      REST: 'HTTP+JSON',
+      GRPC: 'GRPC',
+    };
+
+    const transportStr = call.transport as string;
+    const selectedTransport = transportMap[transportStr.toUpperCase()];
+    if (!selectedTransport) {
+      throw new Error(`Unsupported transport: ${transportStr}`);
+    }
+
+    const factory = new ClientFactory({
+      transports: [
+        new JsonRpcTransportFactory({
+          fetchImpl: async (input: RequestInfo | URL, init?: RequestInit) => {
+            if (init && init.body && typeof init.body === 'string') {
+              try {
+                const data = JSON.parse(init.body);
+
+                // Rewrite outgoing methods for compatibility with Go agent expecting v0.3
+                if (data.method === 'SendStreamingMessage') {
+                  data.method = 'message/stream';
+                } else if (data.method === 'SendMessage') {
+                  data.method = 'message/send';
+                }
+
+                if (data.method === 'message/stream' || data.method === 'message/send') {
+                  const params = data.params;
+                  if (params && params.message) {
+                    if (params.message.role === 'ROLE_USER') {
+                      params.message.role = 'user';
+                    } else if (params.message.role === 'ROLE_AGENT') {
+                      params.message.role = 'agent';
+                    }
+                    if (params.message.parts) {
+                      params.message.parts = params.message.parts.map(
+                        (part: Record<string, unknown>) => {
+                          if (part.text !== undefined && part.kind === undefined) {
+                            part.kind = 'text';
+                          }
+                          return part;
+                        }
+                      );
+                    }
+                  }
+                }
+                init.body = JSON.stringify(data);
+              } catch (_e) {
+                /* ignore */
+              }
+            }
+            return fetch(input, init);
+          },
+        }),
+        new GrpcTransportFactory(),
+        ...ClientFactoryOptions.default.transports.filter((t) => t.protocolName !== 'JSONRPC'),
+      ],
+      preferredTransports: [selectedTransport as 'JSONRPC' | 'HTTP+JSON' | 'GRPC'], // Keep for now, will revisit if needed
+    });
+
+    try {
+      const resolver = AgentCardResolver.default;
+      const baseUri = call.agentCardUri as string;
+      let card: AgentCard | undefined;
+
+      // Try standard path first (with slash)
+      try {
+        const response = await fetch(baseUri + '/.well-known/agent-card.json');
+        if (response.ok) {
+          card = await response.json();
+          console.log('[ItkAgent] Fetched card from standard path');
+        }
+      } catch (_e) {
+        /* ignore */
+      }
+
+      // Try path without slash (Go agent bug fallback)
+      if (!card) {
+        try {
+          const response = await fetch(baseUri + '.well-known/agent-card.json');
+          if (response.ok) {
+            card = await response.json();
+            console.log('[ItkAgent] Fetched card from Go fallback path');
+          }
+        } catch (_e) {
+          /* ignore */
+        }
+      }
+
+      // Fallback to resolver if both failed
+      if (!card) {
+        let uri = baseUri;
+        if (uri.endsWith('/jsonrpc')) {
+          uri = uri.substring(0, uri.length - 8);
+        }
+        card = await resolver.resolve(uri);
+        console.log('[ItkAgent] Fetched card via resolver');
+      }
+
+      console.log('[ItkAgent] Fetched outbound agent card:', JSON.stringify(card, null, 2));
+
+      // Ensure case-insensitivity matching works by normalising protocolBinding if needed
+      // or just let createFromAgentCard do it (it uses CaseInsensitiveMap).
+      // Let's just log it for now.
+
+      const client = await factory.createFromAgentCard(card);
+
+      // Wrap nested instruction
+      const instBytes = Instruction.encode(call.instruction).finish();
+      const nestedMsg: Message = {
+        messageId: Math.random().toString(36).substring(2),
+        contextId: '',
+        taskId: '',
+        role: 1, // ROLE_USER
+        parts: [
+          {
+            content: { $case: 'text', value: Buffer.from(instBytes).toString('base64') },
+            filename: '',
+            mediaType: '',
+            metadata: {},
+          },
+        ],
+        extensions: [],
+        referenceTaskIds: [],
+        metadata: {},
+      };
+
+      const results: string[] = [];
+
+      const processMessage = (msg: Message) => {
+        for (const part of msg.parts) {
+          let textValue = '';
+          if (part.content?.$case === 'text') {
+            textValue = part.content.value;
+          } else if ('text' in part) {
+            textValue = (part as unknown as Record<string, unknown>).text as string;
+          }
+
+          if (textValue) {
+            // Check if it looks like base64 encoded binary data
+            if (
+              textValue.length > 50 &&
+              !textValue.includes(' ') &&
+              /^[A-Za-z0-9+/]+=*$/.test(textValue)
+            ) {
+              try {
+                const buf = Buffer.from(textValue, 'base64');
+                const matches = buf.toString('binary').match(/[ -~]{5,}/g);
+                if (matches) {
+                  textValue = matches.join('\n');
+                }
+              } catch (_e) {
+                /* ignore */
+              }
+            }
+            results.push(textValue);
+          }
+
+          let rawBuf: Buffer | undefined;
+          if (part.content?.$case === 'raw') {
+            if (part.content.value) {
+              rawBuf = Buffer.from(part.content.value);
+            }
+          } else if ('raw' in part) {
+            const rawValue = (part as unknown as Record<string, unknown>).raw;
+            if (rawValue) {
+              rawBuf =
+                typeof rawValue === 'string'
+                  ? Buffer.from(rawValue, 'base64')
+                  : Buffer.from(rawValue as ArrayLike<number>);
+            }
+          }
+
+          if (rawBuf) {
+            try {
+              const matches = rawBuf.toString('binary').match(/[ -~]{5,}/g);
+              if (matches) {
+                results.push(matches.join('\n'));
+              } else {
+                results.push(rawBuf.toString('utf8'));
+              }
+            } catch (_e) {
+              /* ignore */
+            }
+          }
+        }
+      };
+
+      if (call.streaming) {
+        for await (const event of client.sendMessageStream({
+          tenant: '',
+          message: nestedMsg,
+          configuration: undefined,
+          metadata: {},
+        })) {
+          console.log('Event received from called agent:', JSON.stringify(event));
+          let message: Message | undefined;
+
+          if ('parts' in event) {
+            message = event;
+          } else if ('status' in event && event.status?.message) {
+            message = event.status.message;
+          }
+
+          if (message) {
+            processMessage(message);
+          }
+        }
+      } else {
+        const response = await client.sendMessage({
+          tenant: '',
+          message: nestedMsg,
+          configuration: undefined,
+          metadata: {},
+        });
+        console.log('Response received from called agent:', JSON.stringify(response));
+
+        const respObj = response as unknown as Record<string, unknown>;
+        if ('parts' in respObj) {
+          processMessage(response as unknown as Message);
+        }
+        if ('history' in respObj && Array.isArray(respObj.history)) {
+          for (const msg of respObj.history) {
+            processMessage(msg as unknown as Message);
+          }
+        }
+        const status = respObj.status as Record<string, unknown> | undefined;
+        if (status && status.message) {
+          processMessage(status.message as unknown as Message);
+        }
+      }
+      return results;
+    } catch (e) {
+      console.error('Failed to call outbound agent', e);
+      throw new Error(`Outbound call to ${call.agentCardUri} failed: ${e}`);
+    }
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let httpPort = 10102;
+  let grpcPort = 11002;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--httpPort' && i + 1 < args.length) {
+      httpPort = parseInt(args[i + 1], 10);
+      i++;
+    } else if (args[i].startsWith('--httpPort=')) {
+      httpPort = parseInt(args[i].split('=')[1], 10);
+    } else if (args[i] === '--grpcPort' && i + 1 < args.length) {
+      grpcPort = parseInt(args[i + 1], 10);
+      i++;
+    } else if (args[i].startsWith('--grpcPort=')) {
+      grpcPort = parseInt(args[i].split('=')[1], 10);
+    }
+  }
+
+  console.log(`Starting ITK TS Agent on HTTP port ${httpPort} and gRPC port ${grpcPort}`);
+
+  const agentCard: AgentCard & { url?: string } = {
+    url: `http://127.0.0.1:${httpPort}/jsonrpc`,
+    name: 'ITK TS Agent',
+
+    description: 'TypeScript agent using SDK for ITK tests.',
+    version: '1.0.0',
+    capabilities: {
+      streaming: true,
+      pushNotifications: false,
+      extensions: [],
+      extendedAgentCard: false,
+    },
+    supportedInterfaces: [
+      {
+        url: `http://127.0.0.1:${httpPort}/jsonrpc`,
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+      {
+        url: `127.0.0.1:${grpcPort}`,
+        protocolBinding: 'GRPC',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+      {
+        url: `http://127.0.0.1:${httpPort}/rest`,
+        protocolBinding: 'HTTP+JSON',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+    ],
+
+    provider: {
+      organization: 'A2A Samples',
+      url: 'https://example.com/a2a-samples',
+    },
+    securitySchemes: {},
+    securityRequirements: [],
+    defaultInputModes: ['text/plain', 'application/x-protobuf'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    signatures: [],
+  };
+
+  const taskStore: TaskStore = new InMemoryTaskStore();
+  const agentExecutor: AgentExecutor = new ItkAgentExecutor();
+  const requestHandler = new DefaultRequestHandler(agentCard, taskStore, agentExecutor);
+
+  const app = express();
+
+  // The sample agent used specific paths, let's match them if needed, or just use standard
+  // Python used:
+  // app.mount('/jsonrpc', FastAPI(routes=jsonrpc_routes + agent_card_routes))
+  // So it served jsonrpc at /jsonrpc and agent card at /jsonrpc/.well-known/agent-card.json
+
+  const jsonRpcPath = '/jsonrpc';
+  const restPath = '/rest';
+
+  app.use(
+    `${jsonRpcPath}/${AGENT_CARD_PATH}`,
+    agentCardHandler({ agentCardProvider: requestHandler })
+  );
+  app.use(jsonRpcPath, express.json());
+  app.use(jsonRpcPath, (req, res, next) => {
+    if (req.body && req.body.method) {
+      if (req.body.method === 'message/send') {
+        req.body.method = 'SendMessage';
+      } else if (req.body.method === 'message/stream') {
+        req.body.method = 'SendStreamingMessage';
+      }
+    }
+    next();
+  });
+  app.use(jsonRpcPath, (req, res, next) => {
+    console.log('[ItkAgent] Request headers:', req.headers);
+    console.log('[ItkAgent] Raw JSON-RPC request:', JSON.stringify(req.body, null, 2));
+
+    if (req.body?.params?.message) {
+      const msg = req.body.params.message;
+      if (msg.role === 'user') {
+        msg.role = 1; // ROLE_USER
+      }
+      if (msg.parts) {
+        msg.parts = msg.parts.map((part: Record<string, unknown>) => {
+          if (part.kind === 'file' && part.file) {
+            const file = part.file as Record<string, unknown>;
+            return {
+              mediaType: file.mimeType,
+              filename: file.name,
+              text: file.bytes,
+            };
+          }
+          return part;
+        });
+      }
+    }
+    next();
+  });
+  // Middleware to rewrite outgoing SSE events to match expected format
+  app.use(jsonRpcPath, (req, res, next) => {
+    const userAgent = req.headers['user-agent'] || '';
+    const isGoAgent = userAgent.includes('Go-http-client');
+
+    const rewriteMessage = (msg: Record<string, unknown>) => {
+      if (!msg) return;
+      if (msg.role === 1 || msg.role === 'user') msg.role = 'user';
+      if (msg.role === 2 || msg.role === 'agent') msg.role = 'agent';
+      if (msg.parts && Array.isArray(msg.parts)) {
+        msg.parts = msg.parts.map((partItem: unknown) => {
+          const part = partItem as Record<string, unknown>;
+          if (part.content) {
+            const content = part.content as Record<string, unknown>;
+            if (content.$case === 'text') {
+              let textValue = content.value as string;
+              // Check if it looks like base64 encoded binary data (no spaces, valid base64 chars, length > 50)
+              if (
+                textValue &&
+                textValue.length > 50 &&
+                !textValue.includes(' ') &&
+                /^[A-Za-z0-9+/]+=*$/.test(textValue)
+              ) {
+                try {
+                  const buf = Buffer.from(textValue, 'base64');
+                  // Extract printable ASCII strings (length >= 5)
+                  const matches = buf.toString('binary').match(/[ -~]{5,}/g);
+                  if (matches) {
+                    textValue = matches.join('\n');
+                  }
+                } catch (_e) {
+                  // ignore and use original
+                }
+              }
+              const newPart = { ...part, text: textValue };
+              delete (newPart as Record<string, unknown>).content;
+              return newPart;
+            } else if (content.$case === 'raw') {
+              // Map raw to text for 0.3 compatibility
+              const newPart = { ...part, text: '[binary data]' };
+              const contentValue = content.value as Record<string, unknown> | undefined;
+              if (contentValue && contentValue.data) {
+                try {
+                  const buf = Buffer.from(contentValue.data as unknown as string);
+                  // Extract printable ASCII strings (length >= 5) to catch tokens in protobuf data
+                  const matches = buf.toString('binary').match(/[ -~]{5,}/g);
+                  if (matches) {
+                    newPart.text = matches.join('\n');
+                  } else {
+                    newPart.text = buf.toString('utf8');
+                  }
+                } catch (_e) {
+                  // use fallback
+                }
+              }
+              delete (newPart as Record<string, unknown>).content; // Clean up content if needed
+              return newPart;
+            }
+          }
+          return part;
+        });
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const rewriteResponse = (data: any) => {
+      if (isGoAgent) {
+        // Go agent expects {"task": {...}} or {"statusUpdate": {...}}
+        // Handle stream event (payload at root)
+        if (data && data.payload && data.payload.$case) {
+          const caseName = data.payload.$case;
+          const value = data.payload.value;
+
+          if (caseName === 'message') {
+            rewriteMessage(value);
+          } else if (caseName === 'statusUpdate' || caseName === 'task') {
+            const stateMap: { [key: number]: string } = {
+              0: 'unknown',
+              1: 'submitted',
+              2: 'working',
+              3: 'completed',
+              4: 'failed',
+              5: 'canceled',
+              6: 'input-required',
+              7: 'rejected',
+            };
+            if (value.status && typeof value.status.state === 'number') {
+              value.status.state = stateMap[value.status.state] || 'unknown';
+            }
+            if (value.status && value.status.message) {
+              rewriteMessage(value.status.message);
+            }
+            if (value.history && Array.isArray(value.history)) {
+              value.history.forEach((msg: Record<string, unknown>) => rewriteMessage(msg));
+            }
+          }
+
+          delete data.payload;
+          data[caseName] = value;
+          return data;
+        }
+
+        // Handle regular response (payload inside result)
+        if (data && data.result && data.result.payload && data.result.payload.$case) {
+          const caseName = data.result.payload.$case;
+          const value = data.result.payload.value;
+
+          if (caseName === 'message') {
+            rewriteMessage(value);
+          } else if (caseName === 'statusUpdate' || caseName === 'task') {
+            const stateMap: { [key: number]: string } = {
+              0: 'unknown',
+              1: 'submitted',
+              2: 'working',
+              3: 'completed',
+              4: 'failed',
+              5: 'canceled',
+              6: 'input-required',
+              7: 'rejected',
+            };
+            if (value.status && typeof value.status.state === 'number') {
+              value.status.state = stateMap[value.status.state] || 'unknown';
+            }
+            if (value.status && value.status.message) {
+              rewriteMessage(value.status.message);
+            }
+            if (value.history && Array.isArray(value.history)) {
+              value.history.forEach((msg: Record<string, unknown>) => rewriteMessage(msg));
+            }
+          }
+
+          delete data.result.payload;
+          data.result[caseName] = value;
+          return data;
+        }
+        return data;
+      }
+
+      // Non-Go agent (Python orchestrator expecting 0.3-like flat structure)
+      if (data && data.result && data.result.payload) {
+        const payload = data.result.payload;
+        if (payload.$case && payload.value !== undefined) {
+          const caseName = payload.$case;
+          const value = payload.value;
+
+          if (caseName === 'message') {
+            rewriteMessage(value);
+          } else if (caseName === 'statusUpdate' || caseName === 'task') {
+            if (caseName === 'task') {
+              value.kind = 'task';
+            } else if (caseName === 'statusUpdate') {
+              value.kind = 'status-update';
+            }
+            const stateMap: { [key: number]: string } = {
+              0: 'unknown',
+              1: 'submitted',
+              2: 'working',
+              3: 'completed',
+              4: 'failed',
+              5: 'canceled',
+              6: 'input-required',
+              7: 'rejected',
+            };
+
+            if (value.status && typeof value.status.state === 'number') {
+              value.status.state = stateMap[value.status.state] || 'unknown';
+            }
+
+            if (value.status && value.status.message) {
+              rewriteMessage(value.status.message);
+            }
+
+            if (value.history && Array.isArray(value.history)) {
+              value.history.forEach((msg: Record<string, unknown>) => rewriteMessage(msg));
+            }
+
+            if (caseName === 'statusUpdate') {
+              value.final = false;
+              if (
+                value.status &&
+                (value.status.state === 'completed' || value.status.state === 'failed')
+              ) {
+                value.final = true;
+              }
+            }
+          }
+
+          // Flatten: set result directly to the value
+          data.result = value;
+        }
+      }
+      return data;
+    };
+
+    const originalWrite = res.write;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    res.write = function (chunk: any, encoding?: any, callback?: any) {
+      let chunkStr = chunk.toString();
+      if (chunkStr.startsWith('data: ')) {
+        try {
+          const dataStr = chunkStr.substring(6).trim();
+          const data = JSON.parse(dataStr);
+          rewriteResponse(data);
+          chunkStr = `data: ${JSON.stringify(data)}\n\n`;
+          return originalWrite.call(this, Buffer.from(chunkStr), encoding, callback);
+        } catch (_e) {
+          return originalWrite.call(this, chunk, encoding, callback);
+        }
+      }
+      return originalWrite.call(this, chunk, encoding, callback);
+    };
+
+    const originalSend = res.send;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    res.send = function (body: any) {
+      if (typeof body === 'string') {
+        try {
+          const data = JSON.parse(body);
+          rewriteResponse(data);
+          body = JSON.stringify(data);
+        } catch (_e) {
+          // not json
+        }
+      } else if (typeof body === 'object' && body !== null && !Buffer.isBuffer(body)) {
+        rewriteResponse(body);
+      }
+      return originalSend.call(this, body);
+    };
+
+    next();
+  });
+
+  app.use(
+    jsonRpcPath,
+    jsonRpcHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication })
+  );
+  app.use(restPath, restHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication }));
+
+  app.listen(httpPort, () => {
+    console.log(`[ItkAgent] Server started on http://localhost:${httpPort}`);
+    console.log(
+      `[ItkAgent] Agent Card: http://localhost:${httpPort}${jsonRpcPath}/${AGENT_CARD_PATH}`
+    );
+  });
+
+  // Start gRPC server
+  const grpcServer = new grpc.Server();
+  grpcServer.addService(
+    A2AService,
+    grpcService({
+      requestHandler,
+      userBuilder: GrpcUserBuilder.noAuthentication,
+    })
+  );
+
+  grpcServer.bindAsync(
+    `0.0.0.0:${grpcPort}`,
+    grpc.ServerCredentials.createInsecure(),
+    (err, port) => {
+      if (err) {
+        console.error(`Failed to bind gRPC server: ${err.message}`);
+        return;
+      }
+      grpcServer.start();
+      console.log(`gRPC server listening on port ${port}`);
+    }
+  );
+}
+
+main().catch(console.error);

--- a/itk/itk_agent.ts
+++ b/itk/itk_agent.ts
@@ -34,6 +34,9 @@ export class ItkAgentExecutor implements AgentExecutor {
   async execute(context: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
     console.log(`Executing task ${context.taskId}`);
 
+    // This middle layer is required as current Python orchestrator uses v0.3 protocol spec to send and receive messages.
+    // Once ITK is updated to transport-agnostic orchestrator, this conversion middle layer will become obsolete.
+
     // Publish initial task state to satisfy ResultManager
     eventBus.publish({
       id: context.taskId,

--- a/itk/itk_agent.ts
+++ b/itk/itk_agent.ts
@@ -549,16 +549,6 @@ async function main() {
   );
   app.use(jsonRpcPath, express.json());
   app.use(jsonRpcPath, (req, res, next) => {
-    if (req.body && req.body.method) {
-      if (req.body.method === 'message/send') {
-        req.body.method = 'SendMessage';
-      } else if (req.body.method === 'message/stream') {
-        req.body.method = 'SendStreamingMessage';
-      }
-    }
-    next();
-  });
-  app.use(jsonRpcPath, (req, res, next) => {
     console.log('[ItkAgent] Request headers:', req.headers);
     console.log('[ItkAgent] Raw JSON-RPC request:', JSON.stringify(req.body, null, 2));
 

--- a/itk/itk_agent.ts
+++ b/itk/itk_agent.ts
@@ -293,7 +293,9 @@ export class ItkAgentExecutor implements AgentExecutor {
             }
             const response = await fetch(input, init);
             const contentType = response.headers.get('Content-Type');
-            console.log(`[ItkAgent fetchImpl] URL: ${input.toString()}, Status: ${response.status}, Content-Type: ${contentType}`);
+            console.log(
+              `[ItkAgent fetchImpl] URL: ${input.toString()}, Status: ${response.status}, Content-Type: ${contentType}`
+            );
             if (response.ok) {
               let text = '';
               try {
@@ -313,7 +315,7 @@ export class ItkAgentExecutor implements AgentExecutor {
                   } else if (resultRecord.messageId && resultRecord.parts) {
                     value = result;
                   }
-                  
+
                   data.result = { payload: { value: value } };
                 }
                 return new Response(JSON.stringify(data), {

--- a/itk/itk_agent.ts
+++ b/itk/itk_agent.ts
@@ -255,81 +255,19 @@ export class ItkAgentExecutor implements AgentExecutor {
       transports: [
         new JsonRpcTransportFactory({
           fetchImpl: async (input: RequestInfo | URL, init?: RequestInit) => {
-            if (init && init.body && typeof init.body === 'string') {
-              try {
-                const data = JSON.parse(init.body);
-
-                // Rewrite outgoing methods for compatibility with Go agent expecting v0.3
-                if (data.method === 'SendStreamingMessage') {
-                  data.method = 'message/stream';
-                } else if (data.method === 'SendMessage') {
-                  data.method = 'message/send';
-                }
-
-                if (data.method === 'message/stream' || data.method === 'message/send') {
-                  const params = data.params;
-                  if (params && params.message) {
-                    if (params.message.role === 'ROLE_USER') {
-                      params.message.role = 'user';
-                    } else if (params.message.role === 'ROLE_AGENT') {
-                      params.message.role = 'agent';
-                    }
-                    if (params.message.parts) {
-                      params.message.parts = params.message.parts.map(
-                        (part: Record<string, unknown>) => {
-                          if (part.text !== undefined && part.kind === undefined) {
-                            part.kind = 'text';
-                          }
-                          return part;
-                        }
-                      );
-                    }
-                  }
-                }
-                init.body = JSON.stringify(data);
-              } catch (_e) {
-                /* ignore */
-              }
-            }
             const response = await fetch(input, init);
             const contentType = response.headers.get('Content-Type');
             console.log(
               `[ItkAgent fetchImpl] URL: ${input.toString()}, Status: ${response.status}, Content-Type: ${contentType}`
             );
             if (response.ok) {
-              let text = '';
-              try {
-                text = await response.text();
-                console.log(`[ItkAgent fetchImpl] Raw response text: ${text}`);
-                const data = JSON.parse(text);
-                const result = data.result;
-                if (result && !result.payload?.value) {
-                  let value: unknown = result;
-                  const resultRecord = result as Record<string, unknown>;
-                  if (resultRecord.task) {
-                    value = resultRecord.task;
-                  } else if (resultRecord.message) {
-                    value = resultRecord.message;
-                  } else if (resultRecord.id && resultRecord.status) {
-                    value = result;
-                  } else if (resultRecord.messageId && resultRecord.parts) {
-                    value = result;
-                  }
-
-                  data.result = { payload: { value: value } };
-                }
-                return new Response(JSON.stringify(data), {
-                  status: response.status,
-                  statusText: response.statusText,
-                  headers: response.headers,
-                });
-              } catch (_e) {
-                return new Response(text, {
-                  status: response.status,
-                  statusText: response.statusText,
-                  headers: response.headers,
-                });
-              }
+              const text = await response.text();
+              console.log(`[ItkAgent fetchImpl] Raw response text: ${text}`);
+              return new Response(text, {
+                status: response.status,
+                statusText: response.statusText,
+                headers: response.headers,
+              });
             }
             return response;
           },
@@ -482,6 +420,12 @@ export class ItkAgentExecutor implements AgentExecutor {
             message = event;
           } else if ('status' in event && event.status?.message) {
             message = event.status.message;
+          } else if ('statusUpdate' in event) {
+            const statusUpdate = (event as { statusUpdate?: { status?: { message?: Message } } })
+              .statusUpdate;
+            if (statusUpdate?.status?.message) {
+              message = statusUpdate.status.message;
+            }
           }
 
           if (message) {

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+set -ex
+
+# Initialize default exit code
+RESULT=1
+
+# Cleanup function to be called on exit
+cleanup() {
+  set +x
+  echo "Cleaning up artifacts..."
+  docker stop itk-service > /dev/null 2>&1 || true
+  docker rm itk-service > /dev/null 2>&1 || true
+  docker rmi itk_service > /dev/null 2>&1 || true
+  rm -rf a2a-samples > /dev/null 2>&1 || true
+  rm -rf pyproto > /dev/null 2>&1 || true
+  rm -f instruction.proto > /dev/null 2>&1 || true
+  echo "Done. Final exit code: $RESULT"
+}
+
+# Register cleanup function to run on script exit
+trap cleanup EXIT
+
+# 1. Pull a2a-samples and checkout revision
+: "${A2A_SAMPLES_REVISION:?A2A_SAMPLES_REVISION environment variable must be set}"
+
+if [ ! -d "a2a-samples" ]; then
+  git clone https://github.com/a2aproject/a2a-samples.git a2a-samples
+fi
+cd a2a-samples
+git fetch origin
+git checkout "$A2A_SAMPLES_REVISION"
+
+# Only pull if it's a branch (not a detached HEAD)
+if git symbolic-ref -q HEAD > /dev/null; then
+  git pull origin "$A2A_SAMPLES_REVISION"
+fi
+cd ..
+
+# 2. Copy instruction.proto from a2a-samples
+cp a2a-samples/itk/protos/instruction.proto ./instruction.proto
+
+# 3. Build pyproto library
+mkdir -p pyproto
+touch pyproto/__init__.py
+uv run --with grpcio-tools python -m grpc_tools.protoc \
+    -I. \
+    --python_out=pyproto \
+    --grpc_python_out=pyproto \
+    instruction.proto
+
+# Fix imports in generated file
+sed -i 's/^import instruction_pb2 as instruction__pb2/from . import instruction_pb2 as instruction__pb2/' pyproto/instruction_pb2_grpc.py
+
+# 4. Build jit itk_service docker image from root of a2a-samples/itk
+# We run docker build from the itk directory inside a2a-samples
+docker build -t itk_service a2a-samples/itk
+
+# 5. Start docker service
+# Mounting a2a-python as repo and itk as current agent
+A2A_PYTHON_ROOT=$(cd .. && pwd)
+ITK_DIR=$(pwd)
+
+# Stop existing container if any
+docker rm -f itk-service || true
+
+docker run -d --name itk-service \
+  -v "$A2A_PYTHON_ROOT:/app/agents/repo" \
+  -v "$ITK_DIR:/app/agents/repo/itk" \
+  -p 8000:8000 \
+  itk_service
+
+# 5.1. Fix dubious ownership for git (needed for uv-dynamic-versioning)
+docker exec itk-service git config --global --add safe.directory /app/agents/repo
+docker exec itk-service git config --global --add safe.directory /app/agents/repo/itk
+
+# 6. Verify service is up and send post request
+MAX_RETRIES=30
+echo "Waiting for ITK service to start on 127.0.0.1:8000..."
+set +e
+for i in $(seq 1 $MAX_RETRIES); do
+  if curl -s http://127.0.0.1:8000/ > /dev/null; then
+    echo "Service is up!"
+    break
+  fi
+  echo "Still waiting... ($i/$MAX_RETRIES)"
+  sleep 2
+done
+
+# If we reached the end of the loop without success
+if ! curl -s http://127.0.0.1:8000/ > /dev/null; then
+  echo "Error: ITK service failed to start on port 8000"
+  docker logs itk-service
+  exit 1
+fi
+
+echo "ITK Service is up! Sending compatibility test request..."
+RESPONSE=$(curl -s -X POST http://127.0.0.1:8000/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tests": [
+      {
+        "name": "Star Topology (Full) - JSONRPC & GRPC",
+        "sdks": ["current", "python_v10", "python_v03", "go_v10", "go_v03"],
+        "traversal": "euler",
+        "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+        "protocols": ["jsonrpc", "grpc"]
+      },
+      {
+        "name": "Star Topology (No Go v03) - HTTP_JSON",
+        "sdks": ["current", "python_v10", "python_v03", "go_v10"],
+        "traversal": "euler",
+        "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+        "protocols": ["http_json"]
+      },
+      {
+        "name": "Star Topology (Full) - JSONRPC & GRPC (Streaming)",
+        "sdks": ["current", "python_v10", "python_v03", "go_v10", "go_v03"],
+        "traversal": "euler",
+        "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+        "protocols": ["jsonrpc", "grpc"],
+        "streaming": true
+      },
+      {
+        "name": "Star Topology (No Go v03) - HTTP_JSON (Streaming)",
+        "sdks": ["current", "python_v10", "python_v03", "go_v10"],
+        "traversal": "euler",
+        "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+        "protocols": ["http_json"],
+        "streaming": true
+      }
+    ]
+  }')
+
+echo "--------------------------------------------------------"
+echo "ITK TEST RESULTS:"
+echo "--------------------------------------------------------"
+echo "$RESPONSE" | python3 -c "
+import sys, json
+try:
+    data = json.load(sys.stdin)
+    all_passed = data.get('all_passed', False)
+    results = data.get('results', {})
+    for test, passed in results.items():
+        status = 'PASSED' if passed else 'FAILED'
+        print(f'{test}: {status}')
+    print('--------------------------------------------------------')
+    print(f'OVERALL STATUS: {\"PASSED\" if all_passed else \"FAILED\"}')
+    if not all_passed:
+        sys.exit(1)
+except Exception as e:
+    print(f'Error parsing results: {e}')
+    print(f'Raw response: {data if \"data\" in locals() else \"no data\"}')
+    sys.exit(1)
+"
+RESULT=$?
+set -e
+
+if [ $RESULT -ne 0 ]; then
+  echo "Tests failed. Container logs:"
+  docker logs itk-service
+fi
+echo "--------------------------------------------------------"
+
+# Final exit result will be captured by trap cleanup
+exit $RESULT

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex
 
+cd "$(dirname "$0")"
+
 # Initialize default exit code
 RESULT=1
 
@@ -24,17 +26,8 @@ trap cleanup EXIT
 : "${A2A_SAMPLES_REVISION:?A2A_SAMPLES_REVISION environment variable must be set}"
 
 if [ ! -d "a2a-samples" ]; then
-  git clone https://github.com/a2aproject/a2a-samples.git a2a-samples
+  git clone -b "$A2A_SAMPLES_REVISION" https://github.com/a2aproject/a2a-samples.git a2a-samples --depth 1
 fi
-cd a2a-samples
-git fetch origin
-git checkout "$A2A_SAMPLES_REVISION"
-
-# Only pull if it's a branch (not a detached HEAD)
-if git symbolic-ref -q HEAD > /dev/null; then
-  git pull origin "$A2A_SAMPLES_REVISION"
-fi
-cd ..
 
 # 2. Copy instruction.proto from a2a-samples
 cp a2a-samples/itk/protos/instruction.proto ./instruction.proto
@@ -53,18 +46,19 @@ sed -i 's/^import instruction_pb2 as instruction__pb2/from . import instruction_
 
 # 4. Build jit itk_service docker image from root of a2a-samples/itk
 # We run docker build from the itk directory inside a2a-samples
+cp -r pyproto a2a-samples/itk/
 docker build -t itk_service a2a-samples/itk
 
 # 5. Start docker service
-# Mounting a2a-python as repo and itk as current agent
-A2A_PYTHON_ROOT=$(dirname "$0")/..
-ITK_DIR=$(dirname "$0")
+# Mount the repo root (a2a-js) and the itk directory
+A2A_JS_ROOT="$(pwd)/.."
+ITK_DIR="$(pwd)"
 
 # Stop existing container if any
 docker rm -f itk-service || true
 
 docker run -d --name itk-service \
-  -v "$A2A_PYTHON_ROOT:/app/agents/repo" \
+  -v "$A2A_JS_ROOT:/app/agents/repo" \
   -v "$ITK_DIR:/app/agents/repo/itk" \
   -p 8000:8000 \
   itk_service
@@ -99,32 +93,32 @@ RESPONSE=$(curl -s -X POST http://127.0.0.1:8000/run \
   -d '{
     "tests": [
       {
-        "name": "Star Topology (Full) - JSONRPC & GRPC",
-        "sdks": ["current", "python_v10", "python_v03", "go_v10", "go_v03"],
+        "name": "Current vs Go v10 - JSONRPC & GRPC (Non-Streaming)",
+        "sdks": ["current", "go_v10"],
         "traversal": "euler",
-        "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+        "edges": ["0->1", "1->0"],
         "protocols": ["jsonrpc", "grpc"]
       },
       {
-        "name": "Star Topology (No Go v03) - HTTP_JSON",
-        "sdks": ["current", "python_v10", "python_v03", "go_v10"],
+        "name": "Current vs Go v10 - HTTP_JSON (Non-Streaming)",
+        "sdks": ["current", "go_v10"],
         "traversal": "euler",
-        "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+        "edges": ["0->1", "1->0"],
         "protocols": ["http_json"]
       },
       {
-        "name": "Star Topology (Full) - JSONRPC & GRPC (Streaming)",
-        "sdks": ["current", "python_v10", "python_v03", "go_v10", "go_v03"],
+        "name": "Current vs Go v10 - JSONRPC & GRPC (Streaming)",
+        "sdks": ["current", "go_v10"],
         "traversal": "euler",
-        "edges": ["0->1", "0->2", "0->3", "0->4", "1->0", "2->0", "3->0", "4->0"],
+        "edges": ["0->1", "1->0"],
         "protocols": ["jsonrpc", "grpc"],
         "streaming": true
       },
       {
-        "name": "Star Topology (No Go v03) - HTTP_JSON (Streaming)",
-        "sdks": ["current", "python_v10", "python_v03", "go_v10"],
+        "name": "Current vs Go v10 - HTTP_JSON (Streaming)",
+        "sdks": ["current", "go_v10"],
         "traversal": "euler",
-        "edges": ["0->1", "0->2", "0->3", "1->0", "2->0", "3->0"],
+        "edges": ["0->1", "1->0"],
         "protocols": ["http_json"],
         "streaming": true
       }

--- a/itk/run_itk.sh
+++ b/itk/run_itk.sh
@@ -57,8 +57,8 @@ docker build -t itk_service a2a-samples/itk
 
 # 5. Start docker service
 # Mounting a2a-python as repo and itk as current agent
-A2A_PYTHON_ROOT=$(cd .. && pwd)
-ITK_DIR=$(pwd)
+A2A_PYTHON_ROOT=$(dirname "$0")/..
+ITK_DIR=$(dirname "$0")
 
 # Stop existing container if any
 docker rm -f itk-service || true
@@ -134,10 +134,11 @@ RESPONSE=$(curl -s -X POST http://127.0.0.1:8000/run \
 echo "--------------------------------------------------------"
 echo "ITK TEST RESULTS:"
 echo "--------------------------------------------------------"
-echo "$RESPONSE" | python3 -c "
+printf '%s\n' "$RESPONSE" | python3 -c "
 import sys, json
+raw_input = sys.stdin.read()
 try:
-    data = json.load(sys.stdin)
+    data = json.loads(raw_input)
     all_passed = data.get('all_passed', False)
     results = data.get('results', {})
     for test, passed in results.items():
@@ -149,7 +150,7 @@ try:
         sys.exit(1)
 except Exception as e:
     print(f'Error parsing results: {e}')
-    print(f'Raw response: {data if \"data\" in locals() else \"no data\"}')
+    print(f'Raw response: {raw_input}')
     sys.exit(1)
 "
 RESULT=$?

--- a/package.json
+++ b/package.json
@@ -104,7 +104,9 @@
     "format:readme": "prettier --write ./README.md",
     "coverage": "vitest run --coverage",
     "generate": "curl https://raw.githubusercontent.com/google-a2a/A2A/refs/heads/main/specification/json/a2a.json > spec.json && node scripts/generateTypes.js && rm spec.json",
-    "test-build": "esbuild ./dist/client/index.js ./dist/server/index.js ./dist/index.js --bundle --platform=neutral --outdir=dist/tmp-checks --outbase=./dist"
+    "test-build": "esbuild ./dist/client/index.js ./dist/server/index.js ./dist/index.js --bundle --platform=neutral --outdir=dist/tmp-checks --outbase=./dist",
+    "itk-agent": "tsx itk/itk_agent.ts"
+
   },
   "dependencies": {
     "uuid": "^11.1.0"

--- a/src/client/factory.ts
+++ b/src/client/factory.ts
@@ -98,9 +98,13 @@ export class ClientFactory {
    */
   async createFromAgentCard(agentCard: AgentCard): Promise<Client> {
     const interfaces = agentCard.supportedInterfaces ?? [];
-    const urlsPerAgentTransports = new CaseInsensitiveMap<string>(
-      interfaces.map((i) => [i.protocolBinding, i.url])
-    );
+    const urlsPerAgentTransports = new CaseInsensitiveMap<string>();
+    for (const i of interfaces) {
+      const existing = urlsPerAgentTransports.get(i.protocolBinding);
+      if (!existing || i.protocolVersion === '1.0') {
+        urlsPerAgentTransports.set(i.protocolBinding, i.url);
+      }
+    }
     const transportsByPreference = [
       ...(this.options.preferredTransports ?? []),
       ...interfaces.map((i) => i.protocolBinding),

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -76,11 +76,32 @@ export class JsonRpcTransport implements Transport {
       SendMessageRequest
     );
 
-    if (!rpcResponse.result?.payload?.value) {
-      throw new Error('Invalid response structure from agent.');
+    const result = rpcResponse.result;
+    if (!result) {
+      throw new Error('Invalid response structure from agent: missing result.');
     }
 
-    return rpcResponse.result.payload.value;
+    let value: unknown;
+    const resultRecord = result as unknown as Record<string, unknown>;
+    if (result.payload?.value) {
+      value = result.payload.value;
+    } else if (resultRecord.task) {
+      value = resultRecord.task;
+    } else if (resultRecord.message) {
+      value = resultRecord.message;
+    } else if (resultRecord.id && resultRecord.status) {
+      // Looks like a Task directly
+      value = result;
+    } else if (resultRecord.messageId && resultRecord.parts) {
+      // Looks like a Message directly
+      value = result;
+    }
+
+    if (!value) {
+      throw new Error('Invalid response structure from agent: missing payload value.');
+    }
+
+    return value as SendMessageResult;
   }
 
   async *sendMessageStream(
@@ -307,9 +328,10 @@ export class JsonRpcTransport implements Transport {
         `HTTP error establishing stream for ${method}: ${response.status} ${response.statusText}`
       );
     }
-    if (!response.headers.get('Content-Type')?.startsWith('text/event-stream')) {
+    const contentType = response.headers.get('Content-Type');
+    if (!contentType?.startsWith('text/event-stream')) {
       throw new Error(
-        `Invalid response Content-Type for SSE stream for ${method}. Expected 'text/event-stream'.`
+        `Invalid response Content-Type for SSE stream for ${method}. Expected 'text/event-stream', got '${contentType}'.`
       );
     }
 

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -76,32 +76,11 @@ export class JsonRpcTransport implements Transport {
       SendMessageRequest
     );
 
-    const result = rpcResponse.result;
-    if (!result) {
-      throw new Error('Invalid response structure from agent: missing result.');
+    if (!rpcResponse.result?.payload?.value) {
+      throw new Error('Invalid response structure from agent.');
     }
 
-    let value: unknown;
-    const resultRecord = result as unknown as Record<string, unknown>;
-    if (result.payload?.value) {
-      value = result.payload.value;
-    } else if (resultRecord.task) {
-      value = resultRecord.task;
-    } else if (resultRecord.message) {
-      value = resultRecord.message;
-    } else if (resultRecord.id && resultRecord.status) {
-      // Looks like a Task directly
-      value = result;
-    } else if (resultRecord.messageId && resultRecord.parts) {
-      // Looks like a Message directly
-      value = result;
-    }
-
-    if (!value) {
-      throw new Error('Invalid response structure from agent: missing payload value.');
-    }
-
-    return value as SendMessageResult;
+    return rpcResponse.result.payload.value;
   }
 
   async *sendMessageStream(
@@ -328,10 +307,9 @@ export class JsonRpcTransport implements Transport {
         `HTTP error establishing stream for ${method}: ${response.status} ${response.statusText}`
       );
     }
-    const contentType = response.headers.get('Content-Type');
-    if (!contentType?.startsWith('text/event-stream')) {
+    if (!response.headers.get('Content-Type')?.startsWith('text/event-stream')) {
       throw new Error(
-        `Invalid response Content-Type for SSE stream for ${method}. Expected 'text/event-stream', got '${contentType}'.`
+        `Invalid response Content-Type for SSE stream for ${method}. Expected 'text/event-stream'.`
       );
     }
 

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -76,11 +76,21 @@ export class JsonRpcTransport implements Transport {
       SendMessageRequest
     );
 
-    if (!rpcResponse.result?.payload?.value) {
-      throw new Error('Invalid response structure from agent.');
+    const result = rpcResponse.result as {
+      payload?: { value: unknown };
+      task?: unknown;
+      message?: unknown;
+    };
+    if (result?.payload?.value) {
+      return result.payload.value as SendMessageResult;
     }
-
-    return rpcResponse.result.payload.value;
+    if (result?.task) {
+      return result.task as SendMessageResult;
+    }
+    if (result?.message) {
+      return result.message as SendMessageResult;
+    }
+    throw new Error('Invalid response structure from agent.');
   }
 
   async *sendMessageStream(

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -77,22 +77,11 @@ export class JsonRpcTransport implements Transport {
       options,
       SendMessageRequest
     );
-
-    const result = rpcResponse.result as {
-      payload?: { value: unknown };
-      task?: unknown;
-      message?: unknown;
-    };
-    if (result?.payload?.value) {
-      return result.payload.value as SendMessageResult;
+    const response = SendMessageResponse.fromJSON(rpcResponse.result);
+    if (!response.payload) {
+      throw new Error('Invalid response: missing payload');
     }
-    if (result?.task) {
-      return result.task as SendMessageResult;
-    }
-    if (result?.message) {
-      return result.message as SendMessageResult;
-    }
-    throw new Error('Invalid response structure from agent.');
+    return response.payload.value;
   }
 
   async *sendMessageStream(

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -364,12 +364,11 @@ export class JsonRpcTransport implements Transport {
       throw new Error(`SSE event JSON-RPC response is missing 'result' field. Data: ${jsonData}`);
     }
 
-    const result = a2aStreamResponse.result;
-    if (result?.payload?.value) {
-      return result.payload.value as TStreamItem;
+    const response = StreamResponse.fromJSON(a2aStreamResponse.result);
+    if (!response.payload) {
+      throw new Error('Invalid stream response: missing payload');
     }
-
-    return result as TStreamItem;
+    return response.payload.value as unknown as TStreamItem;
   }
 
   private static mapToError(response: JSONRPCErrorResponse): Error {

--- a/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -13,6 +13,9 @@ import {
   DeleteTaskPushNotificationConfigRequest,
   ListTaskPushNotificationConfigsRequest,
   ListTasksRequest,
+  ListTasksResponse,
+  ListTaskPushNotificationConfigsResponse,
+  AgentCard,
 } from '../../../index.js';
 import {
   A2A_ERROR_CODE,
@@ -160,43 +163,48 @@ export class JsonRpcTransportHandler {
               SendMessageRequest.fromJSON(rpcRequest.params),
               context
             );
-            result = {
-              payload: {
-                $case: 'messageId' in messageOrTask ? 'message' : 'task',
-                value: messageOrTask,
-              },
-            };
+            result =
+              'messageId' in messageOrTask
+                ? { message: Message.toJSON(messageOrTask as Message) }
+                : { task: Task.toJSON(messageOrTask as Task) };
             break;
           }
           case 'GetTask':
-            result = await this.requestHandler.getTask(
-              GetTaskRequest.fromJSON(rpcRequest.params),
-              context
+            result = Task.toJSON(
+              await this.requestHandler.getTask(GetTaskRequest.fromJSON(rpcRequest.params), context)
             );
             break;
           case 'ListTasks':
-            result = await this.requestHandler.listTasks(
-              ListTasksRequest.fromJSON(rpcRequest.params),
-              context
+            result = ListTasksResponse.toJSON(
+              await this.requestHandler.listTasks(
+                ListTasksRequest.fromJSON(rpcRequest.params),
+                context
+              )
             );
             break;
           case 'CancelTask':
-            result = await this.requestHandler.cancelTask(
-              CancelTaskRequest.fromJSON(rpcRequest.params),
-              context
+            result = Task.toJSON(
+              await this.requestHandler.cancelTask(
+                CancelTaskRequest.fromJSON(rpcRequest.params),
+                context
+              )
             );
             break;
           case 'CreateTaskPushNotificationConfig': {
-            result = await this.requestHandler.createTaskPushNotificationConfig(
-              TaskPushNotificationConfig.fromJSON(rpcRequest.params),
-              context
+            result = TaskPushNotificationConfig.toJSON(
+              await this.requestHandler.createTaskPushNotificationConfig(
+                TaskPushNotificationConfig.fromJSON(rpcRequest.params),
+                context
+              )
             );
             break;
           }
           case 'GetTaskPushNotificationConfig':
-            result = await this.requestHandler.getTaskPushNotificationConfig(
-              GetTaskPushNotificationConfigRequest.fromJSON(rpcRequest.params),
-              context
+            result = TaskPushNotificationConfig.toJSON(
+              await this.requestHandler.getTaskPushNotificationConfig(
+                GetTaskPushNotificationConfigRequest.fromJSON(rpcRequest.params),
+                context
+              )
             );
             break;
           case 'DeleteTaskPushNotificationConfig':
@@ -207,13 +215,17 @@ export class JsonRpcTransportHandler {
             result = null;
             break;
           case 'ListTaskPushNotificationConfigs':
-            result = await this.requestHandler.listTaskPushNotificationConfigs(
-              ListTaskPushNotificationConfigsRequest.fromJSON(rpcRequest.params),
-              context
+            result = ListTaskPushNotificationConfigsResponse.toJSON(
+              await this.requestHandler.listTaskPushNotificationConfigs(
+                ListTaskPushNotificationConfigsRequest.fromJSON(rpcRequest.params),
+                context
+              )
             );
             break;
           case 'GetExtendedAgentCard':
-            result = await this.requestHandler.getAuthenticatedExtendedAgentCard(context);
+            result = AgentCard.toJSON(
+              await this.requestHandler.getAuthenticatedExtendedAgentCard(context)
+            );
             break;
           default:
             return {

--- a/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -119,6 +119,7 @@ export class JsonRpcTransportHandler {
           undefined
         > {
           try {
+            // TODO: Improve the conversion below once the agentEventStream will be AsyncGenerator of StreamResponse
             for await (const event of agentEventStream) {
               let result: unknown;
               if ('messageId' in event) {

--- a/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -1,5 +1,4 @@
 import {
-  StreamResponse,
   Message,
   Task,
   TaskStatusUpdateEvent,
@@ -121,22 +120,25 @@ export class JsonRpcTransportHandler {
         > {
           try {
             for await (const event of agentEventStream) {
-              let payload: StreamResponse['payload'];
-
+              let result: unknown;
               if ('messageId' in event) {
-                payload = { $case: 'message', value: event as Message };
+                result = { message: Message.toJSON(event) };
               } else if ('artifacts' in event) {
-                payload = { $case: 'task', value: event as Task };
+                result = { task: Task.toJSON(event) };
               } else if ('status' in event) {
-                payload = { $case: 'statusUpdate', value: event as TaskStatusUpdateEvent };
+                result = {
+                  statusUpdate: TaskStatusUpdateEvent.toJSON(event),
+                };
               } else if ('artifact' in event) {
-                payload = { $case: 'artifactUpdate', value: event as TaskArtifactUpdateEvent };
+                result = {
+                  artifactUpdate: TaskArtifactUpdateEvent.toJSON(event),
+                };
               }
 
               yield {
                 jsonrpc: '2.0',
                 id: requestId, // Use the original request ID for all streamed responses
-                result: { payload },
+                result,
               };
             }
           } catch (streamError) {

--- a/test/client/transports/json_rpc_transport.spec.ts
+++ b/test/client/transports/json_rpc_transport.spec.ts
@@ -69,13 +69,10 @@ describe('JsonRpcTransport', () => {
           JSON.stringify({
             jsonrpc: '2.0',
             result: {
-              payload: {
-                $case: 'msg',
-                value: {
-                  messageId: 'response-msg-1',
-                  role: Role.ROLE_AGENT,
-                  content: [{ part: { $case: 'text', value: 'Response' } }],
-                },
+              message: {
+                messageId: 'response-msg-1',
+                role: Role.ROLE_AGENT,
+                content: [{ part: { $case: 'text', value: 'Response' } }],
               },
             },
             id: 1,

--- a/test/client/util.ts
+++ b/test/client/util.ts
@@ -422,14 +422,7 @@ export function createMockFetch(
 
       const requestBody = JSON.parse((options?.body as string) || '{}');
       const wrappedResult =
-        requestBody.method === 'SendMessage'
-          ? {
-              payload: {
-                $case: 'msg',
-                value: mockMessage,
-              },
-            }
-          : mockMessage;
+        requestBody.method === 'SendMessage' ? { message: mockMessage } : mockMessage;
 
       return createResponse(requestId, wrappedResult);
     }


### PR DESCRIPTION
# Description

Enable ITK tests.

Currently, the testing is done between the current a2a-js state and Go SDK 1.0 for the following configurations:
- Streaming
  - JSON-RPC / gRPC
  - HTTP_JSON
- Non-Streaming
  - JSON-RPC / gRPC
  - HTTP_JSON

# Notes

At the moment, there is an extensive middle layer in `itk_agent.ts`. This middle layer is planned to be removed once ITK tests are less spec dependent and a2a-js is closer to 1.0 release state.

Fixes (partially) #321 🦕
