### PR TITLE
feat: Content type update to application/a2a+json

### DIFF
--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -17,6 +17,7 @@ import {
   TaskPushNotificationConfig,
   SendMessageResult,
   A2A_PROTOCOL_VERSION,
+  A2A_CONTENT_TYPE,
 } from '../../index.js';
 import { RequestOptions } from '../multitransport-client.js';
 import { parseSseStream } from '../../sse_utils.js';
@@ -233,7 +234,7 @@ export class JsonRpcTransport implements Transport {
       id: requestId,
     };
 
-    const httpResponse = await this._fetchRpc(rpcRequest, 'application/json', options);
+    const httpResponse = await this._fetchRpc(rpcRequest, A2A_CONTENT_TYPE, options);
 
     if (!httpResponse.ok) {
       let errorBodyText = '(empty or non-JSON response)';
@@ -273,14 +274,14 @@ export class JsonRpcTransport implements Transport {
 
   private async _fetchRpc(
     rpcRequest: JSONRPCRequest,
-    acceptHeader: string = 'application/json',
+    acceptHeader: string = A2A_CONTENT_TYPE,
     options?: RequestOptions
   ): Promise<Response> {
     const requestInit: RequestInit = {
       method: 'POST',
       headers: {
         ...options?.serviceParameters,
-        'Content-Type': 'application/json',
+        'Content-Type': A2A_CONTENT_TYPE,
         Accept: acceptHeader,
       },
       body: JSON.stringify(rpcRequest),

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -37,6 +37,7 @@ import {
   ListTasksRequest,
   ListTasksResponse,
 } from '../../types/pb/a2a.js';
+import { JSON_CONTENT_TYPE } from '../../constants.js';
 
 const PROTOCOL_NAME: TransportProtocolName = 'JSONRPC';
 
@@ -233,7 +234,7 @@ export class JsonRpcTransport implements Transport {
       id: requestId,
     };
 
-    const httpResponse = await this._fetchRpc(rpcRequest, 'application/json', options);
+    const httpResponse = await this._fetchRpc(rpcRequest, JSON_CONTENT_TYPE, options);
 
     if (!httpResponse.ok) {
       let errorBodyText = '(empty or non-JSON response)';
@@ -273,14 +274,14 @@ export class JsonRpcTransport implements Transport {
 
   private async _fetchRpc(
     rpcRequest: JSONRPCRequest,
-    acceptHeader: string = 'application/json',
+    acceptHeader: string = JSON_CONTENT_TYPE,
     options?: RequestOptions
   ): Promise<Response> {
     const requestInit: RequestInit = {
       method: 'POST',
       headers: {
         ...options?.serviceParameters,
-        'Content-Type': 'application/json',
+        'Content-Type': JSON_CONTENT_TYPE,
         Accept: acceptHeader,
       },
       body: JSON.stringify(rpcRequest),

--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -17,7 +17,6 @@ import {
   TaskPushNotificationConfig,
   SendMessageResult,
   A2A_PROTOCOL_VERSION,
-  A2A_CONTENT_TYPE,
 } from '../../index.js';
 import { RequestOptions } from '../multitransport-client.js';
 import { parseSseStream } from '../../sse_utils.js';
@@ -234,7 +233,7 @@ export class JsonRpcTransport implements Transport {
       id: requestId,
     };
 
-    const httpResponse = await this._fetchRpc(rpcRequest, A2A_CONTENT_TYPE, options);
+    const httpResponse = await this._fetchRpc(rpcRequest, 'application/json', options);
 
     if (!httpResponse.ok) {
       let errorBodyText = '(empty or non-JSON response)';
@@ -274,14 +273,14 @@ export class JsonRpcTransport implements Transport {
 
   private async _fetchRpc(
     rpcRequest: JSONRPCRequest,
-    acceptHeader: string = A2A_CONTENT_TYPE,
+    acceptHeader: string = 'application/json',
     options?: RequestOptions
   ): Promise<Response> {
     const requestInit: RequestInit = {
       method: 'POST',
       headers: {
         ...options?.serviceParameters,
-        'Content-Type': A2A_CONTENT_TYPE,
+        'Content-Type': 'application/json',
         Accept: acceptHeader,
       },
       body: JSON.stringify(rpcRequest),

--- a/src/client/transports/rest_transport.ts
+++ b/src/client/transports/rest_transport.ts
@@ -12,7 +12,7 @@ import {
   VersionNotSupportedError,
 } from '../../errors.js';
 
-import { SendMessageResult, A2A_PROTOCOL_VERSION } from '../../index.js';
+import { SendMessageResult, A2A_PROTOCOL_VERSION, A2A_CONTENT_TYPE } from '../../index.js';
 import { RequestOptions } from '../multitransport-client.js';
 import { parseSseStream } from '../../sse_utils.js';
 import { Transport, TransportFactory } from './transport.js';
@@ -273,11 +273,11 @@ export class RestTransport implements Transport {
 
   private _buildHeaders(
     options: RequestOptions | undefined,
-    acceptHeader: string = 'application/json'
+    acceptHeader: string = A2A_CONTENT_TYPE
   ): HeadersInit {
     return {
       ...options?.serviceParameters,
-      'Content-Type': 'application/json',
+      'Content-Type': A2A_CONTENT_TYPE,
       Accept: acceptHeader,
     };
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,13 @@ export const A2A_VERSION_HEADER = 'A2A-Version';
 export const A2A_PROTOCOL_VERSION = '1.0';
 
 /**
+ * The A2A JSON content type per §11.1.
+ * REST responses SHOULD use this content type.
+ * Push notification payloads MUST use this content type (§14.1).
+ */
+export const A2A_CONTENT_TYPE = 'application/a2a+json';
+
+/**
  * The default page size for listing tasks
  */
 export const DEFAULT_PAGE_SIZE = 50;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,12 @@ export const A2A_VERSION_HEADER = 'A2A-Version';
 export const A2A_PROTOCOL_VERSION = '1.0';
 
 /**
+ * The JSON content type per §9.1.
+ * JSON-RPC requests MUST use this content type.
+ */
+export const JSON_CONTENT_TYPE = 'application/json';
+
+/**
  * The A2A JSON content type per §11.1.
  * REST responses SHOULD use this content type.
  * Push notification payloads MUST use this content type (§14.1).

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
   HTTP_EXTENSION_HEADER,
   A2A_VERSION_HEADER,
   A2A_PROTOCOL_VERSION,
+  A2A_CONTENT_TYPE,
 } from './constants.js';
 export { Extensions, type ExtensionURI } from './extensions.js';
 

--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -10,7 +10,7 @@ import { JSONRPCResponse } from '../transports/jsonrpc/jsonrpc_transport_handler
 import { A2ARequestHandler } from '../request_handler/a2a_request_handler.js';
 import { JsonRpcTransportHandler } from '../transports/jsonrpc/jsonrpc_transport_handler.js';
 import { ServerCallContext } from '../context.js';
-import { A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER } from '../../constants.js';
+import { A2A_CONTENT_TYPE, A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER } from '../../constants.js';
 import { UserBuilder } from './common.js';
 import { SSE_HEADERS, formatSSEEvent, formatSSEErrorEvent } from '../../sse_utils.js';
 import { Extensions } from '../../extensions.js';
@@ -38,7 +38,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
 
   const router = express.Router();
 
-  router.use(express.json(), jsonErrorHandler);
+  router.use(express.json({ type: ['application/json', A2A_CONTENT_TYPE] }), jsonErrorHandler);
 
   router.post('/', async (req: Request, res: Response) => {
     try {
@@ -82,7 +82,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
           };
           if (!res.headersSent) {
             // Should not happen if flushHeaders worked
-            res.status(500).json(errorResponse); // Should be JSON, not SSE here
+            res.status(500).setHeader('Content-Type', A2A_CONTENT_TYPE).json(errorResponse);
           } else {
             // Try to send as last SSE event if possible, though client might have disconnected
             // Use shared formatSSEErrorEvent utility
@@ -96,7 +96,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
       } else {
         // Single JSON-RPC response
         const rpcResponse = rpcResponseOrStream as JSONRPCResponse;
-        res.status(200).json(rpcResponse);
+        res.status(200).setHeader('Content-Type', A2A_CONTENT_TYPE).json(rpcResponse);
       }
     } catch (error) {
       // Catch errors from jsonRpcTransportHandler.handle itself (e.g., initial parse error)
@@ -107,7 +107,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
         error: JsonRpcTransportHandler.mapToJSONRPCError(error),
       };
       if (!res.headersSent) {
-        res.status(500).json(errorResponse);
+        res.status(500).setHeader('Content-Type', A2A_CONTENT_TYPE).json(errorResponse);
       } else if (!res.writableEnded) {
         // If headers sent (likely during a stream attempt that failed early), try to end gracefully
         res.end();

--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -10,7 +10,7 @@ import { JSONRPCResponse } from '../transports/jsonrpc/jsonrpc_transport_handler
 import { A2ARequestHandler } from '../request_handler/a2a_request_handler.js';
 import { JsonRpcTransportHandler } from '../transports/jsonrpc/jsonrpc_transport_handler.js';
 import { ServerCallContext } from '../context.js';
-import { A2A_CONTENT_TYPE, A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER } from '../../constants.js';
+import { A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER } from '../../constants.js';
 import { UserBuilder } from './common.js';
 import { SSE_HEADERS, formatSSEEvent, formatSSEErrorEvent } from '../../sse_utils.js';
 import { Extensions } from '../../extensions.js';
@@ -38,7 +38,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
 
   const router = express.Router();
 
-  router.use(express.json({ type: ['application/json', A2A_CONTENT_TYPE] }), jsonErrorHandler);
+  router.use(express.json(), jsonErrorHandler);
 
   router.post('/', async (req: Request, res: Response) => {
     try {
@@ -82,7 +82,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
           };
           if (!res.headersSent) {
             // Should not happen if flushHeaders worked
-            res.status(500).setHeader('Content-Type', A2A_CONTENT_TYPE).json(errorResponse);
+            res.status(500).json(errorResponse);
           } else {
             // Try to send as last SSE event if possible, though client might have disconnected
             // Use shared formatSSEErrorEvent utility
@@ -96,7 +96,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
       } else {
         // Single JSON-RPC response
         const rpcResponse = rpcResponseOrStream as JSONRPCResponse;
-        res.status(200).setHeader('Content-Type', A2A_CONTENT_TYPE).json(rpcResponse);
+        res.status(200).json(rpcResponse);
       }
     } catch (error) {
       // Catch errors from jsonRpcTransportHandler.handle itself (e.g., initial parse error)
@@ -107,7 +107,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
         error: JsonRpcTransportHandler.mapToJSONRPCError(error),
       };
       if (!res.headersSent) {
-        res.status(500).setHeader('Content-Type', A2A_CONTENT_TYPE).json(errorResponse);
+        res.status(500).json(errorResponse);
       } else if (!res.writableEnded) {
         // If headers sent (likely during a stream attempt that failed early), try to end gracefully
         res.end();

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -14,7 +14,7 @@ import {
   toHTTPError,
 } from '../transports/rest/rest_transport_handler.js';
 import { ServerCallContext } from '../context.js';
-import { A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER } from '../../constants.js';
+import { A2A_CONTENT_TYPE, A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER } from '../../constants.js';
 import { UserBuilder } from './common.js';
 import { Extensions } from '../../extensions.js';
 import { validateVersion } from '../version.js';
@@ -57,7 +57,10 @@ const restErrorHandler: ErrorRequestHandler = (
   next: NextFunction
 ) => {
   if (err instanceof SyntaxError && 'body' in err) {
-    return res.status(400).json(toHTTPError(new RequestMalformedError('Invalid JSON payload.')));
+    return res
+      .status(400)
+      .setHeader('Content-Type', A2A_CONTENT_TYPE)
+      .json(toHTTPError(new RequestMalformedError('Invalid JSON payload.')));
   }
   next(err);
 };
@@ -101,7 +104,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   const router = express.Router();
   const restTransportHandler = new RestTransportHandler(options.requestHandler);
 
-  router.use(express.json(), restErrorHandler);
+  router.use(express.json({ type: ['application/json', A2A_CONTENT_TYPE] }), restErrorHandler);
 
   // ============================================================================
   // Helper Functions
@@ -171,6 +174,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
       if (!responseType || body === undefined) {
         throw new Error('Bug: toJson serializer and body must be provided for non-204 responses.');
       }
+      res.setHeader('Content-Type', A2A_CONTENT_TYPE);
       res.json(responseType.toJSON(body));
     }
   };
@@ -199,7 +203,8 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
     } catch (error) {
       // Early error - return proper HTTP error
       setExtensionsHeader(res, context);
-      res.status(mapErrorToStatus(error)).json(toHTTPError(error));
+      const statusCode = mapErrorToStatus(error);
+      res.status(statusCode).setHeader('Content-Type', A2A_CONTENT_TYPE).json(toHTTPError(error));
       return;
     }
 
@@ -248,7 +253,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
       return;
     }
     const statusCode = mapErrorToStatus(error);
-    res.status(statusCode).json(toHTTPError(error));
+    res.status(statusCode).setHeader('Content-Type', A2A_CONTENT_TYPE).json(toHTTPError(error));
   };
 
   /**

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -14,7 +14,12 @@ import {
   toHTTPError,
 } from '../transports/rest/rest_transport_handler.js';
 import { ServerCallContext } from '../context.js';
-import { A2A_CONTENT_TYPE, A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER } from '../../constants.js';
+import {
+  JSON_CONTENT_TYPE,
+  A2A_CONTENT_TYPE,
+  A2A_VERSION_HEADER,
+  HTTP_EXTENSION_HEADER,
+} from '../../constants.js';
 import { UserBuilder } from './common.js';
 import { Extensions } from '../../extensions.js';
 import { validateVersion } from '../version.js';
@@ -106,7 +111,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
       res.setHeader('Content-Type', A2A_CONTENT_TYPE);
       next();
     },
-    express.json({ type: ['application/json', A2A_CONTENT_TYPE] }),
+    express.json({ type: [JSON_CONTENT_TYPE, A2A_CONTENT_TYPE] }),
     restErrorHandler
   );
 

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -57,10 +57,7 @@ const restErrorHandler: ErrorRequestHandler = (
   next: NextFunction
 ) => {
   if (err instanceof SyntaxError && 'body' in err) {
-    return res
-      .status(400)
-      .setHeader('Content-Type', A2A_CONTENT_TYPE)
-      .json(toHTTPError(new RequestMalformedError('Invalid JSON payload.')));
+    return res.status(400).json(toHTTPError(new RequestMalformedError('Invalid JSON payload.')));
   }
   next(err);
 };
@@ -104,7 +101,14 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   const router = express.Router();
   const restTransportHandler = new RestTransportHandler(options.requestHandler);
 
-  router.use(express.json({ type: ['application/json', A2A_CONTENT_TYPE] }), restErrorHandler);
+  router.use(
+    (_req: Request, res: Response, next: NextFunction) => {
+      res.setHeader('Content-Type', A2A_CONTENT_TYPE);
+      next();
+    },
+    express.json({ type: ['application/json', A2A_CONTENT_TYPE] }),
+    restErrorHandler
+  );
 
   // ============================================================================
   // Helper Functions
@@ -174,7 +178,6 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
       if (!responseType || body === undefined) {
         throw new Error('Bug: toJson serializer and body must be provided for non-204 responses.');
       }
-      res.setHeader('Content-Type', A2A_CONTENT_TYPE);
       res.json(responseType.toJSON(body));
     }
   };
@@ -204,7 +207,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
       // Early error - return proper HTTP error
       setExtensionsHeader(res, context);
       const statusCode = mapErrorToStatus(error);
-      res.status(statusCode).setHeader('Content-Type', A2A_CONTENT_TYPE).json(toHTTPError(error));
+      res.status(statusCode).json(toHTTPError(error));
       return;
     }
 
@@ -253,7 +256,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
       return;
     }
     const statusCode = mapErrorToStatus(error);
-    res.status(statusCode).setHeader('Content-Type', A2A_CONTENT_TYPE).json(toHTTPError(error));
+    res.status(statusCode).json(toHTTPError(error));
   };
 
   /**

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -206,8 +206,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
     } catch (error) {
       // Early error - return proper HTTP error
       setExtensionsHeader(res, context);
-      const statusCode = mapErrorToStatus(error);
-      res.status(statusCode).json(toHTTPError(error));
+      res.status(mapErrorToStatus(error)).json(toHTTPError(error));
       return;
     }
 

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -102,7 +102,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
 
     try {
       const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
+        'Content-Type': 'application/a2a+json',
       };
 
       if (pushConfig.token) {

--- a/test/client/client_auth.spec.ts
+++ b/test/client/client_auth.spec.ts
@@ -122,8 +122,8 @@ describe('JsonRpcTransport Authentication Tests', () => {
       expect(mockFetch.mock.calls[0][1]).to.deep.include({
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
+          'Content-Type': 'application/a2a+json',
+          Accept: 'application/a2a+json',
         },
       });
       expect(mockFetch.mock.calls[0][1].body).to.include('"method":"SendMessage"');
@@ -136,9 +136,9 @@ describe('JsonRpcTransport Authentication Tests', () => {
       // Check headers separately to avoid issues with Authorization header
       expect(mockFetch.mock.calls[1][1].headers).to.have.property(
         'Content-Type',
-        'application/json'
+        'application/a2a+json'
       );
-      expect(mockFetch.mock.calls[1][1].headers).to.have.property('Accept', 'application/json');
+      expect(mockFetch.mock.calls[1][1].headers).to.have.property('Accept', 'application/a2a+json');
       expect(mockFetch.mock.calls[1][1].headers).to.have.property('Authorization');
 
       expect(mockFetch.mock.calls[1][1].headers['Authorization']).to.match(/^Bearer .+$/);

--- a/test/client/client_auth.spec.ts
+++ b/test/client/client_auth.spec.ts
@@ -122,8 +122,8 @@ describe('JsonRpcTransport Authentication Tests', () => {
       expect(mockFetch.mock.calls[0][1]).to.deep.include({
         method: 'POST',
         headers: {
-          'Content-Type': 'application/a2a+json',
-          Accept: 'application/a2a+json',
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
         },
       });
       expect(mockFetch.mock.calls[0][1].body).to.include('"method":"SendMessage"');
@@ -136,9 +136,9 @@ describe('JsonRpcTransport Authentication Tests', () => {
       // Check headers separately to avoid issues with Authorization header
       expect(mockFetch.mock.calls[1][1].headers).to.have.property(
         'Content-Type',
-        'application/a2a+json'
+        'application/json'
       );
-      expect(mockFetch.mock.calls[1][1].headers).to.have.property('Accept', 'application/a2a+json');
+      expect(mockFetch.mock.calls[1][1].headers).to.have.property('Accept', 'application/json');
       expect(mockFetch.mock.calls[1][1].headers).to.have.property('Authorization');
 
       expect(mockFetch.mock.calls[1][1].headers['Authorization']).to.match(/^Bearer .+$/);

--- a/test/client/transports/rest_transport.spec.ts
+++ b/test/client/transports/rest_transport.spec.ts
@@ -97,7 +97,7 @@ describe('RestTransport', () => {
       expect(url).to.equal(`${endpoint}/message:send`);
       expect(options?.method).to.equal('POST');
       expect((options?.headers as Record<string, string>)['Content-Type']).to.equal(
-        'application/json'
+        'application/a2a+json'
       );
     });
 

--- a/test/client/util.ts
+++ b/test/client/util.ts
@@ -3,7 +3,7 @@
  */
 
 import { vi, Mock } from 'vitest';
-import { AGENT_CARD_PATH } from '../../src/constants.js';
+import { AGENT_CARD_PATH, JSON_CONTENT_TYPE } from '../../src/constants.js';
 import { Role, SendMessageResponse, Task, TaskState } from '../../src/types/pb/a2a.js';
 import { SendMessageResult } from '../../src/index.js';
 
@@ -42,7 +42,7 @@ export function createAgentCardResponse(
   status: number = 200,
   headers: Record<string, string> = {}
 ): Response {
-  const defaultHeaders = { 'Content-Type': 'application/json' };
+  const defaultHeaders = { 'Content-Type': JSON_CONTENT_TYPE };
   const responseHeaders = { ...defaultHeaders, ...headers };
 
   // Create a fresh body each time to avoid "Body is unusable" errors
@@ -72,7 +72,7 @@ export function createResponse(
   status: number = 200,
   headers: Record<string, string> = {}
 ): Response {
-  const defaultHeaders = { 'Content-Type': 'application/json' };
+  const defaultHeaders = { 'Content-Type': JSON_CONTENT_TYPE };
   const responseHeaders = { ...defaultHeaders, ...headers };
 
   // Construct the JSON-RPC response structure
@@ -451,7 +451,7 @@ export function createRestResponse(
   status: number = 200,
   headers: Record<string, string> = {}
 ): Response {
-  const defaultHeaders = { 'Content-Type': 'application/json' };
+  const defaultHeaders = { 'Content-Type': JSON_CONTENT_TYPE };
   const responseHeaders = { ...defaultHeaders, ...headers };
   return new Response(JSON.stringify(data), { status, headers: responseHeaders });
 }
@@ -474,7 +474,7 @@ export function createRestErrorResponse(
   const errorBody = { code, message, ...(data && { data }) };
   return new Response(JSON.stringify(errorBody), {
     status,
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': JSON_CONTENT_TYPE },
   });
 }
 

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -806,4 +806,68 @@ describe('restHandler', () => {
       assert.include(response.body.message, '9.9');
     });
   });
+
+  describe('Content-Type: application/a2a+json (§11.1)', () => {
+    it('should return application/a2a+json for successful JSON responses', async () => {
+      (mockRequestHandler.getTask as Mock).mockResolvedValue(testTask);
+
+      const response = await request(app)
+        .get('/tasks/task-1')
+        .set('A2A-Version', '1.0')
+        .expect(200);
+
+      assert.include(response.headers['content-type'], 'application/a2a+json');
+    });
+
+    it('should return application/a2a+json for error responses', async () => {
+      const response = await request(app)
+        .get('/tasks/task-1')
+        .set('A2A-Version', '9.9')
+        .expect(400);
+
+      assert.include(response.headers['content-type'], 'application/a2a+json');
+    });
+
+    it('should accept requests with Content-Type application/a2a+json', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockResolvedValue(testTask);
+
+      const response = await request(app)
+        .post('/message:send')
+        .set('A2A-Version', '1.0')
+        .set('Content-Type', 'application/a2a+json')
+        .send(JSON.stringify({ message: testMessage }))
+        .expect(200);
+
+      assert.include(response.headers['content-type'], 'application/a2a+json');
+    });
+
+    it('should accept requests with Content-Type application/json', async () => {
+      (mockRequestHandler.getTask as Mock).mockResolvedValue(testTask);
+
+      const response = await request(app)
+        .get('/tasks/task-1')
+        .set('A2A-Version', '1.0')
+        .set('Content-Type', 'application/json')
+        .expect(200);
+
+      assert.include(response.headers['content-type'], 'application/a2a+json');
+    });
+
+    it('should return text/event-stream for SSE responses, not application/a2a+json', async () => {
+      const streamResponse = (async function* () {
+        yield { payload: { $case: 'task' as const, value: testTask } };
+      })();
+
+      (mockRequestHandler.sendMessageStream as Mock).mockReturnValue(streamResponse);
+
+      const response = await request(app)
+        .post('/message:stream')
+        .set('A2A-Version', '1.0')
+        .set('Accept', 'text/event-stream')
+        .send({ message: testMessage })
+        .expect(200);
+
+      assert.include(response.headers['content-type'], 'text/event-stream');
+    });
+  });
 });

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -78,7 +78,7 @@ describe('Push Notification Integration Tests', () => {
   }> => {
     return new Promise((resolve) => {
       const app = express();
-      app.use(express.json());
+      app.use(express.json({ type: ['application/json', 'application/a2a+json'] }));
 
       // Endpoint to receive push notifications
       app.post('/notify', (req: Request, res: Response) => {
@@ -271,7 +271,7 @@ describe('Push Notification Integration Tests', () => {
       const firstNotification = receivedNotifications[0];
       assert.equal(firstNotification.method, 'POST');
       assert.equal(firstNotification.url, '/notify/delay_on_submitted');
-      assert.equal(firstNotification.headers['content-type'], 'application/json');
+      assert.equal(firstNotification.headers['content-type'], 'application/a2a+json');
       assert.equal(firstNotification.headers['x-a2a-notification-token'], 'test-auth-token');
       assert.deepEqual(
         firstNotification.body,
@@ -597,7 +597,7 @@ describe('Push Notification Integration Tests', () => {
         );
         assert.equal(
           notification.headers['content-type'],
-          'application/json',
+          'application/a2a+json',
           'Should include content-type header'
         );
       });
@@ -703,7 +703,7 @@ describe('Push Notification Integration Tests', () => {
         );
         assert.equal(
           notification.headers['content-type'],
-          'application/json',
+          'application/a2a+json',
           'Should include content-type header'
         );
       });
@@ -786,7 +786,7 @@ describe('Push Notification Integration Tests', () => {
         );
         assert.equal(
           notification.headers['content-type'],
-          'application/json',
+          'application/a2a+json',
           'Should include content-type header'
         );
       });
@@ -922,7 +922,7 @@ describe('Push Notification Integration Tests', () => {
       receivedNotifications.forEach((notification) => {
         assert.equal(
           notification.headers['content-type'],
-          'application/json',
+          'application/a2a+json',
           'Should include content-type header'
         );
       });


### PR DESCRIPTION
# Description

Updated the content type from `application/json` to `application/a2a+json`.

# Important Note:

The spec mentions that the REST SHOULD use `application/a2a+json` (not MUST). Due to this, the server side needs to accept both versions.