### PR TITLE
ci: Add an option to omit the component name in release version tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "release-type": "node",
+  "include-component-in-tag": false,
   "prerelease": true,
   "prerelease-type": "alpha",
   "versioning": "prerelease",


### PR DESCRIPTION
# Description

Next release should be automatically tagged as `vX.Y.Z` instead of `sdk: vX.Y.Z`.
