### PR TITLE
feat: Remove proto conversion methods for listTaskPushNotificationConfig type

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -9,7 +9,7 @@ exports[`TypeScript Strict Mode`] = {
       [248, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"],
       [271, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"]
     ],
-    "src/server/express/rest_handler.ts:3786025326": [
+    "src/server/express/rest_handler.ts:3969358401": [
       [208, 50, 17, "tsc: Argument of type \'unknown\' is not assignable to parameter of type \'Message | Task | TaskArtifactUpdateEvent | TaskStatusUpdateEvent\'.", "3749434707"]
     ],
     "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:2973243771": [

--- a/.betterer.results
+++ b/.betterer.results
@@ -9,14 +9,14 @@ exports[`TypeScript Strict Mode`] = {
       [248, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"],
       [271, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"]
     ],
-    "src/server/express/rest_handler.ts:1777885052": [
+    "src/server/express/rest_handler.ts:3786025326": [
       [208, 50, 17, "tsc: Argument of type \'unknown\' is not assignable to parameter of type \'Message | Task | TaskArtifactUpdateEvent | TaskStatusUpdateEvent\'.", "3749434707"]
     ],
     "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:2973243771": [
       [90, 12, 10, "tsc: Variable \'rpcRequest\' is used before being assigned.", "3927050741"]
     ],
-    "src/types/converters/to_proto.ts:1276072555": [
-      [57, 52, 19, "tsc: Function lacks ending return statement and return type does not include \'undefined\'.", "2245381585"]
+    "src/types/converters/to_proto.ts:4278018124": [
+      [46, 52, 19, "tsc: Function lacks ending return statement and return type does not include \'undefined\'.", "2245381585"]
     ]
   }`
 };

--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ yarn-error.log
 .project
 .classpath
 .c9/
+.vscode/
 *.launch
 .settings/
 *.sublime-workspace

--- a/src/client/multitransport-client.ts
+++ b/src/client/multitransport-client.ts
@@ -12,6 +12,7 @@ import {
   GetTaskPushNotificationConfigRequest,
   GetTaskRequest,
   ListTaskPushNotificationConfigsRequest,
+  ListTaskPushNotificationConfigsResponse,
   SendMessageConfiguration,
   SendMessageRequest,
   SubscribeToTaskRequest,
@@ -211,7 +212,7 @@ export class Client {
   listTaskPushNotificationConfig(
     params: ListTaskPushNotificationConfigsRequest,
     options?: RequestOptions
-  ): Promise<TaskPushNotificationConfig[]> {
+  ): Promise<ListTaskPushNotificationConfigsResponse> {
     if (!this.agentCard.capabilities?.pushNotifications) {
       throw new PushNotificationNotSupportedError();
     }

--- a/src/client/transports/grpc/grpc_transport.ts
+++ b/src/client/transports/grpc/grpc_transport.ts
@@ -7,7 +7,7 @@ import {
   ListTaskPushNotificationConfigsRequest,
   SubscribeToTaskRequest,
 } from '../../../grpc/pb/a2a.js';
-import { Task, AgentCard } from '../../../types/pb/a2a.js';
+import { Task, AgentCard, ListTaskPushNotificationConfigsResponse } from '../../../types/pb/a2a.js';
 import {
   CancelTaskRequest,
   DeleteTaskPushNotificationConfigRequest,
@@ -153,7 +153,7 @@ export class GrpcTransport implements Transport {
       params,
       options,
       this.grpcClient.listTaskPushNotificationConfigs.bind(this.grpcClient),
-      FromProto.listTaskPushNotificationConfig
+      (res) => (res as ListTaskPushNotificationConfigsResponse).configs
     );
     return rpcResponse;
   }

--- a/src/client/transports/grpc/grpc_transport.ts
+++ b/src/client/transports/grpc/grpc_transport.ts
@@ -147,13 +147,17 @@ export class GrpcTransport implements Transport {
   async listTaskPushNotificationConfig(
     params: ListTaskPushNotificationConfigsRequest,
     options?: RequestOptions
-  ): Promise<TaskPushNotificationConfig[]> {
-    const rpcResponse = await this._sendGrpcRequest(
+  ): Promise<ListTaskPushNotificationConfigsResponse> {
+    const rpcResponse = await this._sendGrpcRequest<
+      ListTaskPushNotificationConfigsRequest,
+      ListTaskPushNotificationConfigsResponse,
+      ListTaskPushNotificationConfigsResponse
+    >(
       'listTaskPushNotificationConfigs',
       params,
       options,
       this.grpcClient.listTaskPushNotificationConfigs.bind(this.grpcClient),
-      (res) => (res as ListTaskPushNotificationConfigsResponse).configs
+      (res) => res
     );
     return rpcResponse;
   }

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -128,7 +128,6 @@ export class JsonRpcTransport implements Transport {
       ListTaskPushNotificationConfigsResponse
     >('ListTaskPushNotificationConfigs', params, options, ListTaskPushNotificationConfigsRequest);
     return ListTaskPushNotificationConfigsResponse.fromJSON(rpcResponse.result);
-
   }
 
   async deleteTaskPushNotificationConfig(

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -120,13 +120,12 @@ export class JsonRpcTransport implements Transport {
   async listTaskPushNotificationConfig(
     params: ListTaskPushNotificationConfigsRequest,
     options?: RequestOptions
-  ): Promise<TaskPushNotificationConfig[]> {
+  ): Promise<ListTaskPushNotificationConfigsResponse> {
     const rpcResponse = await this._sendRpcRequest<
       ListTaskPushNotificationConfigsRequest,
       ListTaskPushNotificationConfigsResponse
     >('ListTaskPushNotificationConfigs', params, options, ListTaskPushNotificationConfigsRequest);
-    const configs = rpcResponse.result.configs || [];
-    return configs.map((c: unknown) => TaskPushNotificationConfig.fromJSON(c));
+    return rpcResponse.result;
   }
 
   async deleteTaskPushNotificationConfig(

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -127,7 +127,8 @@ export class JsonRpcTransport implements Transport {
       ListTaskPushNotificationConfigsRequest,
       ListTaskPushNotificationConfigsResponse
     >('ListTaskPushNotificationConfigs', params, options, ListTaskPushNotificationConfigsRequest);
-    return rpcResponse.result;
+    return ListTaskPushNotificationConfigsResponse.fromJSON(rpcResponse.result);
+
   }
 
   async deleteTaskPushNotificationConfig(

--- a/src/client/transports/rest_transport.ts
+++ b/src/client/transports/rest_transport.ts
@@ -132,7 +132,7 @@ export class RestTransport implements Transport {
   async listTaskPushNotificationConfig(
     params: ListTaskPushNotificationConfigsRequest,
     options?: RequestOptions
-  ): Promise<TaskPushNotificationConfig[]> {
+  ): Promise<ListTaskPushNotificationConfigsResponse> {
     const response = await this._sendRequest<undefined, ListTaskPushNotificationConfigsResponse>(
       'GET',
       `/tasks/${params.taskId}/pushNotificationConfigs`,
@@ -141,7 +141,7 @@ export class RestTransport implements Transport {
       undefined,
       ListTaskPushNotificationConfigsResponse
     );
-    return response.configs;
+    return response;
   }
 
   async deleteTaskPushNotificationConfig(

--- a/src/client/transports/transport.ts
+++ b/src/client/transports/transport.ts
@@ -3,6 +3,7 @@ import {
   SendMessageRequest,
   CancelTaskRequest,
   ListTaskPushNotificationConfigsRequest,
+  ListTaskPushNotificationConfigsResponse,
   DeleteTaskPushNotificationConfigRequest,
   GetTaskRequest,
   GetTaskPushNotificationConfigRequest,
@@ -37,7 +38,7 @@ export interface Transport {
   listTaskPushNotificationConfig(
     params: ListTaskPushNotificationConfigsRequest,
     options?: RequestOptions
-  ): Promise<TaskPushNotificationConfig[]>;
+  ): Promise<ListTaskPushNotificationConfigsResponse>;
 
   deleteTaskPushNotificationConfig(
     params: DeleteTaskPushNotificationConfigRequest,

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -460,15 +460,11 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
         req.params.taskId,
         context
       );
-      const response: ListTaskPushNotificationConfigsResponse = {
-        configs: result,
-        nextPageToken: '',
-      };
       sendResponse<ListTaskPushNotificationConfigsResponse>(
         res,
         HTTP_STATUS.OK,
         context,
-        response,
+        result,
         ListTaskPushNotificationConfigsResponse
       );
     })

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -460,12 +460,15 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
         req.params.taskId,
         context
       );
-      const protoResult = ToProto.listTaskPushNotificationConfig(result);
+      const response: ListTaskPushNotificationConfigsResponse = {
+        configs: result,
+        nextPageToken: '',
+      };
       sendResponse<ListTaskPushNotificationConfigsResponse>(
         res,
         HTTP_STATUS.OK,
         context,
-        protoResult,
+        response,
         ListTaskPushNotificationConfigsResponse
       );
     })

--- a/src/server/grpc/grpc_service.ts
+++ b/src/server/grpc/grpc_service.ts
@@ -171,12 +171,7 @@ export function grpcService(options: GrpcServiceOptions): A2AServiceServer {
         callback,
         (req) => req,
         requestHandler.listTaskPushNotificationConfigs.bind(requestHandler),
-        (res) => {
-          return {
-            configs: res,
-            nextPageToken: '',
-          };
-        }
+        (res) => res
       );
     },
 

--- a/src/server/grpc/grpc_service.ts
+++ b/src/server/grpc/grpc_service.ts
@@ -171,7 +171,12 @@ export function grpcService(options: GrpcServiceOptions): A2AServiceServer {
         callback,
         (req) => req,
         requestHandler.listTaskPushNotificationConfigs.bind(requestHandler),
-        ToProto.listTaskPushNotificationConfig
+        (res) => {
+          return {
+            configs: res,
+            nextPageToken: '',
+          };
+        }
       );
     },
 

--- a/src/server/request_handler/a2a_request_handler.ts
+++ b/src/server/request_handler/a2a_request_handler.ts
@@ -14,6 +14,7 @@ import {
   SendMessageRequest,
   ListTasksRequest,
   ListTasksResponse,
+  ListTaskPushNotificationConfigsResponse,
 } from '../../index.js';
 import { ServerCallContext } from '../context.js';
 
@@ -49,7 +50,7 @@ export interface A2ARequestHandler {
   listTaskPushNotificationConfigs(
     params: ListTaskPushNotificationConfigsRequest,
     context: ServerCallContext
-  ): Promise<TaskPushNotificationConfig[]>;
+  ): Promise<ListTaskPushNotificationConfigsResponse>;
 
   deleteTaskPushNotificationConfig(
     params: DeleteTaskPushNotificationConfigRequest,

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -28,6 +28,7 @@ import {
   SubscribeToTaskRequest,
   ListTasksRequest,
   ListTasksResponse,
+  ListTaskPushNotificationConfigsResponse,
 } from '../../index.js';
 import { AgentExecutor } from '../agent_execution/agent_executor.js';
 import { RequestContext } from '../agent_execution/request_context.js';
@@ -568,7 +569,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   async listTaskPushNotificationConfigs(
     params: ListTaskPushNotificationConfigsRequest,
     context: ServerCallContext
-  ): Promise<TaskPushNotificationConfig[]> {
+  ): Promise<ListTaskPushNotificationConfigsResponse> {
     if (!this.agentCard.capabilities?.pushNotifications) {
       throw new PushNotificationNotSupportedError();
     }
@@ -578,7 +579,10 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
 
-    return (await this.pushNotificationStore?.load(taskId, context)) || [];
+    return {
+      configs: (await this.pushNotificationStore?.load(taskId, context)) || [],
+      nextPageToken: '',
+    };
   }
 
   async deleteTaskPushNotificationConfig(

--- a/src/server/transports/rest/rest_transport_handler.ts
+++ b/src/server/transports/rest/rest_transport_handler.ts
@@ -20,6 +20,7 @@ import {
   ListTasksRequest,
   ListTasksResponse,
   TaskState,
+  ListTaskPushNotificationConfigsResponse,
 } from '../../../index.js';
 import {
   ExtendedAgentCardNotConfiguredError,
@@ -247,12 +248,12 @@ export class RestTransportHandler {
   async listTaskPushNotificationConfigs(
     taskId: string,
     context: ServerCallContext
-  ): Promise<TaskPushNotificationConfig[]> {
-    const configs = await this.requestHandler.listTaskPushNotificationConfigs(
+  ): Promise<ListTaskPushNotificationConfigsResponse> {
+    const result = await this.requestHandler.listTaskPushNotificationConfigs(
       { taskId, pageSize: 0, pageToken: '', tenant: '' },
       context
     );
-    return configs;
+    return result;
   }
 
   /**

--- a/src/types/converters/from_proto.ts
+++ b/src/types/converters/from_proto.ts
@@ -3,8 +3,6 @@ import {
   Message,
   SendMessageResponse,
   Task,
-  TaskPushNotificationConfig,
-  ListTaskPushNotificationConfigsResponse,
   TaskStatusUpdateEvent,
   TaskArtifactUpdateEvent,
   StreamResponse,
@@ -23,12 +21,6 @@ export class FromProto {
       return response.payload.value;
     }
     throw new GenericError('Invalid SendMessageResponse: missing result');
-  }
-
-  static listTaskPushNotificationConfig(
-    request: ListTaskPushNotificationConfigsResponse
-  ): TaskPushNotificationConfig[] {
-    return request.configs;
   }
 
   static messageStreamResult(

--- a/src/types/converters/to_proto.ts
+++ b/src/types/converters/to_proto.ts
@@ -5,21 +5,10 @@ import {
   StreamResponse,
   Task,
   TaskArtifactUpdateEvent,
-  TaskPushNotificationConfig,
   TaskStatusUpdateEvent,
-  ListTaskPushNotificationConfigsResponse,
 } from '../pb/a2a.js';
 
 export class ToProto {
-  static listTaskPushNotificationConfig(
-    configs: TaskPushNotificationConfig[]
-  ): ListTaskPushNotificationConfigsResponse {
-    return {
-      configs,
-      nextPageToken: '',
-    };
-  }
-
   static messageStreamResult(
     event: Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent
   ): StreamResponse {

--- a/test/client/transports/grpc_transport.spec.ts
+++ b/test/client/transports/grpc_transport.spec.ts
@@ -351,7 +351,7 @@ describe('GrpcTransport', () => {
           pageToken: '',
         });
 
-        expect(result).toEqual(mockList);
+        expect(result.configs).toEqual(mockList);
       });
     });
 

--- a/test/client/transports/grpc_transport.spec.ts
+++ b/test/client/transports/grpc_transport.spec.ts
@@ -340,7 +340,9 @@ describe('GrpcTransport', () => {
     describe('listTaskPushNotificationConfig', () => {
       it('should list configs successfully', async () => {
         const mockList = [mockConfig];
-        mockUnarySuccess(mockGrpcClient.listTaskPushNotificationConfigs as Mock, mockList);
+        mockUnarySuccess(mockGrpcClient.listTaskPushNotificationConfigs as Mock, {
+          configs: mockList,
+        });
 
         const result = await transport.listTaskPushNotificationConfig({
           taskId,

--- a/test/client/transports/json_rpc_transport.spec.ts
+++ b/test/client/transports/json_rpc_transport.spec.ts
@@ -200,8 +200,8 @@ describe('JsonRpcTransport', () => {
       const body = JSON.parse(fetchArgs.body as string);
       expect(body.method).toBe('ListTaskPushNotificationConfigs');
       expect(body.params).toEqual({ taskId: 'task1' });
-      expect(result).toHaveLength(1);
-      expect(result[0]).toEqual(expectedConfig);
+      expect(result.configs).toHaveLength(1);
+      expect(result.configs[0]).toEqual(expectedConfig);
     });
   });
 });

--- a/test/client/transports/rest_transport.spec.ts
+++ b/test/client/transports/rest_transport.spec.ts
@@ -334,7 +334,7 @@ describe('RestTransport', () => {
           pageToken: '',
         });
 
-        expect(result).to.deep.equal(expectedConfigs);
+        expect(result.configs).to.deep.equal(expectedConfigs);
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
         const [url, options] = mockFetch.mock.calls[0];

--- a/test/client/transports/rest_transport.spec.ts
+++ b/test/client/transports/rest_transport.spec.ts
@@ -27,7 +27,6 @@ import {
   TaskState,
   TaskPushNotificationConfig,
 } from '../../../src/types/pb/a2a.js';
-import { ToProto } from '../../../src/types/converters/to_proto.js';
 
 describe('RestTransport', () => {
   let transport: RestTransport;
@@ -321,9 +320,10 @@ describe('RestTransport', () => {
         ];
         mockFetch.mockResolvedValue(
           createRestResponse(
-            ListTaskPushNotificationConfigsResponse.toJSON(
-              ToProto.listTaskPushNotificationConfig(protoConfigs)
-            )
+            ListTaskPushNotificationConfigsResponse.toJSON({
+              configs: protoConfigs,
+              nextPageToken: '',
+            })
           )
         );
 

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -1451,7 +1451,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       serverCallContext
     );
 
-    const configs = await handler.listTaskPushNotificationConfigs(
+    const result = await handler.listTaskPushNotificationConfigs(
       {
         tenant: '',
         taskId: taskId,
@@ -1460,8 +1460,9 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       },
       serverCallContext
     );
-    expect(configs).to.have.lengthOf(1);
-    expect(configs[0].url).to.equal('https://new.url');
+    expect(result.configs).to.have.lengthOf(1);
+    expect(result.configs[0].url).to.equal('https://new.url');
+    expect(result.nextPageToken).to.equal('');
   });
 
   it('listTaskPushNotificationConfigs: should return all configs for a task', async () => {
@@ -1522,10 +1523,9 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       pageSize: 0,
       pageToken: '',
     };
-    const listResponse = await handler.listTaskPushNotificationConfigs(
-      listParams,
-      serverCallContext
-    );
+    const listResponse = (
+      await handler.listTaskPushNotificationConfigs(listParams, serverCallContext)
+    ).configs;
 
     expect(listResponse).to.be.an('array').with.lengthOf(2);
     assert.deepInclude(listResponse, {
@@ -1605,15 +1605,17 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     };
     await handler.deleteTaskPushNotificationConfig(deleteParams, serverCallContext);
 
-    const remainingConfigs = await handler.listTaskPushNotificationConfigs(
-      {
-        taskId: taskId,
-        tenant: '',
-        pageSize: 0,
-        pageToken: '',
-      },
-      serverCallContext
-    );
+    const remainingConfigs = (
+      await handler.listTaskPushNotificationConfigs(
+        {
+          taskId: taskId,
+          tenant: '',
+          pageSize: 0,
+          pageToken: '',
+        },
+        serverCallContext
+      )
+    ).configs;
     expect(remainingConfigs).to.have.lengthOf(1);
     expect(remainingConfigs[0].id).to.equal('cfg-del-2');
   });
@@ -1660,7 +1662,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       serverCallContext
     );
 
-    const configs = await handler.listTaskPushNotificationConfigs(
+    const result = await handler.listTaskPushNotificationConfigs(
       {
         taskId: taskId,
         tenant: '',
@@ -1669,7 +1671,8 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       },
       serverCallContext
     );
-    expect(configs).to.be.an('array').with.lengthOf(0);
+    expect(result.configs).to.be.an('array').with.lengthOf(0);
+    expect(result.nextPageToken).to.equal('');
   });
 
   it('should send push notification when task update is received', async () => {

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -470,7 +470,10 @@ describe('restHandler', () => {
     describe('GET /tasks/:taskId/pushNotificationConfigs', () => {
       it('should list push notification configs and return 200', async () => {
         const configs = [mockConfig];
-        (mockRequestHandler.listTaskPushNotificationConfigs as Mock).mockResolvedValue(configs);
+        (mockRequestHandler.listTaskPushNotificationConfigs as Mock).mockResolvedValue({
+          configs: configs,
+          nextPageToken: '',
+        });
 
         const response = await request(app)
           .get('/tasks/task-1/pushNotificationConfigs')

--- a/test/server/grpc/from_proto.spec.ts
+++ b/test/server/grpc/from_proto.spec.ts
@@ -68,19 +68,6 @@ describe('FromProto', () => {
     });
   });
 
-  describe('listTaskPushNotificationConfig', () => {
-    it('should return configs array', () => {
-      const configs: proto.TaskPushNotificationConfig[] = [
-        { tenant: '', taskId: '', id: 'config-1', url: '', token: '', authentication: undefined },
-      ];
-      const response: proto.ListTaskPushNotificationConfigsResponse = {
-        configs,
-        nextPageToken: '',
-      };
-      expect(FromProto.listTaskPushNotificationConfig(response)).toEqual(configs);
-    });
-  });
-
   describe('messageStreamResult', () => {
     it('should return payload value if payload is present', () => {
       const task: proto.Task = {


### PR DESCRIPTION
# Description

Remove `ToProto`/`FromProto` methods for `listTaskPushNotificationConfig` type.
