### PR TITLE
feat: AgentCardSignature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.13",
       "license": "Apache-2.0",
       "dependencies": {
+        "jose": "^6.2.3",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -38,7 +39,7 @@
         "vitest": "^3.2.4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "@bufbuild/protobuf": "^2.10.2",
@@ -5741,6 +5742,15 @@
       "license": "MIT",
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/joycon": {

--- a/package.json
+++ b/package.json
@@ -106,9 +106,9 @@
     "generate": "curl https://raw.githubusercontent.com/google-a2a/A2A/refs/heads/main/specification/json/a2a.json > spec.json && node scripts/generateTypes.js && rm spec.json",
     "test-build": "esbuild ./dist/client/index.js ./dist/server/index.js ./dist/index.js --bundle --platform=neutral --outdir=dist/tmp-checks --outbase=./dist",
     "itk-agent": "tsx itk/itk_agent.ts"
-
   },
   "dependencies": {
+    "jose": "^6.2.3",
     "uuid": "^11.1.0"
   },
   "peerDependencies": {

--- a/src/client/multitransport-client.ts
+++ b/src/client/multitransport-client.ts
@@ -1,4 +1,5 @@
 import { withA2AVersion } from './service-parameters.js';
+import { AgentCardSignatureVerifier } from '../signature.js';
 import { PushNotificationNotSupportedError } from '../errors.js';
 import { TaskPushNotificationConfig, Task, AgentCard, SendMessageResult } from '../index.js';
 import {
@@ -92,13 +93,19 @@ export class Client {
    * automatically by `ClientFactory` from `AgentInterface.tenant`), the tenant
    * is applied to the request transparently.
    */
-  async getAgentCard(options?: RequestOptions): Promise<AgentCard> {
+  async getAgentCard(
+    options?: RequestOptions,
+    verifySignature?: AgentCardSignatureVerifier
+  ): Promise<AgentCard> {
     if (this.agentCard.capabilities?.extendedAgentCard) {
       this.agentCard = await this.executeWithInterceptors(
         { method: 'getAgentCard' },
         options,
         (_, options) => this.transport.getExtendedAgentCard({ tenant: '' }, options)
       );
+    }
+    if (verifySignature) {
+      await verifySignature(this.agentCard);
     }
     return this.agentCard;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,5 +16,12 @@ export {
   A2A_CONTENT_TYPE,
 } from './constants.js';
 export { Extensions, type ExtensionURI } from './extensions.js';
+export {
+  generateAgentCardSignature,
+  verifyAgentCardSignature,
+  canonicalizeAgentCard,
+  type AgentCardSignatureGenerator,
+  type AgentCardSignatureVerifier,
+} from './signature.js';
 
 export type SendMessageResult = Message | Task;

--- a/src/samples/agents/verify-signing/index.ts
+++ b/src/samples/agents/verify-signing/index.ts
@@ -1,0 +1,183 @@
+/**
+ * Agent Card Signing Verification Client
+ *
+ * This sample demonstrates verifying agent card signatures from a remote A2A server.
+ * It uses the a2a-js SDK's verifyAgentCardSignature to validate JWS signatures
+ * on agent cards, fetching the public key from the server's jku endpoint.
+ *
+ * Designed to work against the Python signing_and_verifying sample server:
+ *   https://github.com/a2a-samples/samples/python/agents/signing_and_verifying
+ *
+ * Usage:
+ *   npx tsx src/samples/agents/verify-signing/index.ts [server-url]
+ *
+ * Default server URL: http://localhost:9999
+ */
+
+import crypto from 'node:crypto';
+import {
+  AgentCard,
+  AGENT_CARD_PATH,
+  verifyAgentCardSignature,
+  canonicalizeAgentCard,
+} from '../../../index.js';
+import {
+  ClientFactory,
+  ClientFactoryOptions,
+  DefaultAgentCardResolver,
+  JsonRpcTransportFactory,
+  RestTransportFactory,
+} from '../../../client/index.js';
+
+// --- Configuration ---
+const serverUrl = process.argv[2] || 'http://localhost:9999';
+
+// --- Key Provider ---
+
+/**
+ * Retrieves the public key for signature verification.
+ *
+ * The Python signing server serves PEM-encoded public keys at its jku endpoint
+ * in a simple {kid: pem_string} JSON format. This function fetches the key
+ * and imports it as a CryptoKey for use with the jose library.
+ */
+async function retrievePublicKey(
+  kid: string,
+  jku?: string
+): Promise<crypto.webcrypto.CryptoKey> {
+  if (!jku) {
+    throw new Error(`No jku (JWK Set URL) provided for kid "${kid}"`);
+  }
+
+  console.log(`  Fetching public key: kid="${kid}" from jku="${jku}"`);
+  const response = await fetch(jku);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch public keys from ${jku}: ${response.status}`);
+  }
+
+  const keys: Record<string, string> = await response.json();
+  const pemData = keys[kid];
+  if (!pemData) {
+    throw new Error(`Key "${kid}" not found at ${jku}. Available keys: ${Object.keys(keys).join(', ')}`);
+  }
+
+  // Import the PEM public key as a CryptoKey
+  const key = crypto.createPublicKey(pemData);
+  const jwk = key.export({ format: 'jwk' });
+
+  return crypto.subtle.importKey(
+    'jwk',
+    jwk as JsonWebKey,
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['verify']
+  );
+}
+
+// --- Main ---
+
+async function main() {
+  console.log('=== Agent Card Signing Verification Client ===\n');
+  console.log(`Server URL: ${serverUrl}\n`);
+
+  // Step 1: Fetch the raw agent card to inspect it
+  console.log('--- Step 1: Fetch raw agent card ---');
+  const agentCardUrl = new URL(AGENT_CARD_PATH, serverUrl);
+  const rawResponse = await fetch(agentCardUrl);
+  if (!rawResponse.ok) {
+    throw new Error(`Failed to fetch agent card from ${agentCardUrl}: ${rawResponse.status}`);
+  }
+  const rawCard: AgentCard = await rawResponse.json();
+
+  console.log(`  Agent Name: ${rawCard.name}`);
+  console.log(`  Description: ${rawCard.description}`);
+  console.log(`  Version: ${rawCard.version}`);
+  console.log(`  Signatures found: ${rawCard.signatures?.length ?? 0}`);
+
+  if (rawCard.signatures?.length) {
+    for (let i = 0; i < rawCard.signatures.length; i++) {
+      const sig = rawCard.signatures[i];
+      const header = JSON.parse(
+        Buffer.from(sig.protected, 'base64url').toString()
+      );
+      console.log(`  Signature ${i + 1}:`);
+      console.log(`    Algorithm: ${header.alg}`);
+      console.log(`    Key ID: ${header.kid}`);
+      console.log(`    Type: ${header.typ}`);
+      console.log(`    JKU: ${header.jku}`);
+    }
+  }
+
+  // Step 2: Verify the signature
+  console.log('\n--- Step 2: Verify agent card signature ---');
+  const verifier = verifyAgentCardSignature(retrievePublicKey);
+  try {
+    await verifier(rawCard);
+    console.log('  PASS: Agent card signature is valid!\n');
+  } catch (error) {
+    console.error(`  FAIL: Signature verification failed: ${error}\n`);
+    process.exit(1);
+  }
+
+  // Step 3: Verify canonicalization produces deterministic output
+  console.log('--- Step 3: Verify canonicalization ---');
+  const { signatures: _, ...cardWithoutSignatures } = rawCard;
+  const canonical = canonicalizeAgentCard(cardWithoutSignatures);
+  console.log(`  Canonical form (first 200 chars): ${canonical.substring(0, 200)}...`);
+  // Run it twice to confirm determinism
+  const canonical2 = canonicalizeAgentCard(cardWithoutSignatures);
+  if (canonical === canonical2) {
+    console.log('  PASS: Canonicalization is deterministic.\n');
+  } else {
+    console.error('  FAIL: Canonicalization produced different results!\n');
+    process.exit(1);
+  }
+
+  // Step 4: Verify tamper detection
+  console.log('--- Step 4: Verify tamper detection ---');
+  const tamperedCard = { ...rawCard, name: 'TAMPERED Agent Name' };
+  try {
+    await verifier(tamperedCard);
+    console.error('  FAIL: Tampered card was accepted (should have been rejected)!\n');
+    process.exit(1);
+  } catch {
+    console.log('  PASS: Tampered card was correctly rejected.\n');
+  }
+
+  // Step 5: Use the SDK client to fetch + verify in one step
+  console.log('--- Step 5: Fetch and verify via SDK Client ---');
+  const factory = new ClientFactory(
+    ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+      cardResolver: new DefaultAgentCardResolver(),
+      transports: [new JsonRpcTransportFactory(), new RestTransportFactory()],
+    })
+  );
+
+  const client = await factory.createFromUrl(serverUrl);
+  const verifiedCard = await client.getAgentCard(undefined, verifier);
+  console.log(`  PASS: SDK client fetched and verified agent card: "${verifiedCard.name}"\n`);
+
+  // Step 6: Test extended agent card verification (if supported)
+  if (rawCard.capabilities?.extendedAgentCard) {
+    console.log('--- Step 6: Verify extended agent card signature ---');
+    try {
+      // getAgentCard will fetch the extended card since the capability is set
+      const extendedCard = await client.getAgentCard(undefined, verifier);
+      console.log(`  PASS: Extended agent card verified: "${extendedCard.name}"`);
+      console.log(`  Skills: ${extendedCard.skills?.map((s) => s.name).join(', ')}\n`);
+    } catch (error) {
+      console.error(`  FAIL: Extended card verification failed: ${error}\n`);
+      process.exit(1);
+    }
+  } else {
+    console.log('--- Step 6: Skipped (server does not support extended agent card) ---\n');
+  }
+
+  // Summary
+  console.log('=== All verification checks passed! ===');
+}
+
+main().catch((err) => {
+  console.error('Error:', err);
+  process.exit(1);
+});

--- a/src/samples/agents/verify-signing/index.ts
+++ b/src/samples/agents/verify-signing/index.ts
@@ -41,10 +41,7 @@ const serverUrl = process.argv[2] || 'http://localhost:9999';
  * in a simple {kid: pem_string} JSON format. This function fetches the key
  * and imports it as a CryptoKey for use with the jose library.
  */
-async function retrievePublicKey(
-  kid: string,
-  jku?: string
-): Promise<crypto.webcrypto.CryptoKey> {
+async function retrievePublicKey(kid: string, jku?: string): Promise<crypto.webcrypto.CryptoKey> {
   if (!jku) {
     throw new Error(`No jku (JWK Set URL) provided for kid "${kid}"`);
   }
@@ -58,7 +55,9 @@ async function retrievePublicKey(
   const keys: Record<string, string> = await response.json();
   const pemData = keys[kid];
   if (!pemData) {
-    throw new Error(`Key "${kid}" not found at ${jku}. Available keys: ${Object.keys(keys).join(', ')}`);
+    throw new Error(
+      `Key "${kid}" not found at ${jku}. Available keys: ${Object.keys(keys).join(', ')}`
+    );
   }
 
   // Import the PEM public key as a CryptoKey
@@ -97,9 +96,7 @@ async function main() {
   if (rawCard.signatures?.length) {
     for (let i = 0; i < rawCard.signatures.length; i++) {
       const sig = rawCard.signatures[i];
-      const header = JSON.parse(
-        Buffer.from(sig.protected, 'base64url').toString()
-      );
+      const header = JSON.parse(Buffer.from(sig.protected, 'base64url').toString());
       console.log(`  Signature ${i + 1}:`);
       console.log(`    Algorithm: ${header.alg}`);
       console.log(`    Key ID: ${header.kid}`);
@@ -122,6 +119,7 @@ async function main() {
   // Step 3: Verify canonicalization produces deterministic output
   console.log('--- Step 3: Verify canonicalization ---');
   const { signatures: _, ...cardWithoutSignatures } = rawCard;
+  void _;
   const canonical = canonicalizeAgentCard(cardWithoutSignatures);
   console.log(`  Canonical form (first 200 chars): ${canonical.substring(0, 200)}...`);
   // Run it twice to confirm determinism

--- a/src/samples/package.json
+++ b/src/samples/package.json
@@ -6,7 +6,8 @@
     "agents:movie-agent": "tsx agents/movie-agent/index.ts",
     "agents:sample-agent": "tsx agents/sample-agent/index.ts",
     "agents:extension-agent": "tsx extensions/index.ts",
-    "agents:authentication-agent": "tsx authentication/index.ts"
+    "agents:authentication-agent": "tsx authentication/index.ts",
+    "agents:verify-signing": "tsx agents/verify-signing/index.ts"
   },
   "devDependencies": {
     "@genkit-ai/googleai": "^1.8.0",

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -56,6 +56,7 @@ import { DefaultPushNotificationSender } from '../push_notification/default_push
 import { ServerCallContext } from '../context.js';
 import { DEFAULT_PAGE_SIZE } from '../../constants.js';
 import { TERMINAL_STATE_LIST, isTask, StreamPattern } from '../utils.js';
+import { AgentCardSignatureGenerator } from '../../signature.js';
 
 /**
  * Default implementation of the A2A request handler.
@@ -85,6 +86,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   private readonly pushNotificationStore?: PushNotificationStore;
   private readonly pushNotificationSender?: PushNotificationSender;
   private readonly extendedAgentCardProvider?: AgentCard | ExtendedAgentCardProvider;
+  private readonly agentCardSignatureGenerator?: AgentCardSignatureGenerator;
 
   constructor(
     agentCard: AgentCard,
@@ -93,13 +95,15 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     eventBusManager: ExecutionEventBusManager = new DefaultExecutionEventBusManager(),
     pushNotificationStore?: PushNotificationStore,
     pushNotificationSender?: PushNotificationSender,
-    extendedAgentCardProvider?: AgentCard | ExtendedAgentCardProvider
+    extendedAgentCardProvider?: AgentCard | ExtendedAgentCardProvider,
+    agentCardSignatureGenerator?: AgentCardSignatureGenerator
   ) {
     this.agentCard = agentCard;
     this.taskStore = taskStore;
     this.agentExecutor = agentExecutor;
     this.eventBusManager = eventBusManager;
     this.extendedAgentCardProvider = extendedAgentCardProvider;
+    this.agentCardSignatureGenerator = agentCardSignatureGenerator;
 
     // If push notifications are supported, use the provided store and sender.
     // Otherwise, use the default in-memory store and sender.
@@ -111,6 +115,9 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   }
 
   async getAgentCard(): Promise<AgentCard> {
+    if (this.agentCardSignatureGenerator) {
+      return this.agentCardSignatureGenerator(this.agentCard);
+    }
     return this.agentCard;
   }
 
@@ -124,13 +131,19 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     if (!this.extendedAgentCardProvider) {
       throw new ExtendedAgentCardNotConfiguredError();
     }
+    let agentCard: AgentCard;
     if (typeof this.extendedAgentCardProvider === 'function') {
-      return this.extendedAgentCardProvider(context);
+      agentCard = await this.extendedAgentCardProvider(context);
+    } else if (context.user?.isAuthenticated) {
+      agentCard = this.extendedAgentCardProvider;
+    } else {
+      agentCard = this.agentCard;
     }
-    if (context.user?.isAuthenticated) {
-      return this.extendedAgentCardProvider;
+
+    if (this.agentCardSignatureGenerator) {
+      return this.agentCardSignatureGenerator(agentCard);
     }
-    return this.agentCard;
+    return agentCard;
   }
 
   private async _createRequestContext(

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -111,7 +111,10 @@ export function verifyAgentCardSignature(
     // fromJSON strips non-schema fields (e.g., backward-compatibility fields
     // injected by other SDK implementations), and toJSON omits fields with
     // default values. This mirrors the Python SDK's MessageToDict behavior.
-    const normalizedCard = AgentCard.toJSON(AgentCard.fromJSON(agentCard)) as Record<string, unknown>;
+    const normalizedCard = AgentCard.toJSON(AgentCard.fromJSON(agentCard)) as Record<
+      string,
+      unknown
+    >;
     delete normalizedCard.signatures;
     const canonicalPayload = canonicalizeAgentCard(normalizedCard as Omit<AgentCard, 'signatures'>);
     const payloadBytes = new TextEncoder().encode(canonicalPayload);

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -107,9 +107,13 @@ export function verifyAgentCardSignature(
       throw new Error('No signatures found on agent card to verify.');
     }
 
-    const { signatures: _, ...cardWithoutSignatures } = agentCard;
-    void _;
-    const canonicalPayload = canonicalizeAgentCard(cardWithoutSignatures);
+    // Round-trip through AgentCard.fromJSON/toJSON to normalize the card:
+    // fromJSON strips non-schema fields (e.g., backward-compatibility fields
+    // injected by other SDK implementations), and toJSON omits fields with
+    // default values. This mirrors the Python SDK's MessageToDict behavior.
+    const normalizedCard = AgentCard.toJSON(AgentCard.fromJSON(agentCard)) as Record<string, unknown>;
+    delete normalizedCard.signatures;
+    const canonicalPayload = canonicalizeAgentCard(normalizedCard as Omit<AgentCard, 'signatures'>);
     const payloadBytes = new TextEncoder().encode(canonicalPayload);
     const encodedPayload = jose.base64url.encode(payloadBytes);
 

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -44,8 +44,7 @@ export function generateAgentCardSignature(
   header?: jose.JWSHeaderParameters
 ): AgentCardSignatureGenerator {
   return async (agentCard: AgentCard): Promise<AgentCard> => {
-    const { signatures: _, ...cardWithoutSignatures } = agentCard;
-    void _;
+    const { signatures: existingSignatures, ...cardWithoutSignatures } = agentCard;
     const canonicalPayload = canonicalizeAgentCard(cardWithoutSignatures);
 
     const signBuilder = new jose.FlattenedSign(
@@ -64,10 +63,10 @@ export function generateAgentCardSignature(
       header: jws.header,
     };
 
-    if (!agentCard.signatures) agentCard.signatures = [];
-    agentCard.signatures.push(agentCardSignature);
-
-    return agentCard;
+    return {
+      ...agentCard,
+      signatures: [...(existingSignatures ?? []), agentCardSignature],
+    };
   };
 }
 
@@ -132,7 +131,7 @@ export function verifyAgentCardSignature(
         await jose.flattenedVerify(jws, publicKey);
         return; // At least one valid signature found
       } catch (error) {
-        console.warn('Signature verification failed for entry:', error);
+        console.debug('Signature verification on entry was not successful:', signatureEntry, error);
       }
     }
 

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -149,7 +149,7 @@ function cleanEmpty(d: unknown): unknown {
   }
 
   if (Array.isArray(d)) {
-    const cleanedList = d.map((v) => cleanEmpty(v));
+    const cleanedList = d.map((v) => cleanEmpty(v)).filter((v) => v !== null);
     return cleanedList.length > 0 ? cleanedList : null;
   }
 

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -44,9 +44,9 @@ export function generateAgentCardSignature(
   header?: jose.JWSHeaderParameters
 ): AgentCardSignatureGenerator {
   return async (agentCard: AgentCard): Promise<AgentCard> => {
-    const cardCopy = JSON.parse(JSON.stringify(agentCard));
-    delete cardCopy.signatures;
-    const canonicalPayload = canonicalizeAgentCard(cardCopy);
+    const { signatures: _, ...cardWithoutSignatures } = agentCard;
+    void _;
+    const canonicalPayload = canonicalizeAgentCard(cardWithoutSignatures);
 
     const signBuilder = new jose.FlattenedSign(
       new TextEncoder().encode(canonicalPayload)
@@ -108,9 +108,9 @@ export function verifyAgentCardSignature(
       throw new Error('No signatures found on agent card to verify.');
     }
 
-    const cardCopy = JSON.parse(JSON.stringify(agentCard));
-    delete cardCopy.signatures;
-    const canonicalPayload = canonicalizeAgentCard(cardCopy);
+    const { signatures: _, ...cardWithoutSignatures } = agentCard;
+    void _;
+    const canonicalPayload = canonicalizeAgentCard(cardWithoutSignatures);
     const payloadBytes = new TextEncoder().encode(canonicalPayload);
     const encodedPayload = jose.base64url.encode(payloadBytes);
 
@@ -150,7 +150,7 @@ function cleanEmpty(d: unknown): unknown {
   }
 
   if (Array.isArray(d)) {
-    const cleanedList = d.map((v) => cleanEmpty(v)).filter((v) => v !== null);
+    const cleanedList = d.map((v) => cleanEmpty(v));
     return cleanedList.length > 0 ? cleanedList : null;
   }
 

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -1,0 +1,207 @@
+/**
+ * Agent Card Signature utilities per §8.4.
+ *
+ * Provides JWS signing and verification for Agent Cards using
+ * JCS (RFC 8785) canonicalization and the `jose` library.
+ *
+ * Agent Cards MAY be signed using JWS. Canonicalization MUST use JCS.
+ * Clients SHOULD verify signatures when present.
+ */
+
+import * as jose from 'jose';
+import { AgentCard, AgentCardSignature } from './index.js';
+
+/**
+ * A function that signs an agent card and returns the card with signatures attached.
+ */
+export type AgentCardSignatureGenerator = (agentCard: AgentCard) => Promise<AgentCard>;
+
+/**
+ * Creates an {@link AgentCardSignatureGenerator} that signs an agent card using JWS
+ * (Flattened JSON Serialization) with the provided private key.
+ *
+ * The agent card is canonicalized using JCS (RFC 8785) before signing.
+ * The `signatures` field is excluded from the payload before canonicalization.
+ *
+ * @param privateKey - The private key used for signing.
+ * @param protectedHeader - JWS protected header (MUST include `alg`, `kid`, `typ`).
+ * @param header - Optional unprotected JWS header values.
+ * @returns A function that signs an agent card and appends the signature.
+ *
+ * @example
+ * ```ts
+ * const signer = generateAgentCardSignature(privateKey, {
+ *   alg: 'ES256',
+ *   kid: 'my-key-id',
+ *   typ: 'JOSE',
+ * });
+ * const signedCard = await signer(agentCard);
+ * ```
+ */
+export function generateAgentCardSignature(
+  privateKey: jose.CryptoKey | jose.KeyObject | jose.JWK,
+  protectedHeader: jose.JWSHeaderParameters,
+  header?: jose.JWSHeaderParameters
+): AgentCardSignatureGenerator {
+  return async (agentCard: AgentCard): Promise<AgentCard> => {
+    const cardCopy = JSON.parse(JSON.stringify(agentCard));
+    delete cardCopy.signatures;
+    const canonicalPayload = canonicalizeAgentCard(cardCopy);
+
+    const signBuilder = new jose.FlattenedSign(
+      new TextEncoder().encode(canonicalPayload)
+    ).setProtectedHeader(protectedHeader);
+
+    if (header) {
+      signBuilder.setUnprotectedHeader(header);
+    }
+
+    const jws = await signBuilder.sign(privateKey);
+
+    const agentCardSignature: AgentCardSignature = {
+      protected: jws.protected!,
+      signature: jws.signature,
+      header: jws.header,
+    };
+
+    if (!agentCard.signatures) agentCard.signatures = [];
+    agentCard.signatures.push(agentCardSignature);
+
+    return agentCard;
+  };
+}
+
+/**
+ * A function that verifies an agent card's signatures.
+ * Throws if no valid signature is found.
+ */
+export type AgentCardSignatureVerifier = (agentCard: AgentCard) => Promise<void>;
+
+/**
+ * Creates an {@link AgentCardSignatureVerifier} that verifies agent card signatures.
+ *
+ * The verifier iterates through all signatures on the card and succeeds if at least
+ * one signature is valid (multi-signature support). The agent card is canonicalized
+ * using JCS (RFC 8785) and compared against each signature's payload.
+ *
+ * @param retrievePublicKey - A function that retrieves the public key for a given `kid`
+ *   and optional `jku` (JWK Set URL). Called for each signature's protected header.
+ * @returns A function that verifies an agent card's signatures.
+ *
+ * @example
+ * ```ts
+ * const verifier = verifyAgentCardSignature(async (kid, jku) => {
+ *   // Fetch the public key from your key store
+ *   return await fetchPublicKey(kid, jku);
+ * });
+ * await verifier(agentCard); // throws if no valid signature
+ * ```
+ */
+export function verifyAgentCardSignature(
+  retrievePublicKey: (
+    kid: string,
+    jku?: string
+  ) => Promise<jose.CryptoKey | jose.KeyObject | jose.JWK>
+): AgentCardSignatureVerifier {
+  return async (agentCard: AgentCard): Promise<void> => {
+    if (!agentCard.signatures?.length) {
+      throw new Error('No signatures found on agent card to verify.');
+    }
+
+    const cardCopy = JSON.parse(JSON.stringify(agentCard));
+    delete cardCopy.signatures;
+    const canonicalPayload = canonicalizeAgentCard(cardCopy);
+    const payloadBytes = new TextEncoder().encode(canonicalPayload);
+    const encodedPayload = jose.base64url.encode(payloadBytes);
+
+    for (const signatureEntry of agentCard.signatures) {
+      try {
+        const protectedHeader = jose.decodeProtectedHeader(signatureEntry);
+        if (!protectedHeader.kid || !protectedHeader.typ || !protectedHeader.alg) {
+          throw new Error('Missing required header parameters (kid, typ, alg)');
+        }
+
+        const publicKey = await retrievePublicKey(protectedHeader.kid, protectedHeader.jku);
+        const jws: jose.FlattenedJWS = {
+          payload: encodedPayload,
+          protected: signatureEntry.protected,
+          signature: signatureEntry.signature,
+          header: signatureEntry.header as jose.JWSHeaderParameters,
+        };
+
+        await jose.flattenedVerify(jws, publicKey);
+        return; // At least one valid signature found
+      } catch (error) {
+        console.warn('Signature verification failed for entry:', error);
+      }
+    }
+
+    throw new Error('No valid signatures found on agent card.');
+  };
+}
+
+/**
+ * Removes empty values (empty strings, null, undefined, empty arrays, empty objects)
+ * recursively from a value, preparing it for JCS canonicalization.
+ */
+function cleanEmpty(d: unknown): unknown {
+  if (d === '' || d === null || d === undefined) {
+    return null;
+  }
+
+  if (Array.isArray(d)) {
+    const cleanedList = d.map((v) => cleanEmpty(v)).filter((v) => v !== null);
+    return cleanedList.length > 0 ? cleanedList : null;
+  }
+
+  if (typeof d === 'object') {
+    if (d instanceof Date) return d;
+    const cleanedDict: Record<string, unknown> = {};
+    for (const [key, v] of Object.entries(d as Record<string, unknown>)) {
+      const cleanedValue = cleanEmpty(v);
+      if (cleanedValue !== null) {
+        cleanedDict[key] = cleanedValue;
+      }
+    }
+    return Object.keys(cleanedDict).length > 0 ? cleanedDict : null;
+  }
+
+  return d;
+}
+
+/**
+ * JCS Canonicalization (RFC 8785).
+ * Sorts object keys recursively and serializes to a deterministic JSON string.
+ */
+function jcsStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return '[' + value.map((item) => jcsStringify(item)).join(',') + ']';
+  }
+
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record).sort();
+  const parts = keys.map((key) => `${JSON.stringify(key)}:${jcsStringify(record[key])}`);
+
+  return '{' + parts.join(',') + '}';
+}
+
+/**
+ * Canonicalizes an agent card using JCS (RFC 8785) for signing/verification.
+ *
+ * The `signatures` field MUST be excluded from the agent card before calling this.
+ * Empty values are cleaned recursively, then keys are sorted deterministically.
+ *
+ * @param agentCard - The agent card without the `signatures` field.
+ * @returns The canonical JSON string representation.
+ */
+export function canonicalizeAgentCard(agentCard: Omit<AgentCard, 'signatures'>): string {
+  const cleaned = cleanEmpty(agentCard);
+  if (!cleaned) {
+    return '{}';
+  }
+  return jcsStringify(cleaned);
+}

--- a/src/signature.ts
+++ b/src/signature.ts
@@ -154,7 +154,7 @@ function cleanEmpty(d: unknown): unknown {
   }
 
   if (typeof d === 'object') {
-    if (d instanceof Date) return d;
+    if (d instanceof Date) return d.toISOString();
     const cleanedDict: Record<string, unknown> = {};
     for (const [key, v] of Object.entries(d as Record<string, unknown>)) {
       const cleanedValue = cleanEmpty(v);

--- a/test/signature.spec.ts
+++ b/test/signature.spec.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import * as jose from 'jose';
+import {
+  generateAgentCardSignature,
+  verifyAgentCardSignature,
+  canonicalizeAgentCard,
+} from '../src/signature.js';
+import { AgentCard } from '../src/index.js';
+
+let mockAgentCard: AgentCard;
+let privateKey: jose.CryptoKey;
+let publicKey: jose.CryptoKey;
+const ALG = 'ES256';
+
+describe('Agent Card Signature', () => {
+  beforeAll(async () => {
+    const keys = await jose.generateKeyPair(ALG, { extractable: true });
+    privateKey = keys.privateKey;
+    publicKey = keys.publicKey;
+  });
+
+  beforeEach(() => {
+    mockAgentCard = {
+      name: 'Test Agent',
+      description: 'An agent for testing purposes',
+      version: '1.0.0',
+      capabilities: {
+        streaming: true,
+        pushNotifications: true,
+        extensions: [],
+      },
+      supportedInterfaces: [
+        {
+          url: 'http://localhost:8080',
+          protocolBinding: 'JSONRPC',
+          tenant: '',
+          protocolVersion: '1.0',
+        },
+      ],
+      defaultInputModes: ['text/plain'],
+      defaultOutputModes: ['text/plain'],
+      skills: [],
+      provider: { organization: 'Test', url: '' },
+      securitySchemes: {},
+      securityRequirements: [],
+      signatures: [],
+    };
+  });
+
+  describe('canonicalizeAgentCard', () => {
+    it('should remove empty values and sort keys recursively (JCS)', () => {
+      const input = {
+        name: 'Example Agent',
+        description: '',
+        capabilities: {
+          streaming: false,
+          pushNotifications: false,
+          extensions: [],
+        },
+        skills: [],
+        defaultInputModes: [],
+        defaultOutputModes: [],
+        version: '1.0.0',
+        supportedInterfaces: [],
+        provider: { organization: '', url: '' },
+        securitySchemes: {},
+        securityRequirements: [],
+      } as Omit<AgentCard, 'signatures'>;
+
+      const result = canonicalizeAgentCard(input);
+      const parsed = JSON.parse(result);
+
+      // Empty values should be removed
+      expect(parsed.description).toBeUndefined();
+      expect(parsed.skills).toBeUndefined();
+      expect(parsed.defaultInputModes).toBeUndefined();
+
+      // Non-empty values should be preserved
+      expect(parsed.name).toBe('Example Agent');
+      expect(parsed.version).toBe('1.0.0');
+
+      // Keys should be sorted
+      const keys = Object.keys(parsed);
+      const sortedKeys = [...keys].sort();
+      expect(keys).toEqual(sortedKeys);
+    });
+
+    it('should produce deterministic output regardless of key order', () => {
+      const card1 = { name: 'Agent', version: '1.0', capabilities: { streaming: true } };
+      const card2 = { capabilities: { streaming: true }, version: '1.0', name: 'Agent' };
+
+      expect(canonicalizeAgentCard(card1 as any)).toBe(canonicalizeAgentCard(card2 as any));
+    });
+  });
+
+  describe('generateAgentCardSignature', () => {
+    it('should add a signature to the agent card', async () => {
+      const signer = generateAgentCardSignature(privateKey, {
+        alg: ALG,
+        kid: 'test-key-1',
+        typ: 'JOSE',
+      });
+
+      const signedCard = await signer(mockAgentCard);
+
+      expect(signedCard.signatures).toBeDefined();
+      expect(signedCard.signatures).toHaveLength(1);
+
+      const sig = signedCard.signatures[0];
+      expect(sig.protected).toBeDefined();
+      expect(sig.signature).toBeDefined();
+
+      const decodedHeader = jose.decodeProtectedHeader(sig);
+      expect(decodedHeader.kid).toBe('test-key-1');
+      expect(decodedHeader.alg).toBe(ALG);
+    });
+
+    it('should append signatures if one already exists', async () => {
+      const signer = generateAgentCardSignature(privateKey, {
+        alg: ALG,
+        kid: 'key-1',
+        typ: 'JOSE',
+      });
+
+      await signer(mockAgentCard);
+      await signer(mockAgentCard);
+      expect(mockAgentCard.signatures).toHaveLength(2);
+    });
+  });
+
+  describe('verifyAgentCardSignature', () => {
+    const mockRetrieveKey = vi.fn();
+
+    beforeEach(() => {
+      mockRetrieveKey.mockReset();
+      mockRetrieveKey.mockImplementation(async () => publicKey);
+    });
+
+    it('should successfully verify a valid signature', async () => {
+      const signer = generateAgentCardSignature(privateKey, {
+        alg: ALG,
+        kid: 'test-key-1',
+        typ: 'JOSE',
+      });
+      await signer(mockAgentCard);
+
+      const verifier = verifyAgentCardSignature(mockRetrieveKey);
+      await expect(verifier(mockAgentCard)).resolves.not.toThrow();
+
+      expect(mockRetrieveKey).toHaveBeenCalledWith('test-key-1', undefined);
+    });
+
+    it('should fail if the payload has been tampered with', async () => {
+      const signer = generateAgentCardSignature(privateKey, {
+        alg: ALG,
+        kid: 'test-key-1',
+        typ: 'JOSE',
+      });
+      await signer(mockAgentCard);
+
+      mockAgentCard.name = 'Modified Agent Name';
+      const verifier = verifyAgentCardSignature(mockRetrieveKey);
+      await expect(verifier(mockAgentCard)).rejects.toThrow('No valid signatures found');
+    });
+
+    it('should fail if the signature is invalid/malformed', async () => {
+      const signer = generateAgentCardSignature(privateKey, {
+        alg: ALG,
+        kid: 'test-key-1',
+        typ: 'JOSE',
+      });
+      await signer(mockAgentCard);
+
+      mockAgentCard.signatures[0].signature = 'invalid_signature_string';
+      const verifier = verifyAgentCardSignature(mockRetrieveKey);
+      await expect(verifier(mockAgentCard)).rejects.toThrow('No valid signatures found');
+    });
+
+    it('should throw if no signatures are present', async () => {
+      mockAgentCard.signatures = [];
+      const verifier = verifyAgentCardSignature(mockRetrieveKey);
+      await expect(verifier(mockAgentCard)).rejects.toThrow('No signatures found');
+    });
+
+    it('should pass if at least one signature is valid (multi-sig)', async () => {
+      // Add an invalid signature first
+      mockAgentCard.signatures = [
+        {
+          protected: 'invalid_value',
+          signature: 'invalid_value',
+          header: undefined,
+        },
+      ];
+
+      // Then add a valid one
+      const signer = generateAgentCardSignature(privateKey, {
+        alg: ALG,
+        kid: 'test-key-1',
+        typ: 'JOSE',
+      });
+      await signer(mockAgentCard);
+
+      const verifier = verifyAgentCardSignature(mockRetrieveKey);
+      await expect(verifier(mockAgentCard)).resolves.not.toThrow();
+    });
+
+    it('should pass jku to retrievePublicKey when present in header', async () => {
+      const signer = generateAgentCardSignature(privateKey, {
+        alg: ALG,
+        kid: 'test-key-1',
+        typ: 'JOSE',
+        jku: 'https://example.com/.well-known/jwks.json',
+      });
+      await signer(mockAgentCard);
+
+      const verifier = verifyAgentCardSignature(mockRetrieveKey);
+      await verifier(mockAgentCard);
+
+      expect(mockRetrieveKey).toHaveBeenCalledWith(
+        'test-key-1',
+        'https://example.com/.well-known/jwks.json'
+      );
+    });
+  });
+});

--- a/test/signature.spec.ts
+++ b/test/signature.spec.ts
@@ -205,6 +205,28 @@ describe('Agent Card Signature', () => {
       await expect(verifier(signedCard)).resolves.not.toThrow();
     });
 
+    it('should verify cards with non-schema fields (cross-implementation compat)', async () => {
+      const signer = generateAgentCardSignature(privateKey, {
+        alg: ALG,
+        kid: 'test-key-1',
+        typ: 'JOSE',
+      });
+      const signedCard = await signer(mockAgentCard);
+
+      // Simulate backward-compat fields injected by another SDK implementation
+      // (e.g., Python SDK v0.3 compat layer adds these to the HTTP response)
+      const cardWithExtraFields = {
+        ...signedCard,
+        url: 'http://localhost:8080',
+        preferredTransport: 'JSONRPC',
+        protocolVersion: '0.3',
+        supportsAuthenticatedExtendedCard: false,
+      };
+
+      const verifier = verifyAgentCardSignature(mockRetrieveKey);
+      await expect(verifier(cardWithExtraFields as AgentCard)).resolves.not.toThrow();
+    });
+
     it('should pass jku to retrievePublicKey when present in header', async () => {
       const signer = generateAgentCardSignature(privateKey, {
         alg: ALG,

--- a/test/signature.spec.ts
+++ b/test/signature.spec.ts
@@ -122,9 +122,10 @@ describe('Agent Card Signature', () => {
         typ: 'JOSE',
       });
 
-      await signer(mockAgentCard);
-      await signer(mockAgentCard);
-      expect(mockAgentCard.signatures).toHaveLength(2);
+      const signed1 = await signer(mockAgentCard);
+      const signed2 = await signer(signed1);
+      expect(signed2.signatures).toHaveLength(2);
+      expect(mockAgentCard.signatures).toHaveLength(0);
     });
   });
 
@@ -142,10 +143,10 @@ describe('Agent Card Signature', () => {
         kid: 'test-key-1',
         typ: 'JOSE',
       });
-      await signer(mockAgentCard);
+      const signedCard = await signer(mockAgentCard);
 
       const verifier = verifyAgentCardSignature(mockRetrieveKey);
-      await expect(verifier(mockAgentCard)).resolves.not.toThrow();
+      await expect(verifier(signedCard)).resolves.not.toThrow();
 
       expect(mockRetrieveKey).toHaveBeenCalledWith('test-key-1', undefined);
     });
@@ -156,11 +157,11 @@ describe('Agent Card Signature', () => {
         kid: 'test-key-1',
         typ: 'JOSE',
       });
-      await signer(mockAgentCard);
+      const signedCard = await signer(mockAgentCard);
 
-      mockAgentCard.name = 'Modified Agent Name';
+      const modifiedAgentCard = { ...signedCard, name: 'Modified Agent Name' };
       const verifier = verifyAgentCardSignature(mockRetrieveKey);
-      await expect(verifier(mockAgentCard)).rejects.toThrow('No valid signatures found');
+      await expect(verifier(modifiedAgentCard)).rejects.toThrow('No valid signatures found');
     });
 
     it('should fail if the signature is invalid/malformed', async () => {
@@ -169,11 +170,11 @@ describe('Agent Card Signature', () => {
         kid: 'test-key-1',
         typ: 'JOSE',
       });
-      await signer(mockAgentCard);
+      const signedCard = await signer(mockAgentCard);
 
-      mockAgentCard.signatures[0].signature = 'invalid_signature_string';
+      (signedCard.signatures as any)[0].signature = 'invalid_signature_string';
       const verifier = verifyAgentCardSignature(mockRetrieveKey);
-      await expect(verifier(mockAgentCard)).rejects.toThrow('No valid signatures found');
+      await expect(verifier(signedCard)).rejects.toThrow('No valid signatures found');
     });
 
     it('should throw if no signatures are present', async () => {
@@ -198,10 +199,10 @@ describe('Agent Card Signature', () => {
         kid: 'test-key-1',
         typ: 'JOSE',
       });
-      await signer(mockAgentCard);
+      const signedCard = await signer(mockAgentCard);
 
       const verifier = verifyAgentCardSignature(mockRetrieveKey);
-      await expect(verifier(mockAgentCard)).resolves.not.toThrow();
+      await expect(verifier(signedCard)).resolves.not.toThrow();
     });
 
     it('should pass jku to retrievePublicKey when present in header', async () => {
@@ -211,10 +212,10 @@ describe('Agent Card Signature', () => {
         typ: 'JOSE',
         jku: 'https://example.com/.well-known/jwks.json',
       });
-      await signer(mockAgentCard);
+      const signedCard = await signer(mockAgentCard);
 
       const verifier = verifyAgentCardSignature(mockRetrieveKey);
-      await verifier(mockAgentCard);
+      await verifier(signedCard);
 
       expect(mockRetrieveKey).toHaveBeenCalledWith(
         'test-key-1',


### PR DESCRIPTION
# Description

Implementing the feature of `AgentCardSignature`. The PR is based on #290.

# Important note

Most changes are ported 1-1. The main difference between the implementation here and the one on the #290 is that in the initial PR, the `agentCard` had root `signatures` incremented. This resulted in constantly growing `agentCard` object.

In the #290 there were also [unit tests](https://github.com/guglielmo-san/a2a-js/blob/b0b27a82f7fd0372cc521a90043268d1f6a62d07/test/signature.spec.ts#L64-L97) to confirm that behavior but it seems like an undesired outcome. In this PR, using `generateAgentCardSignature` will return a new `agentCard` with incremented signatures instead of incrementing the original object.

Fixes #289  🦕
