### PR TITLE
refactor: Resolve most of the open TODOs

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -9,8 +9,8 @@ exports[`TypeScript Strict Mode`] = {
       [327, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"],
       [350, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"]
     ],
-    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:3231104525": [
-      [91, 12, 10, "tsc: Variable \'rpcRequest\' is used before being assigned.", "3927050741"]
+    "src/server/transports/jsonrpc/jsonrpc_transport_handler.ts:1878858438": [
+      [89, 12, 10, "tsc: Variable \'rpcRequest\' is used before being assigned.", "3927050741"]
     ]
   }`
 };

--- a/src/samples/cli.ts
+++ b/src/samples/cli.ts
@@ -254,7 +254,6 @@ async function fetchAndDisplayAgentCard() {
     }
     console.log(`  Supported Transports: ${Array.from(supportedTransports).join(', ')}`);
 
-    // TODO (https://github.com/a2aproject/a2a-js/issues/179): Add a way to get the protocol name from the transport.
     console.log(
       colorize(
         'green',

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -345,8 +345,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
       const result = await restTransportHandler.getTask(
         req.params.taskId,
         context,
-        //TODO: clarify for version 1.0.0 the format of the historyLength query parameter, and if history should always be added to the returned object
-        req.query.historyLength ?? req.query.history_length
+        req.query.historyLength
       );
       sendResponse<Task>(res, HTTP_STATUS.OK, context, result, Task);
     })

--- a/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -62,9 +62,7 @@ export class JsonRpcTransportHandler {
    * For non-streaming methods, it returns a Promise of a single JSONRPCMessage (Result or ErrorResponse).
    */
   public async handle(
-    // TODO: remove the eslint disable and replace the any (https://github.com/a2aproject/a2a-js/issues/179)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    requestBody: any,
+    requestBody: string | Record<string, unknown>,
     context: ServerCallContext
   ): Promise<JSONRPCResponse | AsyncGenerator<JSONRPCResponse, void, undefined>> {
     let rpcRequest: A2ARequest;

--- a/test/server/jsonrpc_transport_handler.spec.ts
+++ b/test/server/jsonrpc_transport_handler.spec.ts
@@ -56,7 +56,10 @@ describe('JsonRpcTransportHandler', () => {
     });
 
     it('should return an invalid params error for a non-string/non-object request body', async () => {
-      const response = (await transportHandler.handle(123, defaultContext)) as JSONRPCErrorResponse;
+      const response = (await transportHandler.handle(
+        123 as any,
+        defaultContext
+      )) as JSONRPCErrorResponse;
       expect(response.error.code).to.equal(A2A_ERROR_CODE.INVALID_PARAMS);
       expect(response.error.message).to.equal('Invalid request body type.');
     });


### PR DESCRIPTION
# Description

There are currently 4 real TODOs in the codebase:

- Usage of `any` in `jsonrpc_transport_handler.ts` - **FIXED**
- Snake case and camel case acceptance for `historyLength` - **FIXED**
- Stale TODO in cli.ts mentioning exposing protocolName which was already implemented - **TODO REMOVED**
- gRPC error mapping should be removed and the errors themselves enriched - **NOT TACKLED, WILL BE DONE IN THE SEPARATE PR**.
