### PR TITLE
ci: Update samples to 1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,8 @@
   "release-type": "node",
   "prerelease": true,
   "prerelease-type": "alpha",
+  "versioning": "prerelease",
+  "bootstrap-sha": "82d36c7",
   "packages": {
     ".": {}
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,7 @@
   "prerelease": true,
   "prerelease-type": "alpha",
   "versioning": "prerelease",
-  "bootstrap-sha": "82d36c7",
+  "last-release-sha": "82d36c7",
   "packages": {
     ".": {}
   }

--- a/src/samples/agents/movie-agent/index.ts
+++ b/src/samples/agents/movie-agent/index.ts
@@ -316,7 +316,7 @@ const movieAgentCard: AgentCard = {
       url: 'http://localhost:41241/',
       protocolBinding: 'JSONRPC',
       tenant: '',
-      protocolVersion: '0.3.0',
+      protocolVersion: '1.0',
     },
   ],
   provider: {

--- a/src/samples/agents/sample-agent/index.ts
+++ b/src/samples/agents/sample-agent/index.ts
@@ -20,7 +20,7 @@ const sampleAgentCard: AgentCard = {
       url: 'http://localhost:41241/',
       protocolBinding: 'JSONRPC',
       tenant: '',
-      protocolVersion: '0.3.0',
+      protocolVersion: '1.0',
     },
   ],
   provider: {


### PR DESCRIPTION
# Description

Update sample agent's protocol versions to 1.0.

# Fix

Add `bootstrap-sha` to the release-please config to apply release only on top of currently newest release (0.3.13).