### PR TITLE
feat: defined compat-specific consts and mappings

### DIFF
--- a/src/compat/v0_3/constants.ts
+++ b/src/compat/v0_3/constants.ts
@@ -54,9 +54,23 @@ export const LEGACY_JSONRPC_TO_V1: Readonly<Record<string, string>> = Object.fre
 });
 
 /**
+ * v1.0 PascalCase method names that exist in v1.0 but have NO equivalent in
+ * v0.3 (neither JSON-RPC nor gRPC). Translating one of these names into the
+ * v0.3 coordinate system yields a "method not implemented in v0.3" error
+ * (JSON-RPC code -32004 / `A2AError.unsupportedOperation`) instead of the
+ * generic invalid-request error.
+ *
+ * Per §3.5.6 of the v0.3 spec, `tasks/list` was gRPC/REST-only in v0.3 (no
+ * JSON-RPC binding), and the v0.3 protobuf shipped in this repo has no
+ * `ListTasks` RPC at all -- so for compat purposes the v1.0 `ListTasks`
+ * method is treated as fully absent.
+ */
+export const V1_METHODS_WITHOUT_LEGACY_EQUIVALENT: ReadonlySet<string> = new Set(['ListTasks']);
+
+/**
  * v1.0 PascalCase method name -> v0.3 JSON-RPC method string.
  *
- * `ListTasks` is omitted: v0.3 has no equivalent JSON-RPC method.
+ * Methods listed in {@link V1_METHODS_WITHOUT_LEGACY_EQUIVALENT} are omitted.
  */
 export const V1_TO_LEGACY_JSONRPC: Readonly<Record<string, string>> = Object.freeze(
   Object.fromEntries(Object.entries(LEGACY_JSONRPC_TO_V1).map(([k, v]) => [v, k]))
@@ -94,7 +108,7 @@ export const LEGACY_GRPC_TO_V1: Readonly<Record<string, string>> = Object.freeze
 /**
  * v1.0 PascalCase method name -> v0.3 gRPC PascalCase method name.
  *
- * `ListTasks` is omitted: v0.3 has no equivalent gRPC method.
+ * Methods listed in {@link V1_METHODS_WITHOUT_LEGACY_EQUIVALENT} are omitted.
  */
 export const V1_TO_LEGACY_GRPC: Readonly<Record<string, string>> = Object.freeze(
   Object.fromEntries(Object.entries(LEGACY_GRPC_TO_V1).map(([k, v]) => [v, k]))
@@ -112,14 +126,44 @@ const lookup = (
   return mapped;
 };
 
+/**
+ * Looks up `method` in `table`. If the lookup fails AND `method` is a known
+ * v1.0 method that has no v0.3 equivalent (per
+ * {@link V1_METHODS_WITHOUT_LEGACY_EQUIVALENT}), throws
+ * `A2AError.unsupportedOperation` (-32004) so callers can distinguish "this
+ * is a real v1.0 method but v0.3 simply does not implement it" from "this
+ * name is gibberish". Otherwise behaves like {@link lookup}.
+ */
+const lookupFromV1 = (
+  table: Readonly<Record<string, string>>,
+  method: string,
+  legacyTransport: string
+): string => {
+  const mapped = table[method];
+  if (mapped !== undefined) return mapped;
+  if (V1_METHODS_WITHOUT_LEGACY_EQUIVALENT.has(method)) {
+    throw A2AError.unsupportedOperation(
+      `v1.0 method "${method}" has no equivalent in v0.3 ${legacyTransport}`
+    );
+  }
+  throw A2AError.invalidRequest(`Unknown v1.0 method: "${method}"`);
+};
+
 /** Translate a v0.3 JSON-RPC method name to its v1.0 PascalCase equivalent. */
 export function legacyJsonRpcToV1Method(method: string): string {
   return lookup(LEGACY_JSONRPC_TO_V1, method, 'legacy JSON-RPC');
 }
 
-/** Translate a v1.0 PascalCase method name to its v0.3 JSON-RPC equivalent. */
+/**
+ * Translate a v1.0 PascalCase method name to its v0.3 JSON-RPC equivalent.
+ *
+ * Throws `A2AError.unsupportedOperation` (-32004) if `method` is a v1.0 name
+ * that has no v0.3 equivalent (e.g. `ListTasks`); throws
+ * `A2AError.invalidRequest` (-32600) if `method` is not a known v1.0 method
+ * at all.
+ */
 export function v1MethodToLegacyJsonRpc(method: string): string {
-  return lookup(V1_TO_LEGACY_JSONRPC, method, 'v1.0');
+  return lookupFromV1(V1_TO_LEGACY_JSONRPC, method, 'JSON-RPC');
 }
 
 /** Translate a v0.3 JSON-RPC method name to its v0.3 gRPC equivalent. */
@@ -130,4 +174,21 @@ export function legacyJsonRpcToLegacyGrpcMethod(method: string): string {
 /** Translate a v0.3 gRPC method name to its v0.3 JSON-RPC equivalent. */
 export function legacyGrpcToLegacyJsonRpcMethod(method: string): string {
   return lookup(LEGACY_GRPC_TO_LEGACY_JSONRPC, method, 'legacy gRPC');
+}
+
+/** Translate a v0.3 gRPC method name to its v1.0 PascalCase equivalent. */
+export function legacyGrpcToV1Method(method: string): string {
+  return lookup(LEGACY_GRPC_TO_V1, method, 'legacy gRPC');
+}
+
+/**
+ * Translate a v1.0 PascalCase method name to its v0.3 gRPC equivalent.
+ *
+ * Throws `A2AError.unsupportedOperation` (-32004) if `method` is a v1.0 name
+ * that has no v0.3 equivalent (e.g. `ListTasks`); throws
+ * `A2AError.invalidRequest` (-32600) if `method` is not a known v1.0 method
+ * at all.
+ */
+export function v1MethodToLegacyGrpc(method: string): string {
+  return lookupFromV1(V1_TO_LEGACY_GRPC, method, 'gRPC');
 }

--- a/src/compat/v0_3/constants.ts
+++ b/src/compat/v0_3/constants.ts
@@ -1,0 +1,133 @@
+/**
+ * Compat-layer constants and method-name mappings for the legacy A2A v0.3
+ * protocol.
+ */
+
+import { A2AError } from './server/error.js';
+
+/**
+ * The legacy A2A protocol version this compat layer targets.
+ *
+ * Mirrors the `protocolVersion` field on legacy v0.3 AgentCards.
+ */
+export const A2A_LEGACY_PROTOCOL_VERSION = '0.3';
+
+/**
+ * The HTTP extension header used by legacy v0.3.
+ *
+ * Note: v0.3 used the `X-` prefixed form; the v1.0 spec dropped the prefix
+ * (see `HTTP_EXTENSION_HEADER` in `src/constants.ts`).
+ */
+export const LEGACY_HTTP_EXTENSION_HEADER = 'X-A2A-Extensions';
+
+/**
+ * The JSON content type used by legacy v0.3 JSON-RPC and REST transports.
+ *
+ * Unlike v1.0 (which uses `application/a2a+json` for REST/push payloads),
+ * v0.3 used plain `application/json` everywhere.
+ */
+export const LEGACY_JSON_CONTENT_TYPE = 'application/json';
+
+export const LEGACY_METHOD_MESSAGE_SEND = 'message/send';
+export const LEGACY_METHOD_MESSAGE_STREAM = 'message/stream';
+export const LEGACY_METHOD_TASKS_GET = 'tasks/get';
+export const LEGACY_METHOD_TASKS_CANCEL = 'tasks/cancel';
+export const LEGACY_METHOD_TASKS_RESUBSCRIBE = 'tasks/resubscribe';
+export const LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_SET = 'tasks/pushNotificationConfig/set';
+export const LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_GET = 'tasks/pushNotificationConfig/get';
+export const LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_LIST = 'tasks/pushNotificationConfig/list';
+export const LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_DELETE = 'tasks/pushNotificationConfig/delete';
+export const LEGACY_METHOD_GET_AUTHENTICATED_EXTENDED_CARD = 'agent/getAuthenticatedExtendedCard';
+
+/** v0.3 JSON-RPC method string -> v1.0 PascalCase method name. */
+export const LEGACY_JSONRPC_TO_V1: Readonly<Record<string, string>> = Object.freeze({
+  [LEGACY_METHOD_MESSAGE_SEND]: 'SendMessage',
+  [LEGACY_METHOD_MESSAGE_STREAM]: 'SendStreamingMessage',
+  [LEGACY_METHOD_TASKS_GET]: 'GetTask',
+  [LEGACY_METHOD_TASKS_CANCEL]: 'CancelTask',
+  [LEGACY_METHOD_TASKS_RESUBSCRIBE]: 'SubscribeToTask',
+  [LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_SET]: 'CreateTaskPushNotificationConfig',
+  [LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_GET]: 'GetTaskPushNotificationConfig',
+  [LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_LIST]: 'ListTaskPushNotificationConfigs',
+  [LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_DELETE]: 'DeleteTaskPushNotificationConfig',
+  [LEGACY_METHOD_GET_AUTHENTICATED_EXTENDED_CARD]: 'GetExtendedAgentCard',
+});
+
+/**
+ * v1.0 PascalCase method name -> v0.3 JSON-RPC method string.
+ *
+ * `ListTasks` is omitted: v0.3 has no equivalent JSON-RPC method.
+ */
+export const V1_TO_LEGACY_JSONRPC: Readonly<Record<string, string>> = Object.freeze(
+  Object.fromEntries(Object.entries(LEGACY_JSONRPC_TO_V1).map(([k, v]) => [v, k]))
+);
+
+/** v0.3 JSON-RPC method string -> v0.3 gRPC PascalCase method name. */
+export const LEGACY_JSONRPC_TO_LEGACY_GRPC: Readonly<Record<string, string>> = Object.freeze({
+  [LEGACY_METHOD_MESSAGE_SEND]: 'SendMessage',
+  [LEGACY_METHOD_MESSAGE_STREAM]: 'SendStreamingMessage',
+  [LEGACY_METHOD_TASKS_GET]: 'GetTask',
+  [LEGACY_METHOD_TASKS_CANCEL]: 'CancelTask',
+  [LEGACY_METHOD_TASKS_RESUBSCRIBE]: 'TaskSubscription',
+  [LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_SET]: 'CreateTaskPushNotificationConfig',
+  [LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_GET]: 'GetTaskPushNotificationConfig',
+  [LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_LIST]: 'ListTaskPushNotificationConfig',
+  [LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_DELETE]: 'DeleteTaskPushNotificationConfig',
+  [LEGACY_METHOD_GET_AUTHENTICATED_EXTENDED_CARD]: 'GetAgentCard',
+});
+
+/** v0.3 gRPC PascalCase method name -> v0.3 JSON-RPC method string. */
+export const LEGACY_GRPC_TO_LEGACY_JSONRPC: Readonly<Record<string, string>> = Object.freeze(
+  Object.fromEntries(Object.entries(LEGACY_JSONRPC_TO_LEGACY_GRPC).map(([k, v]) => [v, k]))
+);
+
+/** v0.3 gRPC PascalCase method name -> v1.0 PascalCase method name. */
+export const LEGACY_GRPC_TO_V1: Readonly<Record<string, string>> = Object.freeze(
+  Object.fromEntries(
+    Object.entries(LEGACY_JSONRPC_TO_LEGACY_GRPC).map(([jsonRpc, grpc]) => [
+      grpc,
+      LEGACY_JSONRPC_TO_V1[jsonRpc],
+    ])
+  )
+);
+
+/**
+ * v1.0 PascalCase method name -> v0.3 gRPC PascalCase method name.
+ *
+ * `ListTasks` is omitted: v0.3 has no equivalent gRPC method.
+ */
+export const V1_TO_LEGACY_GRPC: Readonly<Record<string, string>> = Object.freeze(
+  Object.fromEntries(Object.entries(LEGACY_GRPC_TO_V1).map(([k, v]) => [v, k]))
+);
+
+const lookup = (
+  table: Readonly<Record<string, string>>,
+  method: string,
+  direction: string
+): string => {
+  const mapped = table[method];
+  if (mapped === undefined) {
+    throw A2AError.invalidRequest(`Unknown ${direction} method: "${method}"`);
+  }
+  return mapped;
+};
+
+/** Translate a v0.3 JSON-RPC method name to its v1.0 PascalCase equivalent. */
+export function legacyJsonRpcToV1Method(method: string): string {
+  return lookup(LEGACY_JSONRPC_TO_V1, method, 'legacy JSON-RPC');
+}
+
+/** Translate a v1.0 PascalCase method name to its v0.3 JSON-RPC equivalent. */
+export function v1MethodToLegacyJsonRpc(method: string): string {
+  return lookup(V1_TO_LEGACY_JSONRPC, method, 'v1.0');
+}
+
+/** Translate a v0.3 JSON-RPC method name to its v0.3 gRPC equivalent. */
+export function legacyJsonRpcToLegacyGrpcMethod(method: string): string {
+  return lookup(LEGACY_JSONRPC_TO_LEGACY_GRPC, method, 'legacy JSON-RPC');
+}
+
+/** Translate a v0.3 gRPC method name to its v0.3 JSON-RPC equivalent. */
+export function legacyGrpcToLegacyJsonRpcMethod(method: string): string {
+  return lookup(LEGACY_GRPC_TO_LEGACY_JSONRPC, method, 'legacy gRPC');
+}

--- a/src/compat/v0_3/index.ts
+++ b/src/compat/v0_3/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Compat-layer constants and method-name mappings for the legacy A2A v0.3
+ * protocol.
+ */
+
+export * from './constants.js';
+export { A2AError as LegacyA2AError } from './server/error.js';

--- a/src/compat/v0_3/server/error.ts
+++ b/src/compat/v0_3/server/error.ts
@@ -1,7 +1,7 @@
 import * as schema from '../types/types.js';
 
 /**
- * Custom error class for A2A server operations, incorporating JSON-RPC error codes.
+ * Custom error class for A2A server operations, incorporating JSON-RPC error codes, used by the v0.3 compat layer.
  */
 export class A2AError extends Error {
   public code: number;

--- a/test/compat/v0_3/constants.spec.ts
+++ b/test/compat/v0_3/constants.spec.ts
@@ -17,11 +17,14 @@ import {
   LEGACY_GRPC_TO_V1,
   LEGACY_JSONRPC_TO_LEGACY_GRPC,
   LEGACY_JSONRPC_TO_V1,
+  V1_METHODS_WITHOUT_LEGACY_EQUIVALENT,
   V1_TO_LEGACY_GRPC,
   V1_TO_LEGACY_JSONRPC,
   legacyGrpcToLegacyJsonRpcMethod,
+  legacyGrpcToV1Method,
   legacyJsonRpcToLegacyGrpcMethod,
   legacyJsonRpcToV1Method,
+  v1MethodToLegacyGrpc,
   v1MethodToLegacyJsonRpc,
 } from '../../../src/compat/v0_3/constants.js';
 import { A2AError } from '../../../src/compat/v0_3/server/error.js';
@@ -106,16 +109,39 @@ describe('compat/v0_3/constants - round-trip invariants', () => {
 });
 
 describe('compat/v0_3/constants - asymmetric v1.0 methods', () => {
-  it('V1_TO_LEGACY_JSONRPC has no entry for ListTasks (no v0.3 equivalent)', () => {
-    expect(V1_TO_LEGACY_JSONRPC).not.toHaveProperty('ListTasks');
+  it('V1_METHODS_WITHOUT_LEGACY_EQUIVALENT contains ListTasks', () => {
+    expect(V1_METHODS_WITHOUT_LEGACY_EQUIVALENT.has('ListTasks')).toBe(true);
   });
 
-  it('V1_TO_LEGACY_GRPC has no entry for ListTasks', () => {
-    expect(V1_TO_LEGACY_GRPC).not.toHaveProperty('ListTasks');
+  it('every entry in V1_METHODS_WITHOUT_LEGACY_EQUIVALENT is absent from both V1 -> legacy maps', () => {
+    for (const method of V1_METHODS_WITHOUT_LEGACY_EQUIVALENT) {
+      expect(V1_TO_LEGACY_JSONRPC, `JSON-RPC has unexpected ${method}`).not.toHaveProperty(method);
+      expect(V1_TO_LEGACY_GRPC, `gRPC has unexpected ${method}`).not.toHaveProperty(method);
+    }
   });
 
-  it('v1MethodToLegacyJsonRpc throws for ListTasks', () => {
-    expect(() => v1MethodToLegacyJsonRpc('ListTasks')).toThrow(A2AError);
+  it('v1MethodToLegacyJsonRpc throws unsupportedOperation (-32004) for ListTasks', () => {
+    try {
+      v1MethodToLegacyJsonRpc('ListTasks');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(A2AError);
+      expect((err as A2AError).code).toBe(-32004);
+      expect((err as A2AError).message).toContain('ListTasks');
+      expect((err as A2AError).message).toContain('JSON-RPC');
+    }
+  });
+
+  it('v1MethodToLegacyGrpc throws unsupportedOperation (-32004) for ListTasks', () => {
+    try {
+      v1MethodToLegacyGrpc('ListTasks');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(A2AError);
+      expect((err as A2AError).code).toBe(-32004);
+      expect((err as A2AError).message).toContain('ListTasks');
+      expect((err as A2AError).message).toContain('gRPC');
+    }
   });
 });
 
@@ -154,6 +180,26 @@ describe('compat/v0_3/constants - helper error behaviour', () => {
   it('legacyGrpcToLegacyJsonRpcMethod throws A2AError(invalidRequest) on unknown input', () => {
     try {
       legacyGrpcToLegacyJsonRpcMethod('NopeNope');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(A2AError);
+      expect((err as A2AError).code).toBe(-32600);
+    }
+  });
+
+  it('v1MethodToLegacyGrpc throws A2AError(invalidRequest) on gibberish input', () => {
+    try {
+      v1MethodToLegacyGrpc('NotARealMethodAtAll');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(A2AError);
+      expect((err as A2AError).code).toBe(-32600);
+    }
+  });
+
+  it('legacyGrpcToV1Method throws A2AError(invalidRequest) on unknown input', () => {
+    try {
+      legacyGrpcToV1Method('AlsoFake');
       expect.fail('expected throw');
     } catch (err) {
       expect(err).toBeInstanceOf(A2AError);
@@ -205,6 +251,19 @@ describe('compat/v0_3/constants - divergent-name spot checks', () => {
     );
     expect(legacyGrpcToLegacyJsonRpcMethod('ListTaskPushNotificationConfig')).toBe(
       'tasks/pushNotificationConfig/list'
+    );
+  });
+
+  it('v1 <-> legacy gRPC helpers translate the divergent names', () => {
+    expect(v1MethodToLegacyGrpc('SubscribeToTask')).toBe('TaskSubscription');
+    expect(v1MethodToLegacyGrpc('GetExtendedAgentCard')).toBe('GetAgentCard');
+    expect(v1MethodToLegacyGrpc('ListTaskPushNotificationConfigs')).toBe(
+      'ListTaskPushNotificationConfig'
+    );
+    expect(legacyGrpcToV1Method('TaskSubscription')).toBe('SubscribeToTask');
+    expect(legacyGrpcToV1Method('GetAgentCard')).toBe('GetExtendedAgentCard');
+    expect(legacyGrpcToV1Method('ListTaskPushNotificationConfig')).toBe(
+      'ListTaskPushNotificationConfigs'
     );
   });
 });

--- a/test/compat/v0_3/constants.spec.ts
+++ b/test/compat/v0_3/constants.spec.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import {
+  A2A_LEGACY_PROTOCOL_VERSION,
+  LEGACY_HTTP_EXTENSION_HEADER,
+  LEGACY_JSON_CONTENT_TYPE,
+  LEGACY_METHOD_GET_AUTHENTICATED_EXTENDED_CARD,
+  LEGACY_METHOD_MESSAGE_SEND,
+  LEGACY_METHOD_MESSAGE_STREAM,
+  LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_DELETE,
+  LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_GET,
+  LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_LIST,
+  LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_SET,
+  LEGACY_METHOD_TASKS_CANCEL,
+  LEGACY_METHOD_TASKS_GET,
+  LEGACY_METHOD_TASKS_RESUBSCRIBE,
+  LEGACY_GRPC_TO_LEGACY_JSONRPC,
+  LEGACY_GRPC_TO_V1,
+  LEGACY_JSONRPC_TO_LEGACY_GRPC,
+  LEGACY_JSONRPC_TO_V1,
+  V1_TO_LEGACY_GRPC,
+  V1_TO_LEGACY_JSONRPC,
+  legacyGrpcToLegacyJsonRpcMethod,
+  legacyJsonRpcToLegacyGrpcMethod,
+  legacyJsonRpcToV1Method,
+  v1MethodToLegacyJsonRpc,
+} from '../../../src/compat/v0_3/constants.js';
+import { A2AError } from '../../../src/compat/v0_3/server/error.js';
+
+const ALL_LEGACY_METHODS = [
+  LEGACY_METHOD_MESSAGE_SEND,
+  LEGACY_METHOD_MESSAGE_STREAM,
+  LEGACY_METHOD_TASKS_GET,
+  LEGACY_METHOD_TASKS_CANCEL,
+  LEGACY_METHOD_TASKS_RESUBSCRIBE,
+  LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_SET,
+  LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_GET,
+  LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_LIST,
+  LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_DELETE,
+  LEGACY_METHOD_GET_AUTHENTICATED_EXTENDED_CARD,
+];
+
+describe('compat/v0_3/constants - protocol/transport constants', () => {
+  it('exposes the correct legacy protocol version', () => {
+    expect(A2A_LEGACY_PROTOCOL_VERSION).toBe('0.3');
+  });
+
+  it('exposes the X-prefixed legacy extension header', () => {
+    expect(LEGACY_HTTP_EXTENSION_HEADER).toBe('X-A2A-Extensions');
+  });
+
+  it('exposes the legacy plain JSON content type', () => {
+    expect(LEGACY_JSON_CONTENT_TYPE).toBe('application/json');
+  });
+});
+
+describe('compat/v0_3/constants - mapping completeness', () => {
+  it('LEGACY_JSONRPC_TO_V1 contains every named legacy method', () => {
+    for (const method of ALL_LEGACY_METHODS) {
+      expect(LEGACY_JSONRPC_TO_V1, `missing ${method}`).toHaveProperty(method);
+    }
+    expect(Object.keys(LEGACY_JSONRPC_TO_V1)).toHaveLength(ALL_LEGACY_METHODS.length);
+  });
+
+  it('LEGACY_JSONRPC_TO_LEGACY_GRPC contains every named legacy method', () => {
+    for (const method of ALL_LEGACY_METHODS) {
+      expect(LEGACY_JSONRPC_TO_LEGACY_GRPC, `missing ${method}`).toHaveProperty(method);
+    }
+    expect(Object.keys(LEGACY_JSONRPC_TO_LEGACY_GRPC)).toHaveLength(ALL_LEGACY_METHODS.length);
+  });
+});
+
+describe('compat/v0_3/constants - round-trip invariants', () => {
+  it('LEGACY_JSONRPC_TO_V1 <-> V1_TO_LEGACY_JSONRPC is bijective', () => {
+    for (const [legacy, v1] of Object.entries(LEGACY_JSONRPC_TO_V1)) {
+      expect(V1_TO_LEGACY_JSONRPC[v1]).toBe(legacy);
+    }
+    for (const [v1, legacy] of Object.entries(V1_TO_LEGACY_JSONRPC)) {
+      expect(LEGACY_JSONRPC_TO_V1[legacy]).toBe(v1);
+    }
+  });
+
+  it('LEGACY_JSONRPC_TO_LEGACY_GRPC <-> LEGACY_GRPC_TO_LEGACY_JSONRPC is bijective', () => {
+    for (const [jsonRpc, grpc] of Object.entries(LEGACY_JSONRPC_TO_LEGACY_GRPC)) {
+      expect(LEGACY_GRPC_TO_LEGACY_JSONRPC[grpc]).toBe(jsonRpc);
+    }
+    for (const [grpc, jsonRpc] of Object.entries(LEGACY_GRPC_TO_LEGACY_JSONRPC)) {
+      expect(LEGACY_JSONRPC_TO_LEGACY_GRPC[jsonRpc]).toBe(grpc);
+    }
+  });
+
+  it('LEGACY_GRPC_TO_V1 <-> V1_TO_LEGACY_GRPC is bijective', () => {
+    for (const [legacyGrpc, v1] of Object.entries(LEGACY_GRPC_TO_V1)) {
+      expect(V1_TO_LEGACY_GRPC[v1]).toBe(legacyGrpc);
+    }
+    for (const [v1, legacyGrpc] of Object.entries(V1_TO_LEGACY_GRPC)) {
+      expect(LEGACY_GRPC_TO_V1[legacyGrpc]).toBe(v1);
+    }
+  });
+
+  it('legacy gRPC -> v1 is the composition of legacy gRPC -> legacy JSON-RPC -> v1', () => {
+    for (const [legacyGrpc, v1] of Object.entries(LEGACY_GRPC_TO_V1)) {
+      const viaJsonRpc = LEGACY_JSONRPC_TO_V1[LEGACY_GRPC_TO_LEGACY_JSONRPC[legacyGrpc]];
+      expect(viaJsonRpc).toBe(v1);
+    }
+  });
+});
+
+describe('compat/v0_3/constants - asymmetric v1.0 methods', () => {
+  it('V1_TO_LEGACY_JSONRPC has no entry for ListTasks (no v0.3 equivalent)', () => {
+    expect(V1_TO_LEGACY_JSONRPC).not.toHaveProperty('ListTasks');
+  });
+
+  it('V1_TO_LEGACY_GRPC has no entry for ListTasks', () => {
+    expect(V1_TO_LEGACY_GRPC).not.toHaveProperty('ListTasks');
+  });
+
+  it('v1MethodToLegacyJsonRpc throws for ListTasks', () => {
+    expect(() => v1MethodToLegacyJsonRpc('ListTasks')).toThrow(A2AError);
+  });
+});
+
+describe('compat/v0_3/constants - helper error behaviour', () => {
+  it('legacyJsonRpcToV1Method throws A2AError(invalidRequest) on unknown input', () => {
+    try {
+      legacyJsonRpcToV1Method('does/not/exist');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(A2AError);
+      expect((err as A2AError).code).toBe(-32600);
+      expect((err as A2AError).message).toContain('does/not/exist');
+    }
+  });
+
+  it('v1MethodToLegacyJsonRpc throws A2AError(invalidRequest) on unknown input', () => {
+    try {
+      v1MethodToLegacyJsonRpc('NotAMethod');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(A2AError);
+      expect((err as A2AError).code).toBe(-32600);
+    }
+  });
+
+  it('legacyJsonRpcToLegacyGrpcMethod throws A2AError(invalidRequest) on unknown input', () => {
+    try {
+      legacyJsonRpcToLegacyGrpcMethod('still/nope');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(A2AError);
+      expect((err as A2AError).code).toBe(-32600);
+    }
+  });
+
+  it('legacyGrpcToLegacyJsonRpcMethod throws A2AError(invalidRequest) on unknown input', () => {
+    try {
+      legacyGrpcToLegacyJsonRpcMethod('NopeNope');
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(A2AError);
+      expect((err as A2AError).code).toBe(-32600);
+    }
+  });
+});
+
+describe('compat/v0_3/constants - divergent-name spot checks', () => {
+  it('tasks/resubscribe maps to v1.0 SubscribeToTask but legacy gRPC TaskSubscription', () => {
+    expect(legacyJsonRpcToV1Method('tasks/resubscribe')).toBe('SubscribeToTask');
+    expect(legacyJsonRpcToLegacyGrpcMethod('tasks/resubscribe')).toBe('TaskSubscription');
+  });
+
+  it('agent/getAuthenticatedExtendedCard maps to v1.0 GetExtendedAgentCard but legacy gRPC GetAgentCard', () => {
+    expect(legacyJsonRpcToV1Method('agent/getAuthenticatedExtendedCard')).toBe(
+      'GetExtendedAgentCard'
+    );
+    expect(legacyJsonRpcToLegacyGrpcMethod('agent/getAuthenticatedExtendedCard')).toBe(
+      'GetAgentCard'
+    );
+  });
+
+  it('tasks/pushNotificationConfig/list maps to v1.0 plural and legacy gRPC singular', () => {
+    expect(legacyJsonRpcToV1Method('tasks/pushNotificationConfig/list')).toBe(
+      'ListTaskPushNotificationConfigs'
+    );
+    expect(legacyJsonRpcToLegacyGrpcMethod('tasks/pushNotificationConfig/list')).toBe(
+      'ListTaskPushNotificationConfig'
+    );
+  });
+
+  it('message/send is identical across all three coordinate systems', () => {
+    expect(legacyJsonRpcToV1Method('message/send')).toBe('SendMessage');
+    expect(legacyJsonRpcToLegacyGrpcMethod('message/send')).toBe('SendMessage');
+  });
+
+  it('inverse helpers recover the legacy JSON-RPC names for the divergent methods', () => {
+    expect(v1MethodToLegacyJsonRpc('SubscribeToTask')).toBe('tasks/resubscribe');
+    expect(v1MethodToLegacyJsonRpc('GetExtendedAgentCard')).toBe(
+      'agent/getAuthenticatedExtendedCard'
+    );
+    expect(v1MethodToLegacyJsonRpc('ListTaskPushNotificationConfigs')).toBe(
+      'tasks/pushNotificationConfig/list'
+    );
+    expect(legacyGrpcToLegacyJsonRpcMethod('TaskSubscription')).toBe('tasks/resubscribe');
+    expect(legacyGrpcToLegacyJsonRpcMethod('GetAgentCard')).toBe(
+      'agent/getAuthenticatedExtendedCard'
+    );
+    expect(legacyGrpcToLegacyJsonRpcMethod('ListTaskPushNotificationConfig')).toBe(
+      'tasks/pushNotificationConfig/list'
+    );
+  });
+});


### PR DESCRIPTION
# Description

Defined compat layer specific constants (eg `LEGACY_HTTP_EXTENSION_HEADER`).
Created mappings between v0.3 and v1.0 method names and helper methods for translating them.

Closes #472  🦕
