### PR TITLE
feat: Add support for custom authentication scheme and credentials in auth headers

### DIFF
--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -105,11 +105,11 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
    */
   private _buildAuthHeaders(pushConfig: TaskPushNotificationConfig): Record<string, string> {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    const auth = pushConfig.authentication;
 
-    if (pushConfig.authentication?.scheme && pushConfig.authentication?.credentials) {
-      headers['Authorization'] =
-        `${pushConfig.authentication.scheme} ${pushConfig.authentication.credentials}`;
-    } else if (pushConfig.token) {
+    if (auth?.scheme != null && auth?.credentials != null) {
+      headers['Authorization'] = auth.scheme + ' ' + auth.credentials;
+    } else if (pushConfig.token != null) {
       headers[this.options.tokenHeaderName] = pushConfig.token;
     }
 

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -105,11 +105,11 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
    */
   private _buildAuthHeaders(pushConfig: TaskPushNotificationConfig): Record<string, string> {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    const auth = pushConfig.authentication;
 
-    if (auth?.scheme != null && auth?.credentials != null) {
-      headers['Authorization'] = auth.scheme + ' ' + auth.credentials;
-    } else if (pushConfig.token != null) {
+    if (pushConfig.authentication?.scheme && pushConfig.authentication?.credentials) {
+      headers['Authorization'] =
+        `${pushConfig.authentication.scheme} ${pushConfig.authentication.credentials}`;
+    } else if (pushConfig.token) {
       headers[this.options.tokenHeaderName] = pushConfig.token;
     }
 

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -9,7 +9,9 @@ export interface DefaultPushNotificationSenderOptions {
    */
   timeout?: number;
   /**
-   * Custom header name for the token. Defaults to 'X-A2A-Notification-Token'.
+   * Custom header name for the legacy token. Defaults to 'X-A2A-Notification-Token'.
+   * Used only when `pushConfig.token` is set and `pushConfig.authentication` is not.
+   * @deprecated Use `pushConfig.authentication` with `AuthenticationInfo` instead.
    */
   tokenHeaderName?: string;
 }
@@ -90,6 +92,30 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     }
   }
 
+  /**
+   * Builds the authentication headers for a push notification request.
+   *
+   * Per §4.3.3, the agent MUST include auth credentials per the push
+   * notification config's `authentication` field when sending notifications.
+   *
+   * Priority:
+   * 1. `pushConfig.authentication` (AuthenticationInfo with scheme + credentials)
+   *    → sets `Authorization: <scheme> <credentials>` per RFC 9110 §11.4
+   * 2. `pushConfig.token` (legacy) → sets the custom token header (deprecated)
+   */
+  private _buildAuthHeaders(pushConfig: TaskPushNotificationConfig): Record<string, string> {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+
+    if (pushConfig.authentication?.scheme && pushConfig.authentication?.credentials) {
+      headers['Authorization'] =
+        `${pushConfig.authentication.scheme} ${pushConfig.authentication.credentials}`;
+    } else if (pushConfig.token) {
+      headers[this.options.tokenHeaderName] = pushConfig.token;
+    }
+
+    return headers;
+  }
+
   private async _dispatchNotification(
     streamResponse: StreamResponse,
     pushConfig: TaskPushNotificationConfig,
@@ -101,17 +127,9 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     const timeoutId = setTimeout(() => controller.abort(), this.options.timeout);
 
     try {
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-      };
-
-      if (pushConfig.token) {
-        headers[this.options.tokenHeaderName] = pushConfig.token;
-      }
-
       const response = await fetch(url, {
         method: 'POST',
-        headers,
+        headers: this._buildAuthHeaders(pushConfig),
         body: JSON.stringify(StreamResponse.toJSON(streamResponse)),
         signal: controller.signal,
       });

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -929,6 +929,232 @@ describe('Push Notification Integration Tests', () => {
     });
   });
 
+  describe('AuthenticationInfo (§4.3.3)', () => {
+    it('should set Authorization header from authentication config', async () => {
+      const contextId = 'ctx-auth-info';
+      const pushConfig: TaskPushNotificationConfig = {
+        tenant: '',
+        taskId: '',
+        id: 'config-auth-info',
+        url: `${testServerUrl}/notify`,
+        token: '',
+        authentication: { scheme: 'Bearer', credentials: 'my-jwt-token-123' },
+      };
+
+      const params: SendMessageRequest = {
+        tenant: '',
+        message: {
+          ...createTestMessage('Auth info test'),
+          contextId,
+          extensions: [],
+          metadata: {},
+        },
+        metadata: {},
+        configuration: {
+          taskPushNotificationConfig: pushConfig,
+          historyLength: 0,
+          returnImmediately: false,
+          acceptedOutputModes: [],
+        },
+      };
+
+      mockAgentExecutor.execute.mockImplementation(async (ctx, bus) => {
+        fakeTaskExecute(ctx, bus);
+      });
+
+      await handler.sendMessage(params, defaultContext);
+      await waitForPushNotifications(pushNotificationSenderSpy);
+
+      assert.isAtLeast(receivedNotifications.length, 1, 'Should receive at least one notification');
+      const notification = receivedNotifications[0];
+      assert.equal(
+        notification.headers['authorization'],
+        'Bearer my-jwt-token-123',
+        'Should set Authorization header from AuthenticationInfo'
+      );
+      assert.isUndefined(
+        notification.headers['x-a2a-notification-token'],
+        'Should not set legacy token header when authentication is provided'
+      );
+    });
+
+    it('should support Basic auth scheme', async () => {
+      const contextId = 'ctx-basic-auth';
+      const pushConfig: TaskPushNotificationConfig = {
+        tenant: '',
+        taskId: '',
+        id: 'config-basic-auth',
+        url: `${testServerUrl}/notify`,
+        token: '',
+        authentication: { scheme: 'Basic', credentials: 'dXNlcjpwYXNz' },
+      };
+
+      const params: SendMessageRequest = {
+        tenant: '',
+        message: {
+          ...createTestMessage('Basic auth test'),
+          contextId,
+          extensions: [],
+          metadata: {},
+        },
+        metadata: {},
+        configuration: {
+          taskPushNotificationConfig: pushConfig,
+          historyLength: 0,
+          returnImmediately: false,
+          acceptedOutputModes: [],
+        },
+      };
+
+      mockAgentExecutor.execute.mockImplementation(async (ctx, bus) => {
+        fakeTaskExecute(ctx, bus);
+      });
+
+      await handler.sendMessage(params, defaultContext);
+      await waitForPushNotifications(pushNotificationSenderSpy);
+
+      assert.isAtLeast(receivedNotifications.length, 1);
+      assert.equal(receivedNotifications[0].headers['authorization'], 'Basic dXNlcjpwYXNz');
+    });
+
+    it('should prefer authentication over legacy token', async () => {
+      const contextId = 'ctx-auth-precedence';
+      const pushConfig: TaskPushNotificationConfig = {
+        tenant: '',
+        taskId: '',
+        id: 'config-precedence',
+        url: `${testServerUrl}/notify`,
+        token: 'legacy-token-value',
+        authentication: { scheme: 'Bearer', credentials: 'new-auth-token' },
+      };
+
+      const params: SendMessageRequest = {
+        tenant: '',
+        message: {
+          ...createTestMessage('Precedence test'),
+          contextId,
+          extensions: [],
+          metadata: {},
+        },
+        metadata: {},
+        configuration: {
+          taskPushNotificationConfig: pushConfig,
+          historyLength: 0,
+          returnImmediately: false,
+          acceptedOutputModes: [],
+        },
+      };
+
+      mockAgentExecutor.execute.mockImplementation(async (ctx, bus) => {
+        fakeTaskExecute(ctx, bus);
+      });
+
+      await handler.sendMessage(params, defaultContext);
+      await waitForPushNotifications(pushNotificationSenderSpy);
+
+      assert.isAtLeast(receivedNotifications.length, 1);
+      const notification = receivedNotifications[0];
+      assert.equal(
+        notification.headers['authorization'],
+        'Bearer new-auth-token',
+        'Should use AuthenticationInfo credentials'
+      );
+      assert.isUndefined(
+        notification.headers['x-a2a-notification-token'],
+        'Should not set legacy token header when authentication takes precedence'
+      );
+    });
+
+    it('should fall back to legacy token when authentication is undefined', async () => {
+      const contextId = 'ctx-legacy-fallback';
+      const pushConfig: TaskPushNotificationConfig = {
+        tenant: '',
+        taskId: '',
+        id: 'config-legacy',
+        url: `${testServerUrl}/notify`,
+        token: 'fallback-token',
+        authentication: undefined,
+      };
+
+      const params: SendMessageRequest = {
+        tenant: '',
+        message: {
+          ...createTestMessage('Legacy fallback test'),
+          contextId,
+          extensions: [],
+          metadata: {},
+        },
+        metadata: {},
+        configuration: {
+          taskPushNotificationConfig: pushConfig,
+          historyLength: 0,
+          returnImmediately: false,
+          acceptedOutputModes: [],
+        },
+      };
+
+      mockAgentExecutor.execute.mockImplementation(async (ctx, bus) => {
+        fakeTaskExecute(ctx, bus);
+      });
+
+      await handler.sendMessage(params, defaultContext);
+      await waitForPushNotifications(pushNotificationSenderSpy);
+
+      assert.isAtLeast(receivedNotifications.length, 1);
+      const notification = receivedNotifications[0];
+      assert.equal(
+        notification.headers['x-a2a-notification-token'],
+        'fallback-token',
+        'Should use legacy token header as fallback'
+      );
+      assert.isUndefined(
+        notification.headers['authorization'],
+        'Should not set Authorization header when using legacy token'
+      );
+    });
+
+    it('should send no auth headers when neither authentication nor token is set', async () => {
+      const contextId = 'ctx-no-auth';
+      const pushConfig: TaskPushNotificationConfig = {
+        tenant: '',
+        taskId: '',
+        id: 'config-no-auth',
+        url: `${testServerUrl}/notify`,
+        token: '',
+        authentication: undefined,
+      };
+
+      const params: SendMessageRequest = {
+        tenant: '',
+        message: {
+          ...createTestMessage('No auth test'),
+          contextId,
+          extensions: [],
+          metadata: {},
+        },
+        metadata: {},
+        configuration: {
+          taskPushNotificationConfig: pushConfig,
+          historyLength: 0,
+          returnImmediately: false,
+          acceptedOutputModes: [],
+        },
+      };
+
+      mockAgentExecutor.execute.mockImplementation(async (ctx, bus) => {
+        fakeTaskExecute(ctx, bus);
+      });
+
+      await handler.sendMessage(params, defaultContext);
+      await waitForPushNotifications(pushNotificationSenderSpy);
+
+      assert.isAtLeast(receivedNotifications.length, 1);
+      const notification = receivedNotifications[0];
+      assert.isUndefined(notification.headers['authorization']);
+      assert.isUndefined(notification.headers['x-a2a-notification-token']);
+    });
+  });
+
   describe('StreamResponse payload types', () => {
     it('should throw if tried to send message payload', async () => {
       const taskId = 'test-message-payload';


### PR DESCRIPTION
# Description

According to the protocol spec, the agent MUST include auth credentials per the push notification's config. This PR adds support for this.

Note: The old `token` behavior is still supported and the old tests pass without any need for updating.