### PR TITLE
fix: allow DataPart to accept JSON values

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export type A2ARequest =
  * via the `definition` "Part".
  */
 export type Part = TextPart | FilePart | DataPart;
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [k: string]: JsonValue };
 /**
  * Defines a security scheme that can be used to secure an agent's endpoints.
  * This is a discriminated union type based on the OpenAPI 3.0 Security Scheme Object.
@@ -675,9 +676,7 @@ export interface DataPart {
   /**
    * The structured data content.
    */
-  data: {
-    [k: string]: unknown;
-  };
+  data: JsonValue;
   /**
    * The type of this part, used as a discriminator. Always 'data'.
    */

--- a/test/server/grpc/from_proto.spec.ts
+++ b/test/server/grpc/from_proto.spec.ts
@@ -221,6 +221,21 @@ describe('FromProto', () => {
       expect(result).toEqual({ kind: 'data', data });
     });
 
+    it('should convert data parts with array and scalar values', () => {
+      const arrayData = ['foo', { nested: true }, 3];
+      const scalarData = 7;
+
+      const arrayPart = {
+        part: { $case: 'data', value: { data: arrayData } },
+      } as any as proto.Part;
+      const scalarPart = {
+        part: { $case: 'data', value: { data: scalarData } },
+      } as any as proto.Part;
+
+      expect(FromProto.part(arrayPart)).toEqual({ kind: 'data', data: arrayData });
+      expect(FromProto.part(scalarPart)).toEqual({ kind: 'data', data: scalarData });
+    });
+
     it('should throw for an unknown part type', () => {
       const part: proto.Part = { part: { $case: 'invalid', value: undefined } as any }; // Invalid state
       expect(() => FromProto.part(part)).toThrow(new A2AError(-32602, 'Invalid part type'));

--- a/test/server/grpc/to_proto.spec.ts
+++ b/test/server/grpc/to_proto.spec.ts
@@ -150,6 +150,21 @@ describe('ToProto', () => {
       });
     });
 
+    it('should convert data parts with array and scalar values', () => {
+      const arrayData = ['foo', { nested: true }, 3];
+      const scalarData = 7;
+
+      const arrayPart: types.Part = { kind: 'data', data: arrayData };
+      const scalarPart: types.Part = { kind: 'data', data: scalarData };
+
+      expect(ToProto.part(arrayPart)).toEqual({
+        part: { $case: 'data', value: { data: arrayData } },
+      });
+      expect(ToProto.part(scalarPart)).toEqual({
+        part: { $case: 'data', value: { data: scalarData } },
+      });
+    });
+
     it('should throw for an unknown part type', () => {
       const part: types.Part = { kind: 'unknown' } as any;
       expect(() => ToProto.part(part)).toThrow(new A2AError(-32603, 'Invalid part type'));

--- a/test/typecheck/data_part_json_value.ts
+++ b/test/typecheck/data_part_json_value.ts
@@ -1,0 +1,17 @@
+import type { DataPart, Part } from '../../src/types.js';
+
+const arrayDataPart: DataPart = {
+  kind: 'data',
+  data: ['foo', { nested: true }, 3],
+};
+
+const scalarDataPart: DataPart = {
+  kind: 'data',
+  data: 7,
+};
+
+const arrayPart: Part = arrayDataPart;
+const scalarPart: Part = scalarDataPart;
+
+void arrayPart;
+void scalarPart;

--- a/test/typecheck/tsconfig.json
+++ b/test/typecheck/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["./data_part_json_value.ts"]
+}


### PR DESCRIPTION
## Summary
- widen DataPart.data to accept any JSON-compatible value instead of only string-keyed objects
- add converter regression tests for array and scalar data parts on the gRPC path
- add a focused TypeScript typecheck fixture that fails if arrays or scalars stop being accepted again

## Verification
- npx tsc --project test/typecheck/tsconfig.json
- npm test -- test/server/grpc/to_proto.spec.ts test/server/grpc/from_proto.spec.ts
- npx eslint test/server/grpc/to_proto.spec.ts test/server/grpc/from_proto.spec.ts test/typecheck/data_part_json_value.ts
- npx prettier --check test/server/grpc/to_proto.spec.ts test/server/grpc/from_proto.spec.ts test/typecheck/data_part_json_value.ts test/typecheck/tsconfig.json

Note: I did not run 
px prettier --check src/types.ts because the generated file is not currently in repo-wide Prettier baseline and the current formatter wants to restyle the whole file.

Closes #338