### PR TITLE
feat: Check for contextId mismatch

### DIFF
--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -173,6 +173,22 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         }
       }
     }
+    // Validate contextId/taskId consistency per §3.4.3:
+    // When a taskId references an existing task, the contextId (if provided)
+    // MUST match the task's contextId. A mismatch indicates the client is
+    // attempting to associate a task with a different context.
+    if (
+      task &&
+      incomingMessage.contextId &&
+      task.contextId &&
+      incomingMessage.contextId !== task.contextId
+    ) {
+      throw new RequestMalformedError(
+        `contextId mismatch: message contextId '${incomingMessage.contextId}' ` +
+          `does not match task '${task.id}' contextId '${task.contextId}'`
+      );
+    }
+
     // Ensure contextId is present
     const contextId = incomingMessage.contextId || task?.contextId || uuidv4();
 

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -152,6 +152,21 @@ export class DefaultRequestHandler implements A2ARequestHandler {
           `Task ${task.id} is in a terminal state (${task.status!.state}) and cannot be modified.`
         );
       }
+      // Validate contextId/taskId consistency per §3.4.3:
+      // When a taskId references an existing task, the contextId (if provided)
+      // MUST match the task's contextId. A mismatch indicates the client is
+      // attempting to associate a task with a different context.
+      // This check must occur before any task mutation.
+      if (
+        incomingMessage.contextId &&
+        task.contextId &&
+        incomingMessage.contextId !== task.contextId
+      ) {
+        throw new RequestMalformedError(
+          `contextId mismatch: message contextId '${incomingMessage.contextId}' ` +
+            `does not match task '${task.id}' contextId '${task.contextId}'`
+        );
+      }
       // Add incomingMessage to history and save the task.
       task.history = [...(task.history || []), incomingMessage];
       await this.taskStore.save(task, context);
@@ -172,21 +187,6 @@ export class DefaultRequestHandler implements A2ARequestHandler {
           // Optionally, throw an error or handle as per specific requirements
         }
       }
-    }
-    // Validate contextId/taskId consistency per §3.4.3:
-    // When a taskId references an existing task, the contextId (if provided)
-    // MUST match the task's contextId. A mismatch indicates the client is
-    // attempting to associate a task with a different context.
-    if (
-      task &&
-      incomingMessage.contextId &&
-      task.contextId &&
-      incomingMessage.contextId !== task.contextId
-    ) {
-      throw new RequestMalformedError(
-        `contextId mismatch: message contextId '${incomingMessage.contextId}' ` +
-          `does not match task '${task.id}' contextId '${task.contextId}'`
-      );
     }
 
     // Ensure contextId is present

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -152,11 +152,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
           `Task ${task.id} is in a terminal state (${task.status!.state}) and cannot be modified.`
         );
       }
-      // Validate contextId/taskId consistency per §3.4.3:
-      // When a taskId references an existing task, the contextId (if provided)
-      // MUST match the task's contextId. A mismatch indicates the client is
-      // attempting to associate a task with a different context.
-      // This check must occur before any task mutation.
+      // Validate contextId/taskId consistency per §3.4.3.
       if (
         incomingMessage.contextId &&
         task.contextId &&
@@ -188,7 +184,6 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         }
       }
     }
-
     // Ensure contextId is present
     const contextId = incomingMessage.contextId || task?.contextId || uuidv4();
 

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -3319,4 +3319,223 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       expect(result).toBeDefined();
     });
   });
+
+  describe('contextId/taskId mismatch validation (§3.4.3)', () => {
+    it('should reject when message contextId does not match existing task contextId', async () => {
+      const taskContextId = 'task-ctx-original';
+      const messageContextId = 'msg-ctx-different';
+      const taskId = 'task-ctx-mismatch';
+
+      // Create a task with a known contextId
+      const existingTask: Task = {
+        id: taskId,
+        contextId: taskContextId,
+        status: {
+          state: TaskState.TASK_STATE_INPUT_REQUIRED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      };
+      await mockTaskStore.save(existingTask, serverCallContext);
+
+      // Send a message referencing the task but with a different contextId
+      const params: SendMessageRequest = {
+        tenant: '',
+        metadata: {},
+        message: {
+          messageId: 'msg-ctx-mismatch',
+          role: Role.ROLE_USER,
+          parts: [
+            {
+              content: { $case: 'text', value: 'test' },
+              filename: '',
+              mediaType: 'text/plain',
+              metadata: undefined,
+            },
+          ],
+          contextId: messageContextId,
+          taskId: taskId,
+          extensions: [],
+          metadata: {},
+        },
+      } as SendMessageRequest;
+
+      await expect(handler.sendMessage(params, serverCallContext)).rejects.toThrow(
+        RequestMalformedError
+      );
+    });
+
+    it('should include both contextIds in the error message', async () => {
+      const taskContextId = 'ctx-AAA';
+      const messageContextId = 'ctx-BBB';
+      const taskId = 'task-ctx-msg';
+
+      const existingTask: Task = {
+        id: taskId,
+        contextId: taskContextId,
+        status: {
+          state: TaskState.TASK_STATE_WORKING,
+          message: undefined,
+          timestamp: undefined,
+        },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      };
+      await mockTaskStore.save(existingTask, serverCallContext);
+
+      const params: SendMessageRequest = {
+        tenant: '',
+        metadata: {},
+        message: {
+          messageId: 'msg-ctx-err-detail',
+          role: Role.ROLE_USER,
+          parts: [
+            {
+              content: { $case: 'text', value: 'test' },
+              filename: '',
+              mediaType: 'text/plain',
+              metadata: undefined,
+            },
+          ],
+          contextId: messageContextId,
+          taskId: taskId,
+          extensions: [],
+          metadata: {},
+        },
+      } as SendMessageRequest;
+
+      await expect(handler.sendMessage(params, serverCallContext)).rejects.toThrow(/ctx-AAA/);
+      await expect(handler.sendMessage(params, serverCallContext)).rejects.toThrow(/ctx-BBB/);
+    });
+
+    it('should accept when message contextId matches existing task contextId', async () => {
+      const contextId = 'ctx-matching';
+      const taskId = 'task-ctx-match';
+
+      const existingTask: Task = {
+        id: taskId,
+        contextId: contextId,
+        status: {
+          state: TaskState.TASK_STATE_INPUT_REQUIRED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      };
+      await mockTaskStore.save(existingTask, serverCallContext);
+
+      (mockAgentExecutor.execute as unknown as Mock).mockImplementation(
+        async (_ctx: RequestContext, bus: ExecutionEventBus) => {
+          bus.publish(
+            AgentEvent.task({
+              id: taskId,
+              contextId,
+              status: {
+                state: TaskState.TASK_STATE_COMPLETED,
+                message: undefined,
+                timestamp: undefined,
+              },
+              artifacts: [],
+              history: [],
+              metadata: {},
+            })
+          );
+          bus.finished();
+        }
+      );
+
+      const params: SendMessageRequest = {
+        tenant: '',
+        metadata: {},
+        message: {
+          messageId: 'msg-ctx-ok',
+          role: Role.ROLE_USER,
+          parts: [
+            {
+              content: { $case: 'text', value: 'test' },
+              filename: '',
+              mediaType: 'text/plain',
+              metadata: undefined,
+            },
+          ],
+          contextId: contextId,
+          taskId: taskId,
+          extensions: [],
+          metadata: {},
+        },
+      } as SendMessageRequest;
+
+      const result = await handler.sendMessage(params, serverCallContext);
+      expect(result).toBeDefined();
+    });
+
+    it('should accept when message omits contextId for existing task', async () => {
+      const taskId = 'task-ctx-omit';
+      const taskContextId = 'ctx-from-task';
+
+      const existingTask: Task = {
+        id: taskId,
+        contextId: taskContextId,
+        status: {
+          state: TaskState.TASK_STATE_INPUT_REQUIRED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      };
+      await mockTaskStore.save(existingTask, serverCallContext);
+
+      (mockAgentExecutor.execute as unknown as Mock).mockImplementation(
+        async (_ctx: RequestContext, bus: ExecutionEventBus) => {
+          bus.publish(
+            AgentEvent.task({
+              id: taskId,
+              contextId: taskContextId,
+              status: {
+                state: TaskState.TASK_STATE_COMPLETED,
+                message: undefined,
+                timestamp: undefined,
+              },
+              artifacts: [],
+              history: [],
+              metadata: {},
+            })
+          );
+          bus.finished();
+        }
+      );
+
+      const params: SendMessageRequest = {
+        tenant: '',
+        metadata: {},
+        message: {
+          messageId: 'msg-ctx-none',
+          role: Role.ROLE_USER,
+          parts: [
+            {
+              content: { $case: 'text', value: 'test' },
+              filename: '',
+              mediaType: 'text/plain',
+              metadata: undefined,
+            },
+          ],
+          contextId: '',
+          taskId: taskId,
+          extensions: [],
+          metadata: {},
+        },
+      } as SendMessageRequest;
+
+      const result = await handler.sendMessage(params, serverCallContext);
+      expect(result).toBeDefined();
+    });
+  });
 });


### PR DESCRIPTION
# Description

Check for `task` and `message` `contextId` mismatch and throw `RequestMalformedError` in a case once is found. Checking is required by the [spec 3.4.3](https://a2a-protocol.org/latest/specification/#343-multi-turn-conversation-patterns).