### PR TITLE
ci: Remove version specific settings from release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,6 @@
   "prerelease": true,
   "prerelease-type": "alpha",
   "versioning": "prerelease",
-  "last-release-sha": "82d36c7",
-  "release-as": "1.0.0-alpha.0",
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
# Description

Remove version specific settings from release-please. This should fix release-please trying to create a release with the entire `epic/1.0...` branch.