### PR TITLE
feat!: Make ServerCallContext parameter mandatory across all places

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -12,7 +12,7 @@ exports[`TypeScript Strict Mode`] = {
     "src/server/express/rest_handler.ts:1777885052": [
       [208, 50, 17, "tsc: Argument of type \'unknown\' is not assignable to parameter of type \'Message | Task | TaskArtifactUpdateEvent | TaskStatusUpdateEvent\'.", "3749434707"]
     ],
-    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:998892900": [
+    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:2973243771": [
       [90, 12, 10, "tsc: Variable \'rpcRequest\' is used before being assigned.", "3927050741"]
     ],
     "src/types/converters/to_proto.ts:1276072555": [

--- a/src/server/agent_execution/request_context.ts
+++ b/src/server/agent_execution/request_context.ts
@@ -13,15 +13,15 @@ export class RequestContext {
     userMessage: Message,
     taskId: string,
     contextId: string,
-    task: Task | undefined,
-    referenceTasks: Task[] | undefined,
-    context: ServerCallContext
+    context: ServerCallContext,
+    task?: Task,
+    referenceTasks?: Task[]
   ) {
     this.userMessage = userMessage;
     this.taskId = taskId;
     this.contextId = contextId;
+    this.context = context;
     this.task = task;
     this.referenceTasks = referenceTasks;
-    this.context = context;
   }
 }

--- a/src/server/agent_execution/request_context.ts
+++ b/src/server/agent_execution/request_context.ts
@@ -7,15 +7,15 @@ export class RequestContext {
   public readonly contextId: string;
   public readonly task?: Task;
   public readonly referenceTasks?: Task[];
-  public readonly context?: ServerCallContext;
+  public readonly context: ServerCallContext;
 
   constructor(
     userMessage: Message,
     taskId: string,
     contextId: string,
-    task?: Task,
-    referenceTasks?: Task[],
-    context?: ServerCallContext
+    task: Task | undefined,
+    referenceTasks: Task[] | undefined,
+    context: ServerCallContext
   ) {
     this.userMessage = userMessage;
     this.taskId = taskId;

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -32,8 +32,8 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     };
   }
 
-  async send(task: Task): Promise<void> {
-    const pushConfigs = await this.pushNotificationStore.load(task.id, new ServerCallContext());
+  async send(task: Task, context: ServerCallContext): Promise<void> {
+    const pushConfigs = await this.pushNotificationStore.load(task.id, context);
     if (!pushConfigs || pushConfigs.length === 0) {
       return;
     }

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -1,4 +1,5 @@
 import { Task, TaskPushNotificationConfig } from '../../index.js';
+import { ServerCallContext } from '../context.js';
 import { PushNotificationSender } from './push_notification_sender.js';
 import { PushNotificationStore } from './push_notification_store.js';
 
@@ -32,7 +33,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
   }
 
   async send(task: Task): Promise<void> {
-    const pushConfigs = await this.pushNotificationStore.load(task.id);
+    const pushConfigs = await this.pushNotificationStore.load(task.id, new ServerCallContext());
     if (!pushConfigs || pushConfigs.length === 0) {
       return;
     }

--- a/src/server/push_notification/push_notification_sender.ts
+++ b/src/server/push_notification/push_notification_sender.ts
@@ -1,5 +1,6 @@
 import { Task } from '../../index.js';
+import { ServerCallContext } from '../context.js';
 
 export interface PushNotificationSender {
-  send(task: Task): Promise<void>;
+  send(task: Task, context: ServerCallContext): Promise<void>;
 }

--- a/src/server/push_notification/push_notification_store.ts
+++ b/src/server/push_notification/push_notification_store.ts
@@ -1,15 +1,24 @@
 import { TaskPushNotificationConfig } from '../../index.js';
+import { ServerCallContext } from '../context.js';
 
 export interface PushNotificationStore {
-  save(taskId: string, pushNotificationConfig: TaskPushNotificationConfig): Promise<void>;
-  load(taskId: string): Promise<TaskPushNotificationConfig[]>;
-  delete(taskId: string, configId?: string): Promise<void>;
+  save(
+    taskId: string,
+    context: ServerCallContext,
+    pushNotificationConfig: TaskPushNotificationConfig
+  ): Promise<void>;
+  load(taskId: string, context: ServerCallContext): Promise<TaskPushNotificationConfig[]>;
+  delete(taskId: string, context: ServerCallContext, configId?: string): Promise<void>;
 }
 
 export class InMemoryPushNotificationStore implements PushNotificationStore {
   private store: Map<string, TaskPushNotificationConfig[]> = new Map();
 
-  async save(taskId: string, pushNotificationConfig: TaskPushNotificationConfig): Promise<void> {
+  async save(
+    taskId: string,
+    _context: ServerCallContext,
+    pushNotificationConfig: TaskPushNotificationConfig
+  ): Promise<void> {
     const configs = this.store.get(taskId) || [];
 
     // Set ID if it's not already set
@@ -28,12 +37,12 @@ export class InMemoryPushNotificationStore implements PushNotificationStore {
     this.store.set(taskId, configs);
   }
 
-  async load(taskId: string): Promise<TaskPushNotificationConfig[]> {
+  async load(taskId: string, _context: ServerCallContext): Promise<TaskPushNotificationConfig[]> {
     const configs = this.store.get(taskId);
     return configs || [];
   }
 
-  async delete(taskId: string, configId?: string): Promise<void> {
+  async delete(taskId: string, _context: ServerCallContext, configId?: string): Promise<void> {
     // If no configId is provided, use taskId as the configId (backward compatibility)
     if (configId === undefined) {
       configId = taskId;

--- a/src/server/request_handler/a2a_request_handler.ts
+++ b/src/server/request_handler/a2a_request_handler.ts
@@ -20,46 +20,46 @@ import { ServerCallContext } from '../context.js';
 export interface A2ARequestHandler {
   getAgentCard(): Promise<AgentCard>;
 
-  getAuthenticatedExtendedAgentCard(context?: ServerCallContext): Promise<AgentCard>;
+  getAuthenticatedExtendedAgentCard(context: ServerCallContext): Promise<AgentCard>;
 
-  sendMessage(params: SendMessageRequest, context?: ServerCallContext): Promise<Message | Task>;
+  sendMessage(params: SendMessageRequest, context: ServerCallContext): Promise<Message | Task>;
 
   sendMessageStream(
     params: SendMessageRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): AsyncGenerator<
     Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent,
     void,
     undefined
   >;
 
-  getTask(params: GetTaskRequest, context?: ServerCallContext): Promise<Task>;
-  cancelTask(params: CancelTaskRequest, context?: ServerCallContext): Promise<Task>;
+  getTask(params: GetTaskRequest, context: ServerCallContext): Promise<Task>;
+  cancelTask(params: CancelTaskRequest, context: ServerCallContext): Promise<Task>;
 
   createTaskPushNotificationConfig(
     params: TaskPushNotificationConfig,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<TaskPushNotificationConfig>;
 
   getTaskPushNotificationConfig(
     params: GetTaskPushNotificationConfigRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<TaskPushNotificationConfig>;
 
   listTaskPushNotificationConfigs(
     params: ListTaskPushNotificationConfigsRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<TaskPushNotificationConfig[]>;
 
   deleteTaskPushNotificationConfig(
     params: DeleteTaskPushNotificationConfigRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<void>;
 
   resubscribe(
     params: SubscribeToTaskRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): AsyncGenerator<Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent, void, undefined>;
 
-  listTasks(params: ListTasksRequest, context?: ServerCallContext): Promise<ListTasksResponse>;
+  listTasks(params: ListTasksRequest, context: ServerCallContext): Promise<ListTasksResponse>;
 }

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -87,7 +87,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     return this.agentCard;
   }
 
-  async getAuthenticatedExtendedAgentCard(context?: ServerCallContext): Promise<AgentCard> {
+  async getAuthenticatedExtendedAgentCard(context: ServerCallContext): Promise<AgentCard> {
     if (!this.agentCard.capabilities?.extendedAgentCard) {
       throw new UnsupportedOperationError('Agent does not support authenticated extended card.');
     }
@@ -105,7 +105,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
   private async _createRequestContext(
     incomingMessage: Message,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<RequestContext> {
     let task: Task | undefined;
     let referenceTasks: Task[] | undefined;
@@ -170,7 +170,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     taskId: string,
     resultManager: ResultManager,
     eventQueue: ExecutionEventQueue,
-    context: ServerCallContext | undefined,
+    context: ServerCallContext,
     options?: {
       firstResultResolver?: (value: Message | Task | PromiseLike<Message | Task>) => void;
       firstResultRejector?: (reason?: unknown) => void;
@@ -226,7 +226,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
   async sendMessage(
     params: SendMessageRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<Message | Task> {
     const incomingMessage = params.message;
     if (!incomingMessage?.messageId) {
@@ -335,7 +335,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
   async *sendMessageStream(
     params: SendMessageRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): AsyncGenerator<
     Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent,
     void,
@@ -418,7 +418,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     }
   }
 
-  async getTask(params: GetTaskRequest, context?: ServerCallContext): Promise<Task> {
+  async getTask(params: GetTaskRequest, context: ServerCallContext): Promise<Task> {
     const taskId = params.id;
     const task = await this.taskStore.load(taskId, context);
     if (!task) {
@@ -437,7 +437,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
   async listTasks(
     params: ListTasksRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<ListTasksResponse> {
     const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE;
 
@@ -452,7 +452,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     return this.taskStore.list({ ...params, pageSize }, context);
   }
 
-  async cancelTask(params: CancelTaskRequest, context?: ServerCallContext): Promise<Task> {
+  async cancelTask(params: CancelTaskRequest, context: ServerCallContext): Promise<Task> {
     const taskId = params.id;
     const task = await this.taskStore.load(taskId, context);
     if (!task) {
@@ -519,7 +519,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
   async createTaskPushNotificationConfig(
     params: TaskPushNotificationConfig,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<TaskPushNotificationConfig> {
     if (!this.agentCard.capabilities?.pushNotifications) {
       throw new PushNotificationNotSupportedError();
@@ -537,7 +537,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
   async getTaskPushNotificationConfig(
     params: GetTaskPushNotificationConfigRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<TaskPushNotificationConfig> {
     if (!this.agentCard.capabilities?.pushNotifications) {
       throw new PushNotificationNotSupportedError();
@@ -565,7 +565,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
   async listTaskPushNotificationConfigs(
     params: ListTaskPushNotificationConfigsRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<TaskPushNotificationConfig[]> {
     if (!this.agentCard.capabilities?.pushNotifications) {
       throw new PushNotificationNotSupportedError();
@@ -581,7 +581,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
   async deleteTaskPushNotificationConfig(
     params: DeleteTaskPushNotificationConfigRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<void> {
     if (!this.agentCard.capabilities?.pushNotifications) {
       throw new PushNotificationNotSupportedError();
@@ -596,7 +596,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
   async *resubscribe(
     params: SubscribeToTaskRequest,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): AsyncGenerator<
     | Task // Initial task state
     | TaskStatusUpdateEvent
@@ -658,7 +658,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
   private async _sendPushNotificationIfNeeded(
     event: AgentExecutionEvent,
-    context: ServerCallContext | undefined
+    context: ServerCallContext
   ): Promise<void> {
     if (!this.agentCard.capabilities?.pushNotifications) {
       return;
@@ -749,4 +749,4 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   }
 }
 
-export type ExtendedAgentCardProvider = (context?: ServerCallContext) => Promise<AgentCard>;
+export type ExtendedAgentCardProvider = (context: ServerCallContext) => Promise<AgentCard>;

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -686,7 +686,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     }
 
     // Send push notification in the background.
-    this.pushNotificationSender?.send(task);
+    this.pushNotificationSender?.send(task, context);
   }
 
   private async _handleProcessingError(

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -163,7 +163,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       contextId,
       taskId,
     };
-    return new RequestContext(messageForContext, taskId, contextId, task, referenceTasks, context);
+    return new RequestContext(messageForContext, taskId, contextId, context, task, referenceTasks);
   }
 
   private async _processEvents(

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -97,7 +97,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     if (typeof this.extendedAgentCardProvider === 'function') {
       return this.extendedAgentCardProvider(context);
     }
-    if (context?.user?.isAuthenticated) {
+    if (context.user?.isAuthenticated) {
       return this.extendedAgentCardProvider;
     }
     return this.agentCard;
@@ -147,7 +147,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     const contextId = incomingMessage.contextId || task?.contextId || uuidv4();
 
     // Validate requested extensions against agent capabilities
-    if (context?.requestedExtensions) {
+    if (context.requestedExtensions) {
       const agentCard = await this.getAgentCard();
       const exposedExtensions = new Set(
         agentCard.capabilities?.extensions?.map((ext) => ext.uri) || []

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -252,6 +252,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     ) {
       await this.pushNotificationStore?.save(
         taskId,
+        context,
         params.configuration.taskPushNotificationConfig
       );
     }
@@ -366,6 +367,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     ) {
       await this.pushNotificationStore?.save(
         taskId,
+        context,
         params.configuration.taskPushNotificationConfig
       );
     }
@@ -530,7 +532,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
 
-    await this.pushNotificationStore?.save(taskId, params);
+    await this.pushNotificationStore?.save(taskId, context, params);
 
     return params;
   }
@@ -548,7 +550,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
 
-    const configs = (await this.pushNotificationStore?.load(taskId)) || [];
+    const configs = (await this.pushNotificationStore?.load(taskId, context)) || [];
     if (configs.length === 0) {
       throw new GenericError(`Push notification config not found for task ${taskId}.`);
     }
@@ -576,7 +578,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
 
-    return (await this.pushNotificationStore?.load(taskId)) || [];
+    return (await this.pushNotificationStore?.load(taskId, context)) || [];
   }
 
   async deleteTaskPushNotificationConfig(
@@ -591,7 +593,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     if (!task) {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
-    await this.pushNotificationStore?.delete(taskId, params.id);
+    await this.pushNotificationStore?.delete(taskId, context, params.id);
   }
 
   async *resubscribe(

--- a/src/server/result_manager.ts
+++ b/src/server/result_manager.ts
@@ -5,13 +5,13 @@ import { TaskStore } from './store.js';
 
 export class ResultManager {
   private readonly taskStore: TaskStore;
-  private readonly serverCallContext?: ServerCallContext;
+  private readonly serverCallContext: ServerCallContext;
 
   private currentTask?: Task;
   private latestUserMessage?: Message; // To add to history if a new task is created
   private finalMessageResult?: Message; // Stores the message if it's the final result
 
-  constructor(taskStore: TaskStore, serverCallContext?: ServerCallContext) {
+  constructor(taskStore: TaskStore, serverCallContext: ServerCallContext) {
     this.taskStore = taskStore;
     this.serverCallContext = serverCallContext;
   }

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -15,7 +15,7 @@ export interface TaskStore {
    * @param context The context of the current call.
    * @returns A promise resolving when the save operation is complete.
    */
-  save(task: Task, context?: ServerCallContext): Promise<void>;
+  save(task: Task, context: ServerCallContext): Promise<void>;
 
   /**
    * Loads a task by task ID.
@@ -23,36 +23,39 @@ export interface TaskStore {
    * @param context The context of the current call.
    * @returns A promise resolving to an object containing the Task, or undefined if not found.
    */
-  load(taskId: string, context?: ServerCallContext): Promise<Task | undefined>;
+  load(taskId: string, context: ServerCallContext): Promise<Task | undefined>;
 
   /**
    * Lists tasks with filtering and pagination.
    * @param params Filtering and pagination parameters.
    * @param context The context of the current call.
    */
-  list(params: ListTasksRequest, context?: ServerCallContext): Promise<ListTasksResponse>;
+  list(params: ListTasksRequest, context: ServerCallContext): Promise<ListTasksResponse>;
 }
 
 // ========================
 // InMemoryTaskStore
 // ========================
+//
+// Methods in InMemoryTaskStore accept ServerCallContext but do not use it.
+// This is intentional to match the TaskStore interface.
 
 // Use Task directly for storage
 export class InMemoryTaskStore implements TaskStore {
   private store: Map<string, Task> = new Map();
 
-  async load(taskId: string): Promise<Task | undefined> {
+  async load(taskId: string, _context: ServerCallContext): Promise<Task | undefined> {
     const entry = this.store.get(taskId);
     // Return copies to prevent external mutation
     return entry ? { ...entry } : undefined;
   }
 
-  async save(task: Task): Promise<void> {
+  async save(task: Task, _context: ServerCallContext): Promise<void> {
     // Store copies to prevent internal mutation if caller reuses objects
     this.store.set(task.id, { ...task });
   }
 
-  async list(params: ListTasksRequest): Promise<ListTasksResponse> {
+  async list(params: ListTasksRequest, _context: ServerCallContext): Promise<ListTasksResponse> {
     const {
       contextId,
       status,

--- a/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -64,7 +64,7 @@ export class JsonRpcTransportHandler {
     // TODO: remove the eslint disable and replace the any (https://github.com/a2aproject/a2a-js/issues/179)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     requestBody: any,
-    context?: ServerCallContext
+    context: ServerCallContext
   ): Promise<JSONRPCResponse | AsyncGenerator<JSONRPCResponse, void, undefined>> {
     let rpcRequest: A2ARequest;
 

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -107,19 +107,8 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
 
   // Before each test, reset the components to a clean state
   beforeEach(() => {
-    const inMemoryStore = new InMemoryTaskStore();
-    mockTaskStore = {
-      save: async (task: Task, ctx: ServerCallContext) => {
-        return inMemoryStore.save(task, ctx);
-      },
-      load: async (id: string, ctx: ServerCallContext) => {
-        return inMemoryStore.load(id, ctx);
-      },
-      list: async (params: ListTasksRequest, ctx: ServerCallContext) => {
-        return inMemoryStore.list(params, ctx);
-      },
-    };
     // Default mock for most tests
+    mockTaskStore = new InMemoryTaskStore();
     mockAgentExecutor = new MockAgentExecutor();
     executionEventBusManager = new DefaultExecutionEventBusManager();
     handler = new DefaultRequestHandler(

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -107,27 +107,25 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
 
   // Before each test, reset the components to a clean state
   beforeEach(() => {
-    // Wrap in-memory store into a store which ensures we pass server call context.
-    // The parameter is optional to avoid breaking changes, however it should be passed.
     const inMemoryStore = new InMemoryTaskStore();
     mockTaskStore = {
-      save: async (task: Task, ctx?: ServerCallContext) => {
+      save: async (task: Task, ctx: ServerCallContext) => {
         if (!ctx) {
           throw new Error('Missing server call context');
         }
-        return inMemoryStore.save(task);
+        return inMemoryStore.save(task, ctx);
       },
-      load: async (id: string, ctx?: ServerCallContext) => {
+      load: async (id: string, ctx: ServerCallContext) => {
         if (!ctx) {
           throw new Error('Missing server call context');
         }
-        return inMemoryStore.load(id);
+        return inMemoryStore.load(id, ctx);
       },
-      list: async (params: ListTasksRequest, ctx?: ServerCallContext) => {
+      list: async (params: ListTasksRequest, ctx: ServerCallContext) => {
         if (!ctx) {
           throw new Error('Missing server call context');
         }
-        return inMemoryStore.list(params);
+        return inMemoryStore.list(params, ctx);
       },
     };
     // Default mock for most tests
@@ -2450,7 +2448,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     it('getAuthenticatedExtendedAgentCard should fail if the agent card does not support extended agent card', async () => {
       let caughtError;
       try {
-        await handler.getAuthenticatedExtendedAgentCard();
+        await handler.getAuthenticatedExtendedAgentCard(serverCallContext);
       } catch (error: any) {
         caughtError = error;
       } finally {
@@ -2470,7 +2468,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       );
       let caughtError;
       try {
-        await handler.getAuthenticatedExtendedAgentCard();
+        await handler.getAuthenticatedExtendedAgentCard(serverCallContext);
       } catch (error: any) {
         caughtError = error;
       } finally {

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -110,21 +110,12 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     const inMemoryStore = new InMemoryTaskStore();
     mockTaskStore = {
       save: async (task: Task, ctx: ServerCallContext) => {
-        if (!ctx) {
-          throw new Error('Missing server call context');
-        }
         return inMemoryStore.save(task, ctx);
       },
       load: async (id: string, ctx: ServerCallContext) => {
-        if (!ctx) {
-          throw new Error('Missing server call context');
-        }
         return inMemoryStore.load(id, ctx);
       },
       list: async (params: ListTasksRequest, ctx: ServerCallContext) => {
-        if (!ctx) {
-          throw new Error('Missing server call context');
-        }
         return inMemoryStore.list(params, ctx);
       },
     };

--- a/test/server/jsonrpc_transport_handler.spec.ts
+++ b/test/server/jsonrpc_transport_handler.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, beforeEach, afterEach, expect, vi, type Mock } from 'vite
 import { JsonRpcTransportHandler } from '../../src/server/transports/jsonrpc/jsonrpc_transport_handler.js';
 import { A2ARequestHandler } from '../../src/server/request_handler/a2a_request_handler.js';
 import { JSONRPCErrorResponse } from '../../src/core.js';
+import { ServerCallContext } from '../../src/server/context.js';
 import {
   RequestMalformedError,
   TaskNotFoundError,
@@ -19,6 +20,7 @@ import {
 describe('JsonRpcTransportHandler', () => {
   let mockRequestHandler: A2ARequestHandler;
   let transportHandler: JsonRpcTransportHandler;
+  let defaultContext: ServerCallContext;
 
   beforeEach(() => {
     mockRequestHandler = {
@@ -36,6 +38,7 @@ describe('JsonRpcTransportHandler', () => {
       listTasks: vi.fn(),
     };
     transportHandler = new JsonRpcTransportHandler(mockRequestHandler);
+    defaultContext = new ServerCallContext();
   });
 
   afterEach(() => {
@@ -45,19 +48,25 @@ describe('JsonRpcTransportHandler', () => {
   describe('Check JSON-RPC request format', () => {
     it('should return an invalid params error for an invalid JSON string', async () => {
       const invalidJson = '{ "jsonrpc": "2.0", "method": "foo", "id": 1, }'; // trailing comma
-      const response = (await transportHandler.handle(invalidJson)) as JSONRPCErrorResponse;
+      const response = (await transportHandler.handle(
+        invalidJson,
+        defaultContext
+      )) as JSONRPCErrorResponse;
       expect(response.error.code).to.equal(A2A_ERROR_CODE.INVALID_PARAMS);
     });
 
     it('should return an invalid params error for a non-string/non-object request body', async () => {
-      const response = (await transportHandler.handle(123)) as JSONRPCErrorResponse;
+      const response = (await transportHandler.handle(123, defaultContext)) as JSONRPCErrorResponse;
       expect(response.error.code).to.equal(A2A_ERROR_CODE.INVALID_PARAMS);
       expect(response.error.message).to.equal('Invalid request body type.');
     });
 
     it('should return an invalid params error for missing jsonrpc property', async () => {
       const request = { method: 'foo', id: 1 };
-      const response = (await transportHandler.handle(request)) as JSONRPCErrorResponse;
+      const response = (await transportHandler.handle(
+        request,
+        defaultContext
+      )) as JSONRPCErrorResponse;
       expect(response.error.code).to.equal(A2A_ERROR_CODE.INVALID_PARAMS);
       expect(response.error.message).to.equal('Invalid JSON-RPC Request.');
       expect(response.id).to.equal(1);
@@ -65,7 +74,10 @@ describe('JsonRpcTransportHandler', () => {
 
     it('should return an invalid params error for incorrect jsonrpc version', async () => {
       const request = { jsonrpc: '1.0', method: 'foo', id: 1 };
-      const response = (await transportHandler.handle(request)) as JSONRPCErrorResponse;
+      const response = (await transportHandler.handle(
+        request,
+        defaultContext
+      )) as JSONRPCErrorResponse;
       expect(response.error.code).to.equal(A2A_ERROR_CODE.INVALID_PARAMS);
       expect(response.error.message).to.equal('Invalid JSON-RPC Request.');
       expect(response.id).to.equal(1);
@@ -73,7 +85,10 @@ describe('JsonRpcTransportHandler', () => {
 
     it('should return an invalid params error for missing method property', async () => {
       const request = { jsonrpc: '2.0', id: 1 };
-      const response = (await transportHandler.handle(request)) as JSONRPCErrorResponse;
+      const response = (await transportHandler.handle(
+        request,
+        defaultContext
+      )) as JSONRPCErrorResponse;
       expect(response.error.code).to.equal(A2A_ERROR_CODE.INVALID_PARAMS);
       expect(response.error.message).to.equal('Invalid JSON-RPC Request.');
       expect(response.id).to.equal(1);
@@ -81,7 +96,10 @@ describe('JsonRpcTransportHandler', () => {
 
     it('should return an invalid params error for non-string method property', async () => {
       const request = { jsonrpc: '2.0', method: 123, id: 1 };
-      const response = (await transportHandler.handle(request)) as JSONRPCErrorResponse;
+      const response = (await transportHandler.handle(
+        request,
+        defaultContext
+      )) as JSONRPCErrorResponse;
       expect(response.error.code).to.equal(A2A_ERROR_CODE.INVALID_PARAMS);
       expect(response.error.message).to.equal('Invalid JSON-RPC Request.');
       expect(response.id).to.equal(1);
@@ -89,7 +107,10 @@ describe('JsonRpcTransportHandler', () => {
 
     it('should return an invalid params error for invalid id type (object)', async () => {
       const request = { jsonrpc: '2.0', method: 'foo', id: {} };
-      const response = (await transportHandler.handle(request)) as JSONRPCErrorResponse;
+      const response = (await transportHandler.handle(
+        request,
+        defaultContext
+      )) as JSONRPCErrorResponse;
       expect(response.error.code).to.equal(A2A_ERROR_CODE.INVALID_PARAMS);
       expect(response.error.message).to.equal('Invalid JSON-RPC Request.');
       expect(response.id).to.deep.equal({});
@@ -97,7 +118,10 @@ describe('JsonRpcTransportHandler', () => {
 
     it('should return an invalid params error for invalid id type (float)', async () => {
       const request = { jsonrpc: '2.0', method: 'foo', id: 1.23 };
-      const response = (await transportHandler.handle(request)) as JSONRPCErrorResponse;
+      const response = (await transportHandler.handle(
+        request,
+        defaultContext
+      )) as JSONRPCErrorResponse;
       expect(response.error.code).to.equal(A2A_ERROR_CODE.INVALID_PARAMS);
       expect(response.error.message).to.equal('Invalid JSON-RPC Request.');
       expect(response.id).to.equal(1.23);
@@ -110,7 +134,7 @@ describe('JsonRpcTransportHandler', () => {
         id: 'abc-123',
         params: {},
       };
-      const response = await transportHandler.handle(request);
+      const response = await transportHandler.handle(request, defaultContext);
       expect(response).to.have.property('result');
     });
 
@@ -121,7 +145,7 @@ describe('JsonRpcTransportHandler', () => {
         id: 456,
         params: {},
       };
-      const response = await transportHandler.handle(request);
+      const response = await transportHandler.handle(request, defaultContext);
       expect(response).to.have.property('result');
     });
 
@@ -135,7 +159,7 @@ describe('JsonRpcTransportHandler', () => {
       (mockRequestHandler.getAuthenticatedExtendedAgentCard as Mock).mockResolvedValue({
         card: 'data',
       });
-      const response = await transportHandler.handle(request);
+      const response = await transportHandler.handle(request, defaultContext);
       expect(response).to.have.property('result');
     });
 
@@ -155,7 +179,10 @@ describe('JsonRpcTransportHandler', () => {
           id: 1,
           params,
         };
-        const response = (await transportHandler.handle(request)) as JSONRPCErrorResponse;
+        const response = (await transportHandler.handle(
+          request,
+          defaultContext
+        )) as JSONRPCErrorResponse;
         expect(response.error.code).to.equal(A2A_ERROR_CODE.INVALID_PARAMS);
         expect(response.error.message).to.equal('Invalid method parameters.');
         expect(response.id).to.equal(1);
@@ -169,7 +196,7 @@ describe('JsonRpcTransportHandler', () => {
         id: 456,
         params: { this: 'is a dict' },
       };
-      const response = await transportHandler.handle(request);
+      const response = await transportHandler.handle(request, defaultContext);
       expect(response).to.have.property('result');
     });
   });

--- a/test/server/mocks/push_notification_sender.mock.ts
+++ b/test/server/mocks/push_notification_sender.mock.ts
@@ -1,7 +1,8 @@
 import { vi, type Mock } from 'vitest';
 import { Task } from '../../../src/index.js';
 import { PushNotificationSender } from '../../../src/server/push_notification/push_notification_sender.js';
+import { ServerCallContext } from '../../../src/server/context.js';
 
 export class MockPushNotificationSender implements PushNotificationSender {
-  public send: Mock<(task: Task) => Promise<void>> = vi.fn();
+  public send: Mock<(task: Task, context: ServerCallContext) => Promise<void>> = vi.fn();
 }

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -40,6 +40,7 @@ describe('Push Notification Integration Tests', () => {
   let pushNotificationStore: InMemoryPushNotificationStore;
   let pushNotificationSender: DefaultPushNotificationSender;
   let pushNotificationSenderSpy: PushNotificationSenderSpy;
+  let defaultContext: ServerCallContext;
 
   const testAgentCard: AgentCard = {
     name: 'Test Agent',
@@ -137,6 +138,7 @@ describe('Push Notification Integration Tests', () => {
     pushNotificationStore = new InMemoryPushNotificationStore();
     pushNotificationSender = new DefaultPushNotificationSender(pushNotificationStore);
     pushNotificationSenderSpy = vi.spyOn(pushNotificationSender, 'send');
+    defaultContext = new ServerCallContext();
 
     handler = new DefaultRequestHandler(
       testAgentCard,
@@ -215,7 +217,7 @@ describe('Push Notification Integration Tests', () => {
       });
 
       // Send message and wait for completion
-      await handler.sendMessage(params);
+      await handler.sendMessage(params, defaultContext);
 
       // Wait for async push notifications to be sent
       await waitForPushNotifications(pushNotificationSenderSpy);
@@ -315,12 +317,12 @@ describe('Push Notification Integration Tests', () => {
         artifacts: [],
         metadata: {},
       };
-      await taskStore.save(task);
+      await taskStore.save(task, defaultContext);
 
       // Set multiple push notification configs for this message
-      await handler.createTaskPushNotificationConfig(pushConfig1, new ServerCallContext());
+      await handler.createTaskPushNotificationConfig(pushConfig1, defaultContext);
 
-      await handler.createTaskPushNotificationConfig(pushConfig2, new ServerCallContext());
+      await handler.createTaskPushNotificationConfig(pushConfig2, defaultContext);
 
       // Mock the agent executor to publish only completed state
       mockAgentExecutor.execute.mockImplementation(async (ctx, bus) => {
@@ -355,7 +357,7 @@ describe('Push Notification Integration Tests', () => {
       });
 
       // Send a message to trigger notifications
-      await handler.sendMessage(params);
+      await handler.sendMessage(params, defaultContext);
 
       // Wait for async push notifications to be sent
       await waitForPushNotifications(pushNotificationSenderSpy);
@@ -420,7 +422,7 @@ describe('Push Notification Integration Tests', () => {
       });
 
       // Send message and wait for completion - this should not throw an error
-      const result = await handler.sendMessage(params);
+      const result = await handler.sendMessage(params, defaultContext);
       const taskResult = result as Task;
 
       // Wait for async push notifications to be sent
@@ -509,7 +511,7 @@ describe('Push Notification Integration Tests', () => {
         bus.finished();
       });
 
-      await handler.sendMessage(params);
+      await handler.sendMessage(params, defaultContext);
 
       // Wait for async push notifications to be sent
       await waitForPushNotifications(pushNotificationSenderSpy);
@@ -607,7 +609,7 @@ describe('Push Notification Integration Tests', () => {
         bus.finished();
       });
 
-      await customHandler.sendMessage(params);
+      await customHandler.sendMessage(params, defaultContext);
 
       // Wait for async push notifications to be sent
       await waitForPushNotifications(customSenderSpy);
@@ -691,7 +693,7 @@ describe('Push Notification Integration Tests', () => {
         bus.finished();
       });
 
-      await handler.sendMessage(params);
+      await handler.sendMessage(params, defaultContext);
 
       // Wait for async push notifications to be sent
       await waitForPushNotifications(pushNotificationSenderSpy);
@@ -778,11 +780,11 @@ describe('Push Notification Integration Tests', () => {
         artifacts: [],
         metadata: {},
       };
-      await taskStore.save(task);
+      await taskStore.save(task, defaultContext);
 
-      await customHandler.createTaskPushNotificationConfig(pushConfig1, new ServerCallContext());
+      await customHandler.createTaskPushNotificationConfig(pushConfig1, defaultContext);
 
-      await customHandler.createTaskPushNotificationConfig(pushConfig2, new ServerCallContext());
+      await customHandler.createTaskPushNotificationConfig(pushConfig2, defaultContext);
 
       // Mock the agent executor to publish completion
       mockAgentExecutor.execute.mockImplementation(async (ctx, bus) => {
@@ -803,7 +805,7 @@ describe('Push Notification Integration Tests', () => {
         bus.finished();
       });
 
-      await customHandler.sendMessage(params);
+      await customHandler.sendMessage(params, defaultContext);
 
       // Wait for async push notifications to be sent
       await waitForPushNotifications(customSenderSpy);


### PR DESCRIPTION
# Description

Made `ServerCallContext` a mandatory parameter across all extension points.

Notes:

`InMemoryTaskStore` does not use the `ServerCallContext` but still accepts it as an argument to align with `TaskStore` interface which it implements.

Fixes #179  🦕
