### PR TITLE
fix: Accept string task state values in listTasks method

### DIFF
--- a/src/server/transports/rest/rest_transport_handler.ts
+++ b/src/server/transports/rest/rest_transport_handler.ts
@@ -22,6 +22,7 @@ import {
   TaskState,
   ListTaskPushNotificationConfigsResponse,
 } from '../../../index.js';
+import { taskStateFromJSON } from '../../../types/pb/a2a.js';
 import {
   ContentTypeNotSupportedError,
   ExtendedAgentCardNotConfiguredError,
@@ -204,7 +205,9 @@ export class RestTransportHandler {
     const params: ListTasksRequest = {
       tenant: (queryParams.tenant as string) || '',
       contextId: (queryParams.contextId as string) || '',
-      status: queryParams.status ? Number(queryParams.status) : TaskState.TASK_STATE_UNSPECIFIED,
+      status: queryParams.status
+        ? taskStateFromJSON(queryParams.status)
+        : TaskState.TASK_STATE_UNSPECIFIED,
       pageSize: queryParams.pageSize ? Number(queryParams.pageSize) : undefined,
       pageToken: (queryParams.pageToken as string) || '',
       historyLength: queryParams.historyLength ? Number(queryParams.historyLength) : undefined,

--- a/src/server/transports/rest/rest_transport_handler.ts
+++ b/src/server/transports/rest/rest_transport_handler.ts
@@ -206,7 +206,9 @@ export class RestTransportHandler {
       tenant: (queryParams.tenant as string) || '',
       contextId: (queryParams.contextId as string) || '',
       status: queryParams.status
-        ? taskStateFromJSON(queryParams.status)
+        ? taskStateFromJSON(
+            isNaN(Number(queryParams.status)) ? queryParams.status : Number(queryParams.status)
+          )
         : TaskState.TASK_STATE_UNSPECIFIED,
       pageSize: queryParams.pageSize ? Number(queryParams.pageSize) : undefined,
       pageToken: (queryParams.pageToken as string) || '',

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -425,6 +425,48 @@ describe('restHandler', () => {
       assert.deepEqual(response.body.tasks, expectedResponse);
       expect(mockRequestHandler.listTasks as Mock).toHaveBeenCalled();
     });
+
+    it('should parse string enum status filter', async () => {
+      (mockRequestHandler.listTasks as Mock).mockResolvedValue({ tasks: [testTask] });
+
+      await request(app)
+        .get('/tasks?status=TASK_STATE_COMPLETED')
+        .set('A2A-Version', '1.0')
+        .expect(200);
+
+      const callArgs = (mockRequestHandler.listTasks as Mock).mock.calls[0][0];
+      assert.equal(
+        callArgs.status,
+        TaskState.TASK_STATE_COMPLETED,
+        'TASK_STATE_COMPLETED should parse to enum value (3)'
+      );
+    });
+
+    it('should treat unrecognized status values as UNRECOGNIZED (-1)', async () => {
+      (mockRequestHandler.listTasks as Mock).mockResolvedValue({ tasks: [testTask] });
+
+      await request(app).get('/tasks?status=INVALID_VALUE').set('A2A-Version', '1.0').expect(200);
+
+      const callArgs = (mockRequestHandler.listTasks as Mock).mock.calls[0][0];
+      assert.equal(
+        callArgs.status,
+        TaskState.UNRECOGNIZED,
+        'Unrecognized status should return UNRECOGNIZED (-1)'
+      );
+    });
+
+    it('should default to TASK_STATE_UNSPECIFIED when status is not provided', async () => {
+      (mockRequestHandler.listTasks as Mock).mockResolvedValue({ tasks: [testTask] });
+
+      await request(app).get('/tasks').set('A2A-Version', '1.0').expect(200);
+
+      const callArgs = (mockRequestHandler.listTasks as Mock).mock.calls[0][0];
+      assert.equal(
+        callArgs.status,
+        TaskState.TASK_STATE_UNSPECIFIED,
+        'Should default to TASK_STATE_UNSPECIFIED (0)'
+      );
+    });
   });
 
   describe('POST /tasks/:taskId:subscribe', () => {


### PR DESCRIPTION
# Description

Accept string task state values in `listTasks` method. Previously, only numeric values were accepted what was wrong as spec mentions SCREAMING_SNAKE_CASE for such parameters:
- https://a2a-protocol.org/latest/specification/
- https://a2a-protocol.org/latest/specification/#request-all-working-tasks-across-all-contexts
