### PR TITLE
ci: Add --tag next for prereleases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Publish to NPM
         run: |
           if [ "${{ github.event.release.prereleased }}" = "true" ]; then
-            npm publish --provenance --access public --tag beta --dry-run
+            npm publish --provenance --access public --tag next --dry-run
           else
             npm publish --provenance --access public --dry-run
           fi

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Publish to NPM
         run: |
-          if [ "${{ github.event.release.prereleased }}" = "true" ]; then
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
             npm publish --provenance --access public --tag next
           else
             npm publish --provenance --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,13 +29,12 @@ jobs:
           node-version: 18
           registry-url: 'https://wombat-dressing-room.appspot.com/'
 
-        # `--dry-run` will be removed before the merge.
       - name: Publish to NPM
         run: |
           if [ "${{ github.event.release.prereleased }}" = "true" ]; then
-            npm publish --provenance --access public --tag next --dry-run
+            npm publish --provenance --access public --tag next
           else
-            npm publish --provenance --access public --dry-run
+            npm publish --provenance --access public
           fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,6 +28,14 @@ jobs:
         with:
           node-version: 18
           registry-url: 'https://wombat-dressing-room.appspot.com/'
-      - run: npm publish --provenance --access public
+
+        # `--dry-run` will be removed before the merge.
+      - name: Publish to NPM
+        run: |
+          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+            npm publish --provenance --access public --tag beta --dry-run
+          else
+            npm publish --provenance --access public --dry-run
+          fi
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,7 +32,7 @@ jobs:
         # `--dry-run` will be removed before the merge.
       - name: Publish to NPM
         run: |
-          if [ "${{ github.event.release.prerelease }}" = "true" ]; then
+          if [ "${{ github.event.release.prereleased }}" = "true" ]; then
             npm publish --provenance --access public --tag beta --dry-run
           else
             npm publish --provenance --access public --dry-run


### PR DESCRIPTION
# Description

Added handling on prereleases. These should include `--tag next` during the `npm publish` call.

The `if` check is based on the release event type as documented here: https://docs.github.com/en/webhooks/webhook-events-and-payloads#release
