### PR TITLE
docs: Make the install command in the epic's README point to the next release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can install the latest `next` release of the A2A SDK using `npm`.
 npm install @a2a-js/sdk@next
 ```
 
-Note that this is a `next` release, to install the latest stable release, use `npm install @a2a-js/sdk`.
+Note that this is a `next` release. To install the latest stable release, use `npm install @a2a-js/sdk`.
 
 ### For Server Usage
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@
 
 ## Installation
 
-You can install the A2A SDK using `npm`.
+You can install the latest `next` release of the A2A SDK using `npm`.
 
 ```bash
-npm install @a2a-js/sdk
+npm install @a2a-js/sdk@next
 ```
+
+Note that this is a `next` release, to install the latest stable release, use `npm install @a2a-js/sdk`.
 
 ### For Server Usage
 


### PR DESCRIPTION
# Description

The README doc suggested to install the latest stable release but since this README is on the `epic` branch, it could point to the latest `next` release that is already published.
