### PR TITLE
fix(server): prevent ResultManager from leaking mutable Task references.

### DIFF
--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -177,7 +177,10 @@ export class DefaultRequestHandler implements A2ARequestHandler {
           if (event.kind === 'message') {
             firstResult = event;
           } else {
-            firstResult = resultManager.getCurrentTask();
+            // Defense-in-depth: hand the caller a snapshot, not a live reference
+            // to ResultManager's internal state.
+            const current = resultManager.getCurrentTask();
+            firstResult = current ? structuredClone(current) : undefined;
           }
           if (firstResult) {
             options.firstResultResolver(firstResult);

--- a/src/server/result_manager.ts
+++ b/src/server/result_manager.ts
@@ -32,7 +32,9 @@ export class ResultManager {
       // The ExecutionEventQueue will stop after a message event.
     } else if (event.kind === 'task') {
       const taskEvent = event as Task;
-      this.currentTask = { ...taskEvent }; // Make a copy
+      // Deep clone so that subsequent copy-on-write updates never alias the
+      // caller's event object (including its history/artifacts arrays).
+      this.currentTask = structuredClone(taskEvent);
 
       // Ensure the latest user message is in history if not already present
       if (this.latestUserMessage) {
@@ -47,107 +49,75 @@ export class ResultManager {
       await this.saveCurrentTask();
     } else if (event.kind === 'status-update') {
       const updateEvent = event as TaskStatusUpdateEvent;
+      let base: Task | undefined;
       if (this.currentTask && this.currentTask.id === updateEvent.taskId) {
-        this.currentTask.status = updateEvent.status;
-        if (updateEvent.status.message) {
-          // Add message to history if not already present
-          if (
-            !this.currentTask.history?.find(
-              (msg) => msg.messageId === updateEvent.status.message!.messageId
-            )
-          ) {
-            this.currentTask.history = [
-              ...(this.currentTask.history || []),
-              updateEvent.status.message,
-            ];
-          }
-        }
-        await this.saveCurrentTask();
+        base = this.currentTask;
       } else if (!this.currentTask && updateEvent.taskId) {
         // Potentially an update for a task we haven't seen the 'task' event for yet,
         // or we are rehydrating. Attempt to load.
-        const loaded = await this.taskStore.load(updateEvent.taskId, this.serverCallContext);
-        if (loaded) {
-          this.currentTask = loaded;
-          this.currentTask.status = updateEvent.status;
-          if (updateEvent.status.message) {
-            if (
-              !this.currentTask.history?.find(
-                (msg) => msg.messageId === updateEvent.status.message!.messageId
-              )
-            ) {
-              this.currentTask.history = [
-                ...(this.currentTask.history || []),
-                updateEvent.status.message,
-              ];
-            }
-          }
-          await this.saveCurrentTask();
-        } else {
+        base = await this.taskStore.load(updateEvent.taskId, this.serverCallContext);
+        if (base === undefined) {
           console.warn(
             `ResultManager: Received status update for unknown task ${updateEvent.taskId}`
           );
         }
       }
+      if (base !== undefined) {
+        // Copy-on-write: build a new Task so any prior reference handed out
+        // (e.g. via getCurrentTask()) keeps showing its snapshot.
+        const next: Task = { ...base, status: updateEvent.status };
+        if (updateEvent.status.message !== undefined) {
+          const exists = next.history?.some(
+            (msg) => msg.messageId === updateEvent.status.message?.messageId
+          );
+          if (!exists) {
+            next.history = [...(next.history || []), updateEvent.status.message];
+          }
+        }
+        this.currentTask = next;
+        await this.saveCurrentTask();
+      }
       // If it's a final status update, the ExecutionEventQueue will stop.
       // The final result will be the currentTask.
     } else if (event.kind === 'artifact-update') {
       const artifactEvent = event as TaskArtifactUpdateEvent;
+      let base: Task | undefined;
       if (this.currentTask && this.currentTask.id === artifactEvent.taskId) {
-        if (!this.currentTask.artifacts) {
-          this.currentTask.artifacts = [];
-        }
-        const existingArtifactIndex = this.currentTask.artifacts.findIndex(
-          (art) => art.artifactId === artifactEvent.artifact.artifactId
-        );
-        if (existingArtifactIndex !== -1) {
-          if (artifactEvent.append) {
-            // Basic append logic, assuming parts are compatible
-            // More sophisticated merging might be needed for specific part types
-            const existingArtifact = this.currentTask.artifacts[existingArtifactIndex];
-            existingArtifact.parts.push(...artifactEvent.artifact.parts);
-            if (artifactEvent.artifact.description)
-              existingArtifact.description = artifactEvent.artifact.description;
-            if (artifactEvent.artifact.name) existingArtifact.name = artifactEvent.artifact.name;
-            if (artifactEvent.artifact.metadata)
-              existingArtifact.metadata = {
-                ...existingArtifact.metadata,
-                ...artifactEvent.artifact.metadata,
-              };
-          } else {
-            this.currentTask.artifacts[existingArtifactIndex] = artifactEvent.artifact;
-          }
-        } else {
-          this.currentTask.artifacts.push(artifactEvent.artifact);
-        }
-        await this.saveCurrentTask();
+        base = this.currentTask;
       } else if (!this.currentTask && artifactEvent.taskId) {
-        // Similar to status update, try to load if task not in memory
-        const loaded = await this.taskStore.load(artifactEvent.taskId, this.serverCallContext);
-        if (loaded) {
-          this.currentTask = loaded;
-          if (!this.currentTask.artifacts) this.currentTask.artifacts = [];
-          // Apply artifact update logic (as above)
-          const existingArtifactIndex = this.currentTask.artifacts.findIndex(
-            (art) => art.artifactId === artifactEvent.artifact.artifactId
-          );
-          if (existingArtifactIndex !== -1) {
-            if (artifactEvent.append) {
-              this.currentTask.artifacts[existingArtifactIndex].parts.push(
-                ...artifactEvent.artifact.parts
-              );
-            } else {
-              this.currentTask.artifacts[existingArtifactIndex] = artifactEvent.artifact;
-            }
-          } else {
-            this.currentTask.artifacts.push(artifactEvent.artifact);
-          }
-          await this.saveCurrentTask();
-        } else {
+        // No task in memory — try to rehydrate from the store.
+        base = await this.taskStore.load(artifactEvent.taskId, this.serverCallContext);
+        if (base === undefined) {
           console.warn(
             `ResultManager: Received artifact update for unknown task ${artifactEvent.taskId}`
           );
         }
+      }
+      if (base !== undefined) {
+        // Copy-on-write: rebuild the artifacts array so any prior reference
+        // handed out (e.g. via getCurrentTask()) keeps showing its snapshot.
+        const artifacts = [...(base.artifacts || [])];
+        const idx = artifacts.findIndex(
+          (art) => art.artifactId === artifactEvent.artifact.artifactId
+        );
+        if (idx === -1) {
+          artifacts.push(artifactEvent.artifact);
+        } else if (artifactEvent.append) {
+          const existing = artifacts[idx];
+          artifacts[idx] = {
+            ...existing,
+            parts: [...existing.parts, ...artifactEvent.artifact.parts],
+            description: artifactEvent.artifact.description ?? existing.description,
+            name: artifactEvent.artifact.name ?? existing.name,
+            metadata: artifactEvent.artifact.metadata
+              ? { ...existing.metadata, ...artifactEvent.artifact.metadata }
+              : existing.metadata,
+          };
+        } else {
+          artifacts[idx] = artifactEvent.artifact;
+        }
+        this.currentTask = { ...base, artifacts };
+        await this.saveCurrentTask();
       }
     }
   }

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -292,6 +292,67 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     assert.equal(saveSpy.mock.calls[1][0].status.state, 'completed');
   });
 
+  it('sendMessage: (non-blocking) returned task reference must remain a snapshot when later events arrive', async () => {
+    vi.useFakeTimers();
+
+    const params: MessageSendParams = {
+      message: createTestMessage('msg-412', 'Do work'),
+      configuration: { blocking: false, acceptedOutputModes: [] },
+    };
+
+    const taskId = 'task-412';
+    const contextId = 'ctx-412';
+
+    (mockAgentExecutor as MockAgentExecutor).execute.mockImplementation(async (_ctx, bus) => {
+      bus.publish({
+        id: taskId,
+        contextId,
+        status: { state: 'submitted' },
+        kind: 'task',
+      });
+
+      await vi.advanceTimersByTimeAsync(500);
+
+      bus.publish({
+        taskId,
+        contextId,
+        kind: 'status-update',
+        status: {
+          state: 'failed',
+          message: {
+            kind: 'message',
+            role: 'agent',
+            messageId: 'agent-fail-msg',
+            parts: [{ kind: 'text', text: 'Internal Server Error' }],
+            taskId,
+            contextId,
+          },
+        },
+        final: true,
+      });
+      bus.finished();
+    });
+
+    const immediateResult = await handler.sendMessage(params, serverCallContext);
+    if ('id' in immediateResult && 'status' in immediateResult) {
+      assert.equal(
+        immediateResult.status.state,
+        'submitted',
+        "Should hand off in 'submitted' state"
+      );
+      // Let the background event loop drain the second event.
+      await vi.runAllTimersAsync();
+      // The caller's reference must still represent the handoff snapshot.
+      assert.equal(
+        immediateResult.status.state,
+        'submitted',
+        'Reference handed to the response layer must not be mutated by later events'
+      );
+    } else {
+      throw new Error('immediateResult is of Message type.');
+    }
+  });
+
   it('sendMessage: (non-blocking) should handle failure in event loop after successfull task event', async () => {
     vi.useFakeTimers();
 

--- a/test/server/result_manager.spec.ts
+++ b/test/server/result_manager.spec.ts
@@ -1,0 +1,104 @@
+import { describe, beforeEach, it, expect } from 'vitest';
+import { MockTaskStore } from './mocks/task_store.mock.js';
+import { ResultManager } from '../../src/server/index.js';
+import { Message, Task, TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '../../src/index.js';
+
+describe('ResultManager isolation', () => {
+  let mockTaskStore: MockTaskStore;
+  let resultManager: ResultManager;
+
+  const taskId = 't-1';
+  const contextId = 'c-1';
+
+  beforeEach(() => {
+    mockTaskStore = new MockTaskStore();
+    resultManager = new ResultManager(mockTaskStore);
+  });
+
+  const createBaseTaskEvent = (overrides: Partial<Task> = {}): Task => ({
+    kind: 'task',
+    id: taskId,
+    contextId,
+    status: { state: 'submitted', timestamp: '2026-01-01T00:00:00.000Z' },
+    history: [],
+    artifacts: [],
+    ...overrides,
+  });
+
+  it('snapshot returned by getCurrentTask() is not mutated by a later status-update', async () => {
+    await resultManager.processEvent(createBaseTaskEvent());
+    const snap = resultManager.getCurrentTask();
+    expect(snap.status.state).toBe('submitted');
+
+    const update: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId,
+      contextId,
+      status: { state: 'working', timestamp: '2026-01-01T00:00:01.000Z' },
+      final: false,
+    };
+    await resultManager.processEvent(update);
+
+    expect(snap.status.state).toBe('submitted');
+  });
+
+  it('snapshot returned by getCurrentTask() is not mutated by a later artifact-update', async () => {
+    await resultManager.processEvent(createBaseTaskEvent());
+    const snap = resultManager.getCurrentTask();
+    expect(snap.artifacts).toEqual([]);
+
+    const update: TaskArtifactUpdateEvent = {
+      kind: 'artifact-update',
+      taskId,
+      contextId,
+      artifact: { artifactId: 'a-1', parts: [{ kind: 'text', text: 'hello' }] },
+    };
+    await resultManager.processEvent(update);
+    expect(snap.artifacts).toEqual([]);
+  });
+
+  it('source task event arrays are not mutated by subsequent updates', async () => {
+    const userMessage: Message = {
+      kind: 'message',
+      role: 'user',
+      messageId: 'user-m-1',
+      parts: [{ kind: 'text', text: 'hi' }],
+    };
+    resultManager.setContext(userMessage);
+
+    const history: Message[] = [];
+    const artifacts: Task['artifacts'] = [];
+    const taskEvent = createBaseTaskEvent({ history, artifacts });
+    await resultManager.processEvent(taskEvent);
+
+    const statusUpdate: TaskStatusUpdateEvent = {
+      kind: 'status-update',
+      taskId,
+      contextId,
+      status: {
+        state: 'working',
+        timestamp: '2026-01-01T00:00:01.000Z',
+        message: {
+          kind: 'message',
+          role: 'agent',
+          messageId: 'agent-m-1',
+          parts: [{ kind: 'text', text: 'working' }],
+        },
+      },
+      final: false,
+    };
+    await resultManager.processEvent(statusUpdate);
+
+    const artifactUpdate: TaskArtifactUpdateEvent = {
+      kind: 'artifact-update',
+      taskId,
+      contextId,
+      artifact: { artifactId: 'a-1', parts: [{ kind: 'text', text: 'out' }] },
+    };
+    await resultManager.processEvent(artifactUpdate);
+
+    expect(history).toEqual([]);
+    expect(artifacts).toEqual([]);
+    expect(taskEvent.status.state).toBe('submitted');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #412. `ResultManager` was mutating `this.currentTask` in place on every `status-update` and `artifact-update` event, and storing the task with a shallow copy on the initial `task` event. The non-blocking `sendMessage` path in `DefaultRequestHandler` resolves the HTTP response promise with `resultManager.getCurrentTask()` — a live reference. Subsequent events then mutate the object the HTTP layer is about to serialize, so the client receives the post-execution state (e.g. `failed`) instead of the handoff snapshot (e.g. `submitted`).

This is reference aliasing, not concurrency: the single `for await` consumer of `ExecutionEventQueue` processes events strictly in order. The handed-out reference and the in-flight state machine just happen to be the same object.

## Changes

- **`src/server/result_manager.ts`** — `processEvent` no longer mutates `this.currentTask`:
  - `task` ingest: `{ ...taskEvent }` → `structuredClone(taskEvent)`, so the executor's `history`/`artifacts` arrays are not aliased into ResultManager.
  - `status-update`: builds a new `Task` with the updated status (and, if a message is present, a new `history` array). The previous reference is no longer touched.
  - `artifact-update`: builds a new `artifacts` array; when an existing artifact is being appended to, constructs a fresh artifact object rather than mutating `parts`/`metadata` in place.
  - The in-memory and rehydration branches collapse into one shared copy-on-write code path for each event kind.
- **`src/server/request_handler/default_request_handler.ts`** — `structuredClone` the result of `getCurrentTask()` at the non-blocking response boundary. Defense-in-depth: even if anyone later reintroduces internal aliasing in `ResultManager`, the response handed to the caller is guaranteed to be a snapshot.

## Tests

- New `test/server/result_manager.spec.ts` (3 tests, this class previously had no direct test coverage):
  - A reference captured via `getCurrentTask()` is unaffected by a subsequent `status-update`.
  - A reference captured via `getCurrentTask()` is unaffected by a subsequent `artifact-update`.
  - The caller-owned `history`/`artifacts` arrays passed in on the original `task` event are not mutated by later updates.
- New regression test in `test/server/default_request_handler.spec.ts` mirroring the reproduction in #412: publishes `task(submitted)`, advances timers, publishes `status-update(failed)`, then re-asserts the originally-returned reference still shows `state: 'submitted'`.

All four tests fail on the prior implementation and pass after the fix. Full suite: 413/413 passing.

## Behavior notes for reviewers

- **Publish-then-mutate is no longer observable.** An executor that publishes a `Task` value and then mutates its own copy expecting ResultManager to observe the mutation will no longer see that. This pattern is anti-spec (publish should have value semantics) and I'm treating it as a behavior fix rather than a regression. No tests or sample executors depended on it.
- **`artifact-update` rehydration path is now consistent with the in-memory path.** The pre-existing rehydration branch (when no `currentTask` was in memory and the task was loaded from the store) only handled `parts` on append, silently dropping `description`/`name`/`metadata` merges. The consolidated copy-on-write path applies the same merge logic in both branches.
- **`structuredClone` requirement.** Already satisfied — `package.json` requires Node ≥ 18, and `structuredClone` has been a Node global since 17.

## Test plan

- [x] `npm test` — full suite green (413 tests)
- [x] `npx tsc --noEmit` — no new type errors in changed files (pre-existing errors in `src/samples/` are unrelated to this change)
- [x] `npx eslint` on changed files — clean
- [ ] Manual reviewer check: confirm the regression test at `test/server/default_request_handler.spec.ts` reproduces the issue when reverting the fix locally
