### PR TITLE
feat!: Remove specific transport exports

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -11,16 +11,9 @@ export {
 export { Client, type ClientConfig, type RequestOptions } from './multitransport-client.js';
 export type { Transport, TransportFactory } from './transports/transport.js';
 export { ClientFactory, ClientFactoryOptions } from './factory.js';
-export {
-  JsonRpcTransport,
-  JsonRpcTransportFactory,
-  type JsonRpcTransportOptions,
-} from './transports/json_rpc_transport.js';
-export {
-  RestTransport,
-  RestTransportFactory,
-  type RestTransportOptions,
-} from './transports/rest_transport.js';
+export { JsonRpcTransportFactory } from './transports/json_rpc_transport.js';
+export { RestTransportFactory } from './transports/rest_transport.js';
+export { GrpcTransportFactory } from './transports/grpc/grpc_transport.js';
 export type {
   CallInterceptor,
   BeforeArgs,

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,7 +13,6 @@ export type { Transport, TransportFactory } from './transports/transport.js';
 export { ClientFactory, ClientFactoryOptions } from './factory.js';
 export { JsonRpcTransportFactory } from './transports/json_rpc_transport.js';
 export { RestTransportFactory } from './transports/rest_transport.js';
-export { GrpcTransportFactory } from './transports/grpc/grpc_transport.js';
 export type {
   CallInterceptor,
   BeforeArgs,

--- a/src/client/transports/grpc/index.ts
+++ b/src/client/transports/grpc/index.ts
@@ -1,5 +1,1 @@
-export {
-  GrpcTransport,
-  GrpcTransportFactory,
-  type GrpcTransportOptions,
-} from './grpc_transport.js';
+export { GrpcTransportFactory } from './grpc_transport.js';

--- a/src/samples/cli.ts
+++ b/src/samples/cli.ts
@@ -23,8 +23,8 @@ import {
   DefaultAgentCardResolver,
   JsonRpcTransportFactory,
   RestTransportFactory,
+  GrpcTransportFactory,
 } from '../client/index.js';
-import { GrpcTransportFactory } from '../client/transports/grpc/grpc_transport.js';
 
 // --- ANSI Colors ---
 const colors = {

--- a/src/samples/cli.ts
+++ b/src/samples/cli.ts
@@ -23,8 +23,8 @@ import {
   DefaultAgentCardResolver,
   JsonRpcTransportFactory,
   RestTransportFactory,
-  GrpcTransportFactory,
 } from '../client/index.js';
+import { GrpcTransportFactory } from '../client/transports/grpc/index.js';
 
 // --- ANSI Colors ---
 const colors = {

--- a/src/samples/cli.ts
+++ b/src/samples/cli.ts
@@ -24,7 +24,7 @@ import {
   JsonRpcTransportFactory,
   RestTransportFactory,
 } from '../client/index.js';
-import { GrpcTransportFactory } from '../client/transports/grpc/index.js';
+import { GrpcTransportFactory } from '../client/transports/grpc/grpc_transport.js';
 
 // --- ANSI Colors ---
 const colors = {


### PR DESCRIPTION
# Description

Remove specific transport exports from the client's index file. We should only export generic transport types and transport specific factories.

Fixes (partially) #179 🦕
