### PR TITLE
chore: add translation units

### DIFF
--- a/src/compat/v0_3/README.md
+++ b/src/compat/v0_3/README.md
@@ -26,14 +26,14 @@ This module contains the native TypeScript Protobuf bindings generated for the l
 
 ## Translation Layer (`translate/`)
 
-The `translate/` subdirectory contains bidirectional payload translators between the modern v1.0 protobuf types (in `src/types/pb/a2a.ts`) and the legacy v0.3 JSON types (in `types/types.ts`).
+The `translate/` subdirectory contains bidirectional payload translators between the modern v1.0 protobuf types (in `src/types/pb/a2a.ts`) and the legacy v0.3 JSON types (in `src/compat/v0_3/types/types.ts`).
 
 The naming convention is direction-anchored:
 
 - `toCore<Entity>` converts a v0.3 value into the equivalent v1.0 proto value.
 - `toCompat<Entity>` converts a v1.0 proto value into the equivalent v0.3 JSON value.
 
-Translators are split per entity group (`parts.ts`, `messages.ts`, `tasks.ts`, `push_notifications.ts`, `security.ts`, `agent_card.ts`, `requests.ts`, `enums.ts`, `versions.ts`) for clarity and tree-shaking. The full surface is re-exported from `translate/index.ts`.
+Translators are split per entity group (`parts.ts`, `messages.ts`, `tasks.ts`, `push_notifications.ts`, `security.ts`, `agent_card.ts`, `requests.ts`, `enums.ts`, `versions.ts`) for clarity and tree-shaking. The full surface is re-exported from `src/compat/v0_3/translate/index.ts`.
 
 Notable policy decisions:
 

--- a/src/compat/v0_3/README.md
+++ b/src/compat/v0_3/README.md
@@ -23,3 +23,22 @@ This file contains dedicated snake_case TypeScript interfaces mirroring the inte
 This module contains the native TypeScript Protobuf bindings generated for the legacy v0.3 gRPC protocol via `ts-proto`.
 
 - **Purpose**: To decode incoming bytes from legacy gRPC clients or encode outbound bytes to legacy gRPC servers.
+
+## Translation Layer (`translate/`)
+
+The `translate/` subdirectory contains bidirectional payload translators between the modern v1.0 protobuf types (in `src/types/pb/a2a.ts`) and the legacy v0.3 JSON types (in `types/types.ts`).
+
+The naming convention is direction-anchored:
+
+- `toCore<Entity>` converts a v0.3 value into the equivalent v1.0 proto value.
+- `toCompat<Entity>` converts a v1.0 proto value into the equivalent v0.3 JSON value.
+
+Translators are split per entity group (`parts.ts`, `messages.ts`, `tasks.ts`, `push_notifications.ts`, `security.ts`, `agent_card.ts`, `requests.ts`, `enums.ts`, `versions.ts`) for clarity and tree-shaking. The full surface is re-exported from `translate/index.ts`.
+
+Notable policy decisions:
+
+- `PushNotificationAuthenticationInfo.schemes` is truncated to a single scheme going v0.3 → v1.0; only the first entry is kept.
+- The v1.0 `OAuthFlows.deviceCode` flow is silently dropped going v1.0 → v0.3 (v0.3 has no equivalent).
+- `TaskStatusUpdateEvent.final` is computed from the status state going v1.0 → v0.3 (`true` for `completed`, `canceled`, `failed`, `rejected`).
+- `SendMessageConfiguration.returnImmediately` ↔ `MessageSendConfiguration.blocking` with inverted polarity.
+- `toCompatAgentCard` filters `supportedInterfaces` to those whose `protocolVersion` is empty or in `[0.3, 1.0)` and throws `VersionNotSupportedError` if none qualify.

--- a/src/compat/v0_3/index.ts
+++ b/src/compat/v0_3/index.ts
@@ -1,7 +1,8 @@
 /**
- * Compat-layer constants and method-name mappings for the legacy A2A v0.3
- * protocol.
+ * Compat-layer constants, method-name mappings, and payload translators
+ * for the legacy A2A v0.3 protocol.
  */
 
 export * from './constants.js';
+export * from './translate/index.js';
 export { A2AError as LegacyA2AError } from './server/error.js';

--- a/src/compat/v0_3/translate/_clone.ts
+++ b/src/compat/v0_3/translate/_clone.ts
@@ -1,0 +1,32 @@
+/**
+ * Internal deep-clone helpers used across the v0.3 translation layer.
+ *
+ * All metadata-like fields on the v1.0 and v0.3 type surfaces are
+ * `{ [k: string]: unknown }` bags that originate from JSON-RPC wire
+ * payloads or proto3 `Struct` values — strict JSON-shaped values that
+ * `structuredClone` handles natively. Deep-cloning is required so the
+ * translated payload does not alias nested objects/arrays back into the
+ * source, which would otherwise let callers mutate each other's state
+ * through shared references.
+ *
+ * Mirrors the de-facto deep-clone convention in `src/server/store.ts`,
+ * which uses `structuredClone` for the same isolation reasons.
+ *
+ * This module is intentionally not re-exported from `translate/index.ts`
+ * — it is implementation detail of the per-entity translators in this
+ * directory.
+ */
+
+/**
+ * Returns a deep, structured clone of a metadata-shaped record, or
+ * `undefined` for an `undefined` input.
+ *
+ * The `undefined` short-circuit means call sites don't pay a
+ * `structuredClone` call on the common "no metadata" path, which keeps
+ * the translation layer's per-request overhead negligible.
+ */
+export function deepCloneMetadata(
+  metadata: { [k: string]: unknown } | undefined
+): { [k: string]: unknown } | undefined {
+  return metadata === undefined ? undefined : structuredClone(metadata);
+}

--- a/src/compat/v0_3/translate/agent_card.ts
+++ b/src/compat/v0_3/translate/agent_card.ts
@@ -1,0 +1,320 @@
+/**
+ * `AgentCard` (and its sub-types) translators between v1.0 proto and v0.3
+ * JSON.
+ *
+ * The most disruptive shape differences:
+ *
+ *  - **Endpoint surface.** v0.3 stores a single primary endpoint
+ *    (`url` + `preferredTransport`) plus an `additionalInterfaces[]`
+ *    sidecar. v1.0 collapses everything into a single
+ *    `supportedInterfaces[]` array where each entry carries its own
+ *    `(url, protocolBinding, tenant, protocolVersion)`.
+ *  - **Protocol version placement.** v0.3 stores `protocolVersion` once at
+ *    the card level. v1.0 stores it per-interface, so multiple versions
+ *    can be advertised side-by-side.
+ *  - **Extended-card flag.** v0.3 has a card-level
+ *    `supportsAuthenticatedExtendedCard`; v1.0 folds the same flag into
+ *    `capabilities.extendedAgentCard`.
+ *  - **`stateTransitionHistory`.** Only v0.3 has this capability flag; the
+ *    v1.0 → v0.3 direction always leaves it `undefined`.
+ *  - **AgentSkill security shape.** v0.3 uses `security?: { [k]: string[]
+ *    }[]`; v1.0 uses `securityRequirements: SecurityRequirement[]` with
+ *    `StringList` wrappers.
+ *
+ * Going v1.0 → v0.3 we filter `supportedInterfaces` to those whose
+ * `protocolVersion` is empty or falls inside `[0.3, 1.0)` (via
+ * `isLegacyVersion`) and throw `VersionNotSupportedError` if no interface
+ * remains.
+ */
+
+import { VersionNotSupportedError } from '../../../errors.js';
+import { PROTOCOL_VERSION_0_3, isLegacyVersion } from './versions.js';
+import {
+  toCompatSecurityRequirement,
+  toCompatSecurityScheme,
+  toCoreSecurityRequirement,
+  toCoreSecurityScheme,
+} from './security.js';
+import type {
+  AgentCapabilities as V1AgentCapabilities,
+  AgentCard as V1AgentCard,
+  AgentCardSignature as V1AgentCardSignature,
+  AgentExtension as V1AgentExtension,
+  AgentInterface as V1AgentInterface,
+  AgentProvider as V1AgentProvider,
+  AgentSkill as V1AgentSkill,
+} from '../../../types/pb/a2a.js';
+import type * as legacy from '../types/types.js';
+
+/** Default transport advertised when the v0.3 card omits `preferredTransport`. */
+const DEFAULT_PREFERRED_TRANSPORT = 'JSONRPC';
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value !== undefined && value !== '' ? value : undefined;
+}
+
+function cloneMetadata(
+  metadata: { [k: string]: unknown } | undefined
+): { [k: string]: unknown } | undefined {
+  if (metadata === undefined) return undefined;
+  return { ...metadata };
+}
+
+/** v0.3 `AgentInterface` → v1.0 proto `AgentInterface`. */
+export function toCoreAgentInterface(compat: legacy.AgentInterface): V1AgentInterface {
+  return {
+    url: compat.url,
+    protocolBinding: compat.transport,
+    tenant: '',
+    protocolVersion: PROTOCOL_VERSION_0_3,
+  };
+}
+
+/** v1.0 proto `AgentInterface` → v0.3 `AgentInterface`. */
+export function toCompatAgentInterface(core: V1AgentInterface): legacy.AgentInterface {
+  return { url: core.url, transport: core.protocolBinding };
+}
+
+/** v0.3 `AgentProvider` → v1.0 proto `AgentProvider`. */
+export function toCoreAgentProvider(compat: legacy.AgentProvider): V1AgentProvider {
+  return { url: compat.url, organization: compat.organization };
+}
+
+/** v1.0 proto `AgentProvider` → v0.3 `AgentProvider`. */
+export function toCompatAgentProvider(core: V1AgentProvider): legacy.AgentProvider {
+  return { url: core.url, organization: core.organization };
+}
+
+/** v0.3 `AgentExtension` → v1.0 proto `AgentExtension`. */
+export function toCoreAgentExtension(compat: legacy.AgentExtension): V1AgentExtension {
+  return {
+    uri: compat.uri,
+    description: compat.description ?? '',
+    required: compat.required ?? false,
+    params: cloneMetadata(compat.params),
+  };
+}
+
+/** v1.0 proto `AgentExtension` → v0.3 `AgentExtension`. */
+export function toCompatAgentExtension(core: V1AgentExtension): legacy.AgentExtension {
+  const result: legacy.AgentExtension = { uri: core.uri };
+  const description = nonEmpty(core.description);
+  if (description !== undefined) result.description = description;
+  // Always emit `required` so the v0.3 consumer sees the agent's explicit
+  // declaration (even when it's the default `false`).
+  result.required = core.required;
+  const params = cloneMetadata(core.params);
+  if (params !== undefined) result.params = params;
+  return result;
+}
+
+/** v0.3 `AgentCapabilities` → v1.0 proto `AgentCapabilities`. */
+export function toCoreAgentCapabilities(
+  compat: legacy.AgentCapabilities | legacy.AgentCapabilities1
+): V1AgentCapabilities {
+  return {
+    streaming: compat.streaming,
+    pushNotifications: compat.pushNotifications,
+    extensions: compat.extensions ? compat.extensions.map(toCoreAgentExtension) : [],
+    // `extendedAgentCard` is set later by `toCoreAgentCard` based on the
+    // card-level `supportsAuthenticatedExtendedCard` flag.
+    extendedAgentCard: undefined,
+  };
+}
+
+/**
+ * v1.0 proto `AgentCapabilities` → v0.3 `AgentCapabilities`.
+ *
+ * `stateTransitionHistory` has no v1.0 equivalent and is left `undefined`.
+ * `extendedAgentCard` is intentionally NOT propagated here: it is
+ * surfaced on the card level by `toCompatAgentCard`.
+ */
+export function toCompatAgentCapabilities(core: V1AgentCapabilities): legacy.AgentCapabilities1 {
+  const result: legacy.AgentCapabilities1 = {};
+  if (core.streaming !== undefined) result.streaming = core.streaming;
+  if (core.pushNotifications !== undefined) result.pushNotifications = core.pushNotifications;
+  if (core.extensions.length > 0) {
+    result.extensions = core.extensions.map(toCompatAgentExtension);
+  }
+  return result;
+}
+
+/** v0.3 `AgentSkill` → v1.0 proto `AgentSkill`. */
+export function toCoreAgentSkill(compat: legacy.AgentSkill): V1AgentSkill {
+  return {
+    id: compat.id,
+    name: compat.name,
+    description: compat.description,
+    tags: [...compat.tags],
+    examples: compat.examples ? [...compat.examples] : [],
+    inputModes: compat.inputModes ? [...compat.inputModes] : [],
+    outputModes: compat.outputModes ? [...compat.outputModes] : [],
+    securityRequirements: compat.security ? compat.security.map(toCoreSecurityRequirement) : [],
+  };
+}
+
+/** v1.0 proto `AgentSkill` → v0.3 `AgentSkill`. */
+export function toCompatAgentSkill(core: V1AgentSkill): legacy.AgentSkill {
+  const result: legacy.AgentSkill = {
+    id: core.id,
+    name: core.name,
+    description: core.description,
+    tags: [...core.tags],
+  };
+  if (core.examples.length > 0) result.examples = [...core.examples];
+  if (core.inputModes.length > 0) result.inputModes = [...core.inputModes];
+  if (core.outputModes.length > 0) result.outputModes = [...core.outputModes];
+  if (core.securityRequirements.length > 0) {
+    result.security = core.securityRequirements.map(toCompatSecurityRequirement);
+  }
+  return result;
+}
+
+/** v0.3 `AgentCardSignature` → v1.0 proto `AgentCardSignature`. */
+export function toCoreAgentCardSignature(compat: legacy.AgentCardSignature): V1AgentCardSignature {
+  return {
+    protected: compat.protected,
+    signature: compat.signature,
+    header: cloneMetadata(compat.header),
+  };
+}
+
+/** v1.0 proto `AgentCardSignature` → v0.3 `AgentCardSignature`. */
+export function toCompatAgentCardSignature(core: V1AgentCardSignature): legacy.AgentCardSignature {
+  const result: legacy.AgentCardSignature = {
+    protected: core.protected,
+    signature: core.signature,
+  };
+  const header = cloneMetadata(core.header);
+  if (header !== undefined) result.header = header;
+  return result;
+}
+
+/**
+ * Converts a v0.3 JSON `AgentCard` into a v1.0 proto `AgentCard`.
+ *
+ * The card-level `(url, preferredTransport, protocolVersion)` becomes
+ * the first entry in `supportedInterfaces`; `additionalInterfaces` are
+ * appended afterwards. `supportsAuthenticatedExtendedCard` is folded into
+ * `capabilities.extendedAgentCard`.
+ */
+export function toCoreAgentCard(compat: legacy.AgentCard): V1AgentCard {
+  const primary: V1AgentInterface = {
+    url: compat.url,
+    protocolBinding: compat.preferredTransport ?? DEFAULT_PREFERRED_TRANSPORT,
+    tenant: '',
+    protocolVersion: compat.protocolVersion || PROTOCOL_VERSION_0_3,
+  };
+  const additional = compat.additionalInterfaces?.map(toCoreAgentInterface) ?? [];
+  const supportedInterfaces = [primary, ...additional];
+
+  const capabilities = toCoreAgentCapabilities(compat.capabilities);
+  if (compat.supportsAuthenticatedExtendedCard !== undefined) {
+    capabilities.extendedAgentCard = compat.supportsAuthenticatedExtendedCard;
+  }
+
+  const result: V1AgentCard = {
+    name: compat.name,
+    description: compat.description,
+    supportedInterfaces,
+    provider: compat.provider ? toCoreAgentProvider(compat.provider) : undefined,
+    version: compat.version,
+    capabilities,
+    securitySchemes: compat.securitySchemes
+      ? Object.fromEntries(
+          Object.entries(compat.securitySchemes).map(([key, scheme]) => [
+            key,
+            toCoreSecurityScheme(scheme),
+          ])
+        )
+      : {},
+    securityRequirements: compat.security ? compat.security.map(toCoreSecurityRequirement) : [],
+    defaultInputModes: [...compat.defaultInputModes],
+    defaultOutputModes: [...compat.defaultOutputModes],
+    skills: compat.skills.map(toCoreAgentSkill),
+    signatures: compat.signatures ? compat.signatures.map(toCoreAgentCardSignature) : [],
+  };
+
+  if (compat.documentationUrl !== undefined) result.documentationUrl = compat.documentationUrl;
+  if (compat.iconUrl !== undefined) result.iconUrl = compat.iconUrl;
+
+  return result;
+}
+
+/**
+ * Converts a v1.0 proto `AgentCard` into a v0.3 JSON `AgentCard`.
+ *
+ * Filters `supportedInterfaces` to those whose `protocolVersion` is
+ * empty or in `[0.3, 1.0)`; the first surviving entry becomes the v0.3
+ * primary `(url, preferredTransport)`, and the rest become
+ * `additionalInterfaces`. Throws `VersionNotSupportedError` if no
+ * interface qualifies.
+ *
+ * `capabilities.extendedAgentCard` is pulled back out to the card-level
+ * `supportsAuthenticatedExtendedCard` field.
+ */
+export function toCompatAgentCard(core: V1AgentCard): legacy.AgentCard {
+  const compatInterfaces = core.supportedInterfaces.filter(
+    (intf) => !intf.protocolVersion || isLegacyVersion(intf.protocolVersion)
+  );
+  if (compatInterfaces.length === 0) {
+    throw new VersionNotSupportedError(
+      'AgentCard must have at least one interface with a protocol version in [0.3, 1.0).'
+    );
+  }
+
+  const primary = compatInterfaces[0]!;
+  const additionalInterfaces = compatInterfaces.slice(1).map(toCompatAgentInterface);
+
+  const capabilities = core.capabilities
+    ? toCompatAgentCapabilities(core.capabilities)
+    : ({} as legacy.AgentCapabilities1);
+  const supportsExtendedCard =
+    core.capabilities && core.capabilities.extendedAgentCard !== undefined
+      ? core.capabilities.extendedAgentCard
+      : undefined;
+
+  const securitySchemes =
+    Object.keys(core.securitySchemes).length > 0
+      ? Object.fromEntries(
+          Object.entries(core.securitySchemes).map(([key, scheme]) => [
+            key,
+            toCompatSecurityScheme(scheme),
+          ])
+        )
+      : undefined;
+
+  const result: legacy.AgentCard = {
+    name: core.name,
+    description: core.description,
+    version: core.version,
+    url: primary.url,
+    preferredTransport: primary.protocolBinding,
+    protocolVersion: primary.protocolVersion || PROTOCOL_VERSION_0_3,
+    capabilities,
+    defaultInputModes: [...core.defaultInputModes],
+    defaultOutputModes: [...core.defaultOutputModes],
+    skills: core.skills.map(toCompatAgentSkill),
+  };
+
+  if (additionalInterfaces.length > 0) {
+    result.additionalInterfaces = additionalInterfaces;
+  }
+  if (core.provider) result.provider = toCompatAgentProvider(core.provider);
+  if (core.documentationUrl !== undefined && core.documentationUrl !== '') {
+    result.documentationUrl = core.documentationUrl;
+  }
+  if (core.iconUrl !== undefined && core.iconUrl !== '') result.iconUrl = core.iconUrl;
+  if (supportsExtendedCard !== undefined) {
+    result.supportsAuthenticatedExtendedCard = supportsExtendedCard;
+  }
+  if (securitySchemes !== undefined) result.securitySchemes = securitySchemes;
+  if (core.securityRequirements.length > 0) {
+    result.security = core.securityRequirements.map(toCompatSecurityRequirement);
+  }
+  if (core.signatures.length > 0) {
+    result.signatures = core.signatures.map(toCompatAgentCardSignature);
+  }
+
+  return result;
+}

--- a/src/compat/v0_3/translate/agent_card.ts
+++ b/src/compat/v0_3/translate/agent_card.ts
@@ -45,19 +45,13 @@ import type {
   AgentSkill as V1AgentSkill,
 } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
+import { deepCloneMetadata } from './_clone.js';
 
 /** Default transport advertised when the v0.3 card omits `preferredTransport`. */
 const DEFAULT_PREFERRED_TRANSPORT = 'JSONRPC';
 
 function nonEmpty(value: string | undefined): string | undefined {
   return value !== undefined && value !== '' ? value : undefined;
-}
-
-function cloneMetadata(
-  metadata: { [k: string]: unknown } | undefined
-): { [k: string]: unknown } | undefined {
-  if (metadata === undefined) return undefined;
-  return { ...metadata };
 }
 
 /** v0.3 `AgentInterface` → v1.0 proto `AgentInterface`. */
@@ -91,7 +85,7 @@ export function toCoreAgentExtension(compat: legacy.AgentExtension): V1AgentExte
     uri: compat.uri,
     description: compat.description ?? '',
     required: compat.required ?? false,
-    params: cloneMetadata(compat.params),
+    params: deepCloneMetadata(compat.params),
   };
 }
 
@@ -103,7 +97,7 @@ export function toCompatAgentExtension(core: V1AgentExtension): legacy.AgentExte
   // Always emit `required` so the v0.3 consumer sees the agent's explicit
   // declaration (even when it's the default `false`).
   result.required = core.required;
-  const params = cloneMetadata(core.params);
+  const params = deepCloneMetadata(core.params);
   if (params !== undefined) result.params = params;
   return result;
 }
@@ -175,7 +169,7 @@ export function toCoreAgentCardSignature(compat: legacy.AgentCardSignature): V1A
   return {
     protected: compat.protected,
     signature: compat.signature,
-    header: cloneMetadata(compat.header),
+    header: deepCloneMetadata(compat.header),
   };
 }
 
@@ -185,7 +179,7 @@ export function toCompatAgentCardSignature(core: V1AgentCardSignature): legacy.A
     protected: core.protected,
     signature: core.signature,
   };
-  const header = cloneMetadata(core.header);
+  const header = deepCloneMetadata(core.header);
   if (header !== undefined) result.header = header;
   return result;
 }

--- a/src/compat/v0_3/translate/artifacts.ts
+++ b/src/compat/v0_3/translate/artifacts.ts
@@ -1,0 +1,72 @@
+/**
+ * `Artifact` translator between v1.0 proto and v0.3 JSON.
+ *
+ * The wire-level differences handled here:
+ *
+ *  - **Optional fields.** v0.3 omits optional fields (and empty arrays) when
+ *    they equal their default values. v1.0 proto3 initializes all optional
+ *    fields to empty strings / empty arrays, so we must explicitly prune them
+ *    on the v0.3 output side to match expected shapes.
+ *  - **Extension layout.** v1.0 `AgentArtifact.extensions` is a `repeated
+ *    google.protobuf.Any` — since `google.protobuf.Any` is JSON-mapped to a
+ *    `{}` object in many environments, we explicitly copy the repeated
+ *    field to a v0.3-style `string[]` to avoid creating an array of empty
+ *    objects where `string[]` is expected.
+ */
+
+import { toCompatPart, toCorePart } from './parts.js';
+import type { Artifact as V1Artifact } from '../../../types/pb/a2a.js';
+import type * as legacy from '../types/types.js';
+import { deepCloneMetadata } from './_clone.js';
+
+function nonEmptyString(value: string): string | undefined {
+  return value === '' ? undefined : value;
+}
+
+function nonEmptyArray<T>(value: T[]): T[] | undefined {
+  return value.length === 0 ? undefined : [...value];
+}
+
+/**
+ * Converts a v0.3 JSON `Artifact` into a v1.0 proto `Artifact`.
+ *
+ * Optional string fields collapse to the proto3 empty-string default;
+ * optional arrays collapse to empty arrays.
+ */
+export function toCoreArtifact(compatArtifact: legacy.Artifact): V1Artifact {
+  return {
+    artifactId: compatArtifact.artifactId,
+    name: compatArtifact.name ?? '',
+    description: compatArtifact.description ?? '',
+    parts: compatArtifact.parts.map(toCorePart),
+    metadata: deepCloneMetadata(compatArtifact.metadata),
+    extensions: compatArtifact.extensions ? [...compatArtifact.extensions] : [],
+  };
+}
+
+/**
+ * Converts a v1.0 proto `Artifact` into a v0.3 JSON `Artifact`.
+ *
+ * Empty proto3 strings and arrays are pruned to keep v0.3 JSON payloads
+ * minimal and round-trip-stable.
+ */
+export function toCompatArtifact(coreArtifact: V1Artifact): legacy.Artifact {
+  const result: legacy.Artifact = {
+    artifactId: coreArtifact.artifactId,
+    parts: coreArtifact.parts.map(toCompatPart),
+  };
+
+  const name = nonEmptyString(coreArtifact.name);
+  if (name !== undefined) result.name = name;
+
+  const description = nonEmptyString(coreArtifact.description);
+  if (description !== undefined) result.description = description;
+
+  const metadata = deepCloneMetadata(coreArtifact.metadata);
+  if (metadata !== undefined) result.metadata = metadata;
+
+  const extensions = nonEmptyArray(coreArtifact.extensions);
+  if (extensions !== undefined) result.extensions = extensions;
+
+  return result;
+}

--- a/src/compat/v0_3/translate/enums.ts
+++ b/src/compat/v0_3/translate/enums.ts
@@ -9,24 +9,23 @@ import type { TaskStatus as LegacyTaskStatus } from '../types/types.js';
  * The v0.3 JSON `TaskStatus.state` string-literal union, kept around as a
  * narrowed alias so call sites don't have to spell it out repeatedly.
  */
-export type LegacyTaskState = LegacyTaskStatus['state'];
+type LegacyTaskState = LegacyTaskStatus['state'];
 
 /** v0.3 JSON `TaskState` literal → v1.0 proto `TaskState` enum. */
-export const TASK_STATE_COMPAT_TO_CORE: Readonly<Record<LegacyTaskState, V1TaskState>> =
-  Object.freeze({
-    unknown: V1TaskState.TASK_STATE_UNSPECIFIED,
-    submitted: V1TaskState.TASK_STATE_SUBMITTED,
-    working: V1TaskState.TASK_STATE_WORKING,
-    completed: V1TaskState.TASK_STATE_COMPLETED,
-    failed: V1TaskState.TASK_STATE_FAILED,
-    canceled: V1TaskState.TASK_STATE_CANCELED,
-    'input-required': V1TaskState.TASK_STATE_INPUT_REQUIRED,
-    rejected: V1TaskState.TASK_STATE_REJECTED,
-    'auth-required': V1TaskState.TASK_STATE_AUTH_REQUIRED,
-  });
+const TASK_STATE_COMPAT_TO_CORE: Readonly<Record<LegacyTaskState, V1TaskState>> = Object.freeze({
+  unknown: V1TaskState.TASK_STATE_UNSPECIFIED,
+  submitted: V1TaskState.TASK_STATE_SUBMITTED,
+  working: V1TaskState.TASK_STATE_WORKING,
+  completed: V1TaskState.TASK_STATE_COMPLETED,
+  failed: V1TaskState.TASK_STATE_FAILED,
+  canceled: V1TaskState.TASK_STATE_CANCELED,
+  'input-required': V1TaskState.TASK_STATE_INPUT_REQUIRED,
+  rejected: V1TaskState.TASK_STATE_REJECTED,
+  'auth-required': V1TaskState.TASK_STATE_AUTH_REQUIRED,
+});
 
 /** v1.0 proto `TaskState` enum → v0.3 JSON `TaskState` literal. */
-export const TASK_STATE_CORE_TO_COMPAT: ReadonlyMap<V1TaskState, LegacyTaskState> = new Map(
+const TASK_STATE_CORE_TO_COMPAT: ReadonlyMap<V1TaskState, LegacyTaskState> = new Map(
   (Object.entries(TASK_STATE_COMPAT_TO_CORE) as [LegacyTaskState, V1TaskState][]).map(
     ([literal, enumValue]) => [enumValue, literal]
   )

--- a/src/compat/v0_3/translate/enums.ts
+++ b/src/compat/v0_3/translate/enums.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared enum translators for v1.0 ↔ v0.3 conversions.
+ */
+
+import { Role as V1Role, TaskState as V1TaskState } from '../../../types/pb/a2a.js';
+import type { TaskStatus as LegacyTaskStatus } from '../types/types.js';
+
+/**
+ * The v0.3 JSON `TaskStatus.state` string-literal union, kept around as a
+ * narrowed alias so call sites don't have to spell it out repeatedly.
+ */
+export type LegacyTaskState = LegacyTaskStatus['state'];
+
+/** v0.3 JSON `TaskState` literal → v1.0 proto `TaskState` enum. */
+export const TASK_STATE_COMPAT_TO_CORE: Readonly<Record<LegacyTaskState, V1TaskState>> =
+  Object.freeze({
+    unknown: V1TaskState.TASK_STATE_UNSPECIFIED,
+    submitted: V1TaskState.TASK_STATE_SUBMITTED,
+    working: V1TaskState.TASK_STATE_WORKING,
+    completed: V1TaskState.TASK_STATE_COMPLETED,
+    failed: V1TaskState.TASK_STATE_FAILED,
+    canceled: V1TaskState.TASK_STATE_CANCELED,
+    'input-required': V1TaskState.TASK_STATE_INPUT_REQUIRED,
+    rejected: V1TaskState.TASK_STATE_REJECTED,
+    'auth-required': V1TaskState.TASK_STATE_AUTH_REQUIRED,
+  });
+
+/** v1.0 proto `TaskState` enum → v0.3 JSON `TaskState` literal. */
+export const TASK_STATE_CORE_TO_COMPAT: ReadonlyMap<V1TaskState, LegacyTaskState> = new Map(
+  (Object.entries(TASK_STATE_COMPAT_TO_CORE) as [LegacyTaskState, V1TaskState][]).map(
+    ([literal, enumValue]) => [enumValue, literal]
+  )
+);
+
+/**
+ * Translates a v0.3 JSON `TaskState` string literal to its v1.0 proto enum
+ * value. Falls back to `TASK_STATE_UNSPECIFIED` for any unknown literal (the
+ * v0.3 JSON type already enumerates every legal value, so this branch is
+ * effectively defensive).
+ */
+export function toCoreTaskState(state: LegacyTaskState): V1TaskState {
+  return TASK_STATE_COMPAT_TO_CORE[state] ?? V1TaskState.TASK_STATE_UNSPECIFIED;
+}
+
+/**
+ * Translates a v1.0 proto `TaskState` enum value to its v0.3 JSON string
+ * literal. Unmapped values (including `UNRECOGNIZED`) become `'unknown'`.
+ */
+export function toCompatTaskState(state: V1TaskState): LegacyTaskState {
+  return TASK_STATE_CORE_TO_COMPAT.get(state) ?? 'unknown';
+}
+
+/**
+ * Translates a v0.3 JSON `role` literal to its v1.0 proto enum value.
+ *
+ * Inputs other than `'user'` or `'agent'` resolve to `ROLE_UNSPECIFIED` to
+ * avoid throwing inside protocol-translation hot paths; callers that care
+ * about unknown roles should validate upstream.
+ */
+export function toCoreRole(role: 'agent' | 'user'): V1Role {
+  if (role === 'user') return V1Role.ROLE_USER;
+  if (role === 'agent') return V1Role.ROLE_AGENT;
+  return V1Role.ROLE_UNSPECIFIED;
+}
+
+/**
+ * Translates a v1.0 proto `Role` enum value to its v0.3 JSON literal.
+ */
+export function toCompatRole(role: V1Role): 'agent' | 'user' {
+  return role === V1Role.ROLE_USER ? 'user' : 'agent';
+}

--- a/src/compat/v0_3/translate/index.ts
+++ b/src/compat/v0_3/translate/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Bidirectional translators between v1.0 proto types and v0.3 JSON types.
+ *
+ * The files are split per entity group (parts, messages, tasks, …) for
+ * easier maintenance and tree-shakeable imports.
+ */
+
+export * from './agent_card.js';
+export * from './enums.js';
+export * from './messages.js';
+export * from './parts.js';
+export * from './push_notifications.js';
+export * from './requests.js';
+export * from './security.js';
+export * from './tasks.js';
+export * from './versions.js';

--- a/src/compat/v0_3/translate/index.ts
+++ b/src/compat/v0_3/translate/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './agent_card.js';
+export * from './artifacts.js';
 export * from './enums.js';
 export * from './messages.js';
 export * from './parts.js';

--- a/src/compat/v0_3/translate/messages.ts
+++ b/src/compat/v0_3/translate/messages.ts
@@ -19,13 +19,7 @@ import { toCompatRole, toCoreRole } from './enums.js';
 import { toCompatPart, toCorePart } from './parts.js';
 import type { Artifact as V1Artifact, Message as V1Message } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
-
-function cloneMetadata(
-  metadata: { [k: string]: unknown } | undefined
-): { [k: string]: unknown } | undefined {
-  if (metadata === undefined) return undefined;
-  return { ...metadata };
-}
+import { deepCloneMetadata } from './_clone.js';
 
 function nonEmptyString(value: string): string | undefined {
   return value === '' ? undefined : value;
@@ -49,7 +43,7 @@ export function toCoreMessage(compatMsg: legacy.Message): V1Message {
     taskId: compatMsg.taskId ?? '',
     role: toCoreRole(compatMsg.role),
     parts: compatMsg.parts.map(toCorePart),
-    metadata: cloneMetadata(compatMsg.metadata),
+    metadata: deepCloneMetadata(compatMsg.metadata),
     extensions: compatMsg.extensions ? [...compatMsg.extensions] : [],
     referenceTaskIds: compatMsg.referenceTaskIds ? [...compatMsg.referenceTaskIds] : [],
   };
@@ -77,7 +71,7 @@ export function toCompatMessage(coreMsg: V1Message): legacy.Message {
   const taskId = nonEmptyString(coreMsg.taskId);
   if (taskId !== undefined) result.taskId = taskId;
 
-  const metadata = cloneMetadata(coreMsg.metadata);
+  const metadata = deepCloneMetadata(coreMsg.metadata);
   if (metadata !== undefined) result.metadata = metadata;
 
   const extensions = nonEmptyArray(coreMsg.extensions);
@@ -101,7 +95,7 @@ export function toCoreArtifact(compatArtifact: legacy.Artifact): V1Artifact {
     name: compatArtifact.name ?? '',
     description: compatArtifact.description ?? '',
     parts: compatArtifact.parts.map(toCorePart),
-    metadata: cloneMetadata(compatArtifact.metadata),
+    metadata: deepCloneMetadata(compatArtifact.metadata),
     extensions: compatArtifact.extensions ? [...compatArtifact.extensions] : [],
   };
 }
@@ -124,7 +118,7 @@ export function toCompatArtifact(coreArtifact: V1Artifact): legacy.Artifact {
   const description = nonEmptyString(coreArtifact.description);
   if (description !== undefined) result.description = description;
 
-  const metadata = cloneMetadata(coreArtifact.metadata);
+  const metadata = deepCloneMetadata(coreArtifact.metadata);
   if (metadata !== undefined) result.metadata = metadata;
 
   const extensions = nonEmptyArray(coreArtifact.extensions);

--- a/src/compat/v0_3/translate/messages.ts
+++ b/src/compat/v0_3/translate/messages.ts
@@ -1,0 +1,134 @@
+/**
+ * `Message` and `Artifact` translators between v1.0 proto and v0.3 JSON.
+ *
+ * The wire-level differences handled here:
+ *
+ *  - v0.3 JSON `Message` carries a `kind: 'message'` discriminator that
+ *    v1.0 proto lacks (proto discriminates via gRPC oneof wrappers).
+ *  - v1.0 proto stores optional IDs (`contextId`, `taskId`) as empty
+ *    strings; v0.3 JSON marks them genuinely optional. Translation must
+ *    coerce `""` ↔ `undefined`.
+ *  - v0.3 `Message.role` is a string literal `'agent' | 'user'`; v1.0
+ *    uses the numeric `Role` enum.
+ *  - `referenceTaskIds`, `extensions`, and `metadata` follow the
+ *    proto3 "always-present array, possibly empty" vs JSON "omit when
+ *    absent" idiom.
+ */
+
+import { toCompatRole, toCoreRole } from './enums.js';
+import { toCompatPart, toCorePart } from './parts.js';
+import type { Artifact as V1Artifact, Message as V1Message } from '../../../types/pb/a2a.js';
+import type * as legacy from '../types/types.js';
+
+function cloneMetadata(
+  metadata: { [k: string]: unknown } | undefined
+): { [k: string]: unknown } | undefined {
+  if (metadata === undefined) return undefined;
+  return { ...metadata };
+}
+
+function nonEmptyString(value: string): string | undefined {
+  return value === '' ? undefined : value;
+}
+
+function nonEmptyArray<T>(value: T[]): T[] | undefined {
+  return value.length === 0 ? undefined : [...value];
+}
+
+/**
+ * Converts a v0.3 JSON `Message` into a v1.0 proto `Message`.
+ *
+ * Optional string fields collapse `undefined` to `''` (proto3 convention).
+ * Optional arrays collapse `undefined` to `[]`. The v0.3 `kind` discriminator
+ * is intentionally dropped — v1.0 has no equivalent field.
+ */
+export function toCoreMessage(compatMsg: legacy.Message): V1Message {
+  return {
+    messageId: compatMsg.messageId,
+    contextId: compatMsg.contextId ?? '',
+    taskId: compatMsg.taskId ?? '',
+    role: toCoreRole(compatMsg.role),
+    parts: compatMsg.parts.map(toCorePart),
+    metadata: cloneMetadata(compatMsg.metadata),
+    extensions: compatMsg.extensions ? [...compatMsg.extensions] : [],
+    referenceTaskIds: compatMsg.referenceTaskIds ? [...compatMsg.referenceTaskIds] : [],
+  };
+}
+
+/**
+ * Converts a v1.0 proto `Message` into a v0.3 JSON `Message`.
+ *
+ * Empty proto3 strings become `undefined` (JSON-optional). Empty arrays are
+ * dropped entirely. The `kind: 'message'` discriminator is added so the
+ * result can participate in the `Task | Message | …` tagged-union responses
+ * v0.3 JSON-RPC sends back to clients.
+ */
+export function toCompatMessage(coreMsg: V1Message): legacy.Message {
+  const result: legacy.Message = {
+    kind: 'message',
+    messageId: coreMsg.messageId,
+    role: toCompatRole(coreMsg.role),
+    parts: coreMsg.parts.map(toCompatPart),
+  };
+
+  const contextId = nonEmptyString(coreMsg.contextId);
+  if (contextId !== undefined) result.contextId = contextId;
+
+  const taskId = nonEmptyString(coreMsg.taskId);
+  if (taskId !== undefined) result.taskId = taskId;
+
+  const metadata = cloneMetadata(coreMsg.metadata);
+  if (metadata !== undefined) result.metadata = metadata;
+
+  const extensions = nonEmptyArray(coreMsg.extensions);
+  if (extensions !== undefined) result.extensions = extensions;
+
+  const referenceTaskIds = nonEmptyArray(coreMsg.referenceTaskIds);
+  if (referenceTaskIds !== undefined) result.referenceTaskIds = referenceTaskIds;
+
+  return result;
+}
+
+/**
+ * Converts a v0.3 JSON `Artifact` into a v1.0 proto `Artifact`.
+ *
+ * Optional string fields collapse to the proto3 empty-string default;
+ * optional arrays collapse to empty arrays.
+ */
+export function toCoreArtifact(compatArtifact: legacy.Artifact): V1Artifact {
+  return {
+    artifactId: compatArtifact.artifactId,
+    name: compatArtifact.name ?? '',
+    description: compatArtifact.description ?? '',
+    parts: compatArtifact.parts.map(toCorePart),
+    metadata: cloneMetadata(compatArtifact.metadata),
+    extensions: compatArtifact.extensions ? [...compatArtifact.extensions] : [],
+  };
+}
+
+/**
+ * Converts a v1.0 proto `Artifact` into a v0.3 JSON `Artifact`.
+ *
+ * Empty proto3 strings and arrays are pruned to keep v0.3 JSON payloads
+ * minimal and round-trip-stable.
+ */
+export function toCompatArtifact(coreArtifact: V1Artifact): legacy.Artifact {
+  const result: legacy.Artifact = {
+    artifactId: coreArtifact.artifactId,
+    parts: coreArtifact.parts.map(toCompatPart),
+  };
+
+  const name = nonEmptyString(coreArtifact.name);
+  if (name !== undefined) result.name = name;
+
+  const description = nonEmptyString(coreArtifact.description);
+  if (description !== undefined) result.description = description;
+
+  const metadata = cloneMetadata(coreArtifact.metadata);
+  if (metadata !== undefined) result.metadata = metadata;
+
+  const extensions = nonEmptyArray(coreArtifact.extensions);
+  if (extensions !== undefined) result.extensions = extensions;
+
+  return result;
+}

--- a/src/compat/v0_3/translate/messages.ts
+++ b/src/compat/v0_3/translate/messages.ts
@@ -1,5 +1,5 @@
 /**
- * `Message` and `Artifact` translators between v1.0 proto and v0.3 JSON.
+ * `Message` translator between v1.0 proto and v0.3 JSON.
  *
  * The wire-level differences handled here:
  *
@@ -17,7 +17,7 @@
 
 import { toCompatRole, toCoreRole } from './enums.js';
 import { toCompatPart, toCorePart } from './parts.js';
-import type { Artifact as V1Artifact, Message as V1Message } from '../../../types/pb/a2a.js';
+import type { Message as V1Message } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
 import { deepCloneMetadata } from './_clone.js';
 
@@ -79,50 +79,6 @@ export function toCompatMessage(coreMsg: V1Message): legacy.Message {
 
   const referenceTaskIds = nonEmptyArray(coreMsg.referenceTaskIds);
   if (referenceTaskIds !== undefined) result.referenceTaskIds = referenceTaskIds;
-
-  return result;
-}
-
-/**
- * Converts a v0.3 JSON `Artifact` into a v1.0 proto `Artifact`.
- *
- * Optional string fields collapse to the proto3 empty-string default;
- * optional arrays collapse to empty arrays.
- */
-export function toCoreArtifact(compatArtifact: legacy.Artifact): V1Artifact {
-  return {
-    artifactId: compatArtifact.artifactId,
-    name: compatArtifact.name ?? '',
-    description: compatArtifact.description ?? '',
-    parts: compatArtifact.parts.map(toCorePart),
-    metadata: deepCloneMetadata(compatArtifact.metadata),
-    extensions: compatArtifact.extensions ? [...compatArtifact.extensions] : [],
-  };
-}
-
-/**
- * Converts a v1.0 proto `Artifact` into a v0.3 JSON `Artifact`.
- *
- * Empty proto3 strings and arrays are pruned to keep v0.3 JSON payloads
- * minimal and round-trip-stable.
- */
-export function toCompatArtifact(coreArtifact: V1Artifact): legacy.Artifact {
-  const result: legacy.Artifact = {
-    artifactId: coreArtifact.artifactId,
-    parts: coreArtifact.parts.map(toCompatPart),
-  };
-
-  const name = nonEmptyString(coreArtifact.name);
-  if (name !== undefined) result.name = name;
-
-  const description = nonEmptyString(coreArtifact.description);
-  if (description !== undefined) result.description = description;
-
-  const metadata = deepCloneMetadata(coreArtifact.metadata);
-  if (metadata !== undefined) result.metadata = metadata;
-
-  const extensions = nonEmptyArray(coreArtifact.extensions);
-  if (extensions !== undefined) result.extensions = extensions;
 
   return result;
 }

--- a/src/compat/v0_3/translate/parts.ts
+++ b/src/compat/v0_3/translate/parts.ts
@@ -12,14 +12,22 @@
  *    top-level fields on every Part (only meaningful for file parts);
  *    v0.3 puts the equivalents (`name`, `mimeType`) on the inner `file`
  *    object.
+ *
+ * **Data parts.** v1.0 `Part.data` is a `google.protobuf.Value`, so it can
+ * carry primitives, arrays, and `null` in addition to objects. v0.3
+ * `DataPart.data` is typed `{ [k: string]: unknown }` — strictly a JSON
+ * object. v1.0 data parts whose `value` is a primitive, array, or `null`
+ * therefore cannot be represented in v0.3 and throw `A2AError.invalidParams`
+ * during `toCompatPart`. (The Python SDK wraps such values as
+ * `{ value: <primitive> }` with a private `data_part_compat = true`
+ * metadata flag, but that pollutes the v0.3 wire format with an out-of-spec
+ * key; we deliberately diverge from Python here.)
  */
 
 import { A2AError } from '../server/error.js';
 import type * as legacy from '../types/types.js';
 import type { Part as V1Part } from '../../../types/pb/a2a.js';
 import { deepCloneMetadata } from './_clone.js';
-
-const DATA_PART_COMPAT_KEY = 'data_part_compat';
 
 function isPlainObject(value: unknown): value is { [k: string]: unknown } {
   return (
@@ -35,9 +43,9 @@ function isPlainObject(value: unknown): value is { [k: string]: unknown } {
  *   the base64 payload into a `Buffer`); `FileWithUri` → `content.$case:
  *   'url'`. The optional `mimeType` / `name` are lifted to the top-level
  *   `mediaType` / `filename` fields.
- * - Data parts honor the `data_part_compat` flag convention: when this flag
- *   is present on the part's metadata, the original (non-object) value is
- *   unwrapped from `data.value` before being attached to the v1.0 part.
+ * - Data parts pass `data` through unchanged (v0.3 schema guarantees
+ *   `data` is a plain object, which is always valid for the v1.0
+ *   `google.protobuf.Value` target).
  */
 export function toCorePart(compatPart: legacy.Part): V1Part {
   if (compatPart.kind === 'text') {
@@ -75,20 +83,9 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
   }
 
   if (compatPart.kind === 'data') {
-    const metadata = deepCloneMetadata(compatPart.metadata);
-    const dataPartCompat = metadata?.[DATA_PART_COMPAT_KEY] === true;
-    let strippedMetadata: { [k: string]: unknown } | undefined = metadata;
-    if (metadata && DATA_PART_COMPAT_KEY in metadata) {
-      const { [DATA_PART_COMPAT_KEY]: _stripped, ...rest } = metadata;
-      // Avoid leaking the flag back out as proto metadata.
-      void _stripped;
-      strippedMetadata = Object.keys(rest).length === 0 ? undefined : rest;
-    }
-
-    const value = dataPartCompat ? compatPart.data.value : compatPart.data;
     return {
-      content: { $case: 'data', value },
-      metadata: strippedMetadata,
+      content: { $case: 'data', value: compatPart.data },
+      metadata: deepCloneMetadata(compatPart.metadata),
       filename: '',
       mediaType: '',
     };
@@ -107,10 +104,13 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
  *   encoding the `Buffer`); `content.$case: 'url'` ↔ `kind: 'file'` with
  *   `FileWithUri`. `filename` / `mediaType` are pushed down into the
  *   inner file's `name` / `mimeType`.
- * - `content.$case: 'data'`: when the v1.0 value is a plain object it's
- *   used directly; otherwise it's wrapped as `{ value }` and the
- *   `data_part_compat` flag is set on the part's metadata so the inverse
- *   conversion can recover the original value.
+ * - `content.$case: 'data'`: when the v1.0 value is a plain object it is
+ *   used directly. Throws `A2AError.invalidParams` when the value is a
+ *   primitive, array, or `null` — those are not representable in v0.3's
+ *   `DataPart.data: { [k: string]: unknown }` schema.
+ *
+ * @throws {A2AError} when `content` is missing, has an unknown `$case`,
+ * or carries a non-object `data` value.
  */
 export function toCompatPart(corePart: V1Part): legacy.Part {
   const content = corePart.content;
@@ -153,23 +153,15 @@ export function toCompatPart(corePart: V1Part): legacy.Part {
 
   if (content.$case === 'data') {
     const value: unknown = content.value;
-    if (isPlainObject(value)) {
-      const result: legacy.DataPart = { kind: 'data', data: value };
-      if (metadata !== undefined) result.metadata = metadata;
-      return result;
+    if (!isPlainObject(value)) {
+      throw A2AError.invalidParams(
+        'Cannot translate v1 data part to v0.3: value is not a plain object. ' +
+          'v0.3 DataPart.data requires { [k: string]: unknown }; primitives, arrays, and null are not representable.'
+      );
     }
-
-    // Non-object values are wrapped so the v0.3 `data: { [k]: unknown }`
-    // type accepts them; mark this in metadata so `toCorePart` can unwrap.
-    const wrappedMetadata: { [k: string]: unknown } = {
-      ...(metadata ?? {}),
-      [DATA_PART_COMPAT_KEY]: true,
-    };
-    return {
-      kind: 'data',
-      data: { value },
-      metadata: wrappedMetadata,
-    };
+    const result: legacy.DataPart = { kind: 'data', data: value };
+    if (metadata !== undefined) result.metadata = metadata;
+    return result;
   }
 
   throw A2AError.invalidParams(

--- a/src/compat/v0_3/translate/parts.ts
+++ b/src/compat/v0_3/translate/parts.ts
@@ -17,15 +17,9 @@
 import { A2AError } from '../server/error.js';
 import type * as legacy from '../types/types.js';
 import type { Part as V1Part } from '../../../types/pb/a2a.js';
+import { deepCloneMetadata } from './_clone.js';
 
 const DATA_PART_COMPAT_KEY = 'data_part_compat';
-
-function cloneMetadata(
-  metadata: { [k: string]: unknown } | undefined
-): { [k: string]: unknown } | undefined {
-  if (metadata === undefined) return undefined;
-  return { ...metadata };
-}
 
 function isPlainObject(value: unknown): value is { [k: string]: unknown } {
   return (
@@ -49,7 +43,7 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
   if (compatPart.kind === 'text') {
     return {
       content: { $case: 'text', value: compatPart.text },
-      metadata: cloneMetadata(compatPart.metadata),
+      metadata: deepCloneMetadata(compatPart.metadata),
       filename: '',
       mediaType: '',
     };
@@ -59,7 +53,7 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
     const file = compatPart.file;
     const mediaType = file.mimeType ?? '';
     const filename = file.name ?? '';
-    const metadata = cloneMetadata(compatPart.metadata);
+    const metadata = deepCloneMetadata(compatPart.metadata);
 
     if ('bytes' in file) {
       return {
@@ -81,7 +75,7 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
   }
 
   if (compatPart.kind === 'data') {
-    const metadata = cloneMetadata(compatPart.metadata);
+    const metadata = deepCloneMetadata(compatPart.metadata);
     const dataPartCompat = metadata?.[DATA_PART_COMPAT_KEY] === true;
     let strippedMetadata: { [k: string]: unknown } | undefined = metadata;
     if (metadata && DATA_PART_COMPAT_KEY in metadata) {
@@ -120,7 +114,7 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
  */
 export function toCompatPart(corePart: V1Part): legacy.Part {
   const content = corePart.content;
-  const metadata = cloneMetadata(corePart.metadata);
+  const metadata = deepCloneMetadata(corePart.metadata);
 
   if (!content) {
     throw A2AError.invalidParams('Invalid v1.0 part: missing content');

--- a/src/compat/v0_3/translate/parts.ts
+++ b/src/compat/v0_3/translate/parts.ts
@@ -1,0 +1,184 @@
+/**
+ * `Part` translators between v1.0 proto and v0.3 JSON.
+ *
+ * The two formats differ in two structural ways:
+ *
+ *  - **Outer discriminator.** v1.0 uses `part.content.$case` with the four
+ *    cases `'text' | 'raw' | 'url' | 'data'`; v0.3 JSON uses `part.kind`
+ *    with the three cases `'text' | 'file' | 'data'` and nests the
+ *    file-bytes-vs-uri choice under `part.file` (`FileWithBytes |
+ *    FileWithUri`).
+ *  - **File metadata.** v1.0 carries `filename` and `mediaType` as
+ *    top-level fields on every Part (only meaningful for file parts);
+ *    v0.3 puts the equivalents (`name`, `mimeType`) on the inner `file`
+ *    object.
+ */
+
+import { A2AError } from '../server/error.js';
+import type * as legacy from '../types/types.js';
+import type { Part as V1Part } from '../../../types/pb/a2a.js';
+
+const DATA_PART_COMPAT_KEY = 'data_part_compat';
+
+function cloneMetadata(
+  metadata: { [k: string]: unknown } | undefined
+): { [k: string]: unknown } | undefined {
+  if (metadata === undefined) return undefined;
+  return { ...metadata };
+}
+
+function isPlainObject(value: unknown): value is { [k: string]: unknown } {
+  return (
+    typeof value === 'object' && value !== null && !Array.isArray(value) && !Buffer.isBuffer(value)
+  );
+}
+
+/**
+ * Converts a v0.3 JSON `Part` into a v1.0 proto `Part`.
+ *
+ * - Text parts map directly onto `content.$case: 'text'`.
+ * - File parts split: `FileWithBytes` → `content.$case: 'raw'` (decoding
+ *   the base64 payload into a `Buffer`); `FileWithUri` → `content.$case:
+ *   'url'`. The optional `mimeType` / `name` are lifted to the top-level
+ *   `mediaType` / `filename` fields.
+ * - Data parts honor the `data_part_compat` flag convention: when this flag
+ *   is present on the part's metadata, the original (non-object) value is
+ *   unwrapped from `data.value` before being attached to the v1.0 part.
+ */
+export function toCorePart(compatPart: legacy.Part): V1Part {
+  if (compatPart.kind === 'text') {
+    return {
+      content: { $case: 'text', value: compatPart.text },
+      metadata: cloneMetadata(compatPart.metadata),
+      filename: '',
+      mediaType: '',
+    };
+  }
+
+  if (compatPart.kind === 'file') {
+    const file = compatPart.file;
+    const mediaType = file.mimeType ?? '';
+    const filename = file.name ?? '';
+    const metadata = cloneMetadata(compatPart.metadata);
+
+    if ('bytes' in file) {
+      return {
+        content: { $case: 'raw', value: Buffer.from(file.bytes, 'base64') },
+        metadata,
+        filename,
+        mediaType,
+      };
+    }
+    if ('uri' in file) {
+      return {
+        content: { $case: 'url', value: file.uri },
+        metadata,
+        filename,
+        mediaType,
+      };
+    }
+    throw A2AError.invalidParams('Invalid file part: missing `bytes` or `uri`');
+  }
+
+  if (compatPart.kind === 'data') {
+    const metadata = cloneMetadata(compatPart.metadata);
+    const dataPartCompat = metadata?.[DATA_PART_COMPAT_KEY] === true;
+    let strippedMetadata: { [k: string]: unknown } | undefined = metadata;
+    if (metadata && DATA_PART_COMPAT_KEY in metadata) {
+      const { [DATA_PART_COMPAT_KEY]: _stripped, ...rest } = metadata;
+      // Avoid leaking the flag back out as proto metadata.
+      void _stripped;
+      strippedMetadata = Object.keys(rest).length === 0 ? undefined : rest;
+    }
+
+    const value = dataPartCompat ? compatPart.data.value : compatPart.data;
+    return {
+      content: { $case: 'data', value },
+      metadata: strippedMetadata,
+      filename: '',
+      mediaType: '',
+    };
+  }
+
+  throw A2AError.invalidParams(
+    `Invalid v0.3 part kind: ${(compatPart as { kind?: string }).kind ?? 'undefined'}`
+  );
+}
+
+/**
+ * Converts a v1.0 proto `Part` into a v0.3 JSON `Part`.
+ *
+ * - `content.$case: 'text'` ↔ `kind: 'text'`.
+ * - `content.$case: 'raw'` ↔ `kind: 'file'` with `FileWithBytes` (base64
+ *   encoding the `Buffer`); `content.$case: 'url'` ↔ `kind: 'file'` with
+ *   `FileWithUri`. `filename` / `mediaType` are pushed down into the
+ *   inner file's `name` / `mimeType`.
+ * - `content.$case: 'data'`: when the v1.0 value is a plain object it's
+ *   used directly; otherwise it's wrapped as `{ value }` and the
+ *   `data_part_compat` flag is set on the part's metadata so the inverse
+ *   conversion can recover the original value.
+ */
+export function toCompatPart(corePart: V1Part): legacy.Part {
+  const content = corePart.content;
+  const metadata = cloneMetadata(corePart.metadata);
+
+  if (!content) {
+    throw A2AError.invalidParams('Invalid v1.0 part: missing content');
+  }
+
+  if (content.$case === 'text') {
+    const result: legacy.TextPart = { kind: 'text', text: content.value };
+    if (metadata !== undefined) result.metadata = metadata;
+    return result;
+  }
+
+  if (content.$case === 'raw' || content.$case === 'url') {
+    const mimeType = corePart.mediaType !== '' ? corePart.mediaType : undefined;
+    const name = corePart.filename !== '' ? corePart.filename : undefined;
+
+    let file: legacy.FileWithBytes | legacy.FileWithUri;
+    if (content.$case === 'raw') {
+      const bytesBuffer = Buffer.isBuffer(content.value)
+        ? content.value
+        : Buffer.from(content.value as Uint8Array);
+      const fileWithBytes: legacy.FileWithBytes = { bytes: bytesBuffer.toString('base64') };
+      if (mimeType !== undefined) fileWithBytes.mimeType = mimeType;
+      if (name !== undefined) fileWithBytes.name = name;
+      file = fileWithBytes;
+    } else {
+      const fileWithUri: legacy.FileWithUri = { uri: content.value };
+      if (mimeType !== undefined) fileWithUri.mimeType = mimeType;
+      if (name !== undefined) fileWithUri.name = name;
+      file = fileWithUri;
+    }
+
+    const result: legacy.FilePart = { kind: 'file', file };
+    if (metadata !== undefined) result.metadata = metadata;
+    return result;
+  }
+
+  if (content.$case === 'data') {
+    const value: unknown = content.value;
+    if (isPlainObject(value)) {
+      const result: legacy.DataPart = { kind: 'data', data: value };
+      if (metadata !== undefined) result.metadata = metadata;
+      return result;
+    }
+
+    // Non-object values are wrapped so the v0.3 `data: { [k]: unknown }`
+    // type accepts them; mark this in metadata so `toCorePart` can unwrap.
+    const wrappedMetadata: { [k: string]: unknown } = {
+      ...(metadata ?? {}),
+      [DATA_PART_COMPAT_KEY]: true,
+    };
+    return {
+      kind: 'data',
+      data: { value },
+      metadata: wrappedMetadata,
+    };
+  }
+
+  throw A2AError.invalidParams(
+    `Invalid v1.0 part content type: ${(content as { $case?: string }).$case ?? 'unknown'}`
+  );
+}

--- a/src/compat/v0_3/translate/push_notifications.ts
+++ b/src/compat/v0_3/translate/push_notifications.ts
@@ -1,0 +1,142 @@
+/**
+ * Push-notification translators between v1.0 proto and v0.3 JSON.
+ *
+ * Two structural differences need bridging:
+ *
+ *  - **Authentication info.** v1.0 `AuthenticationInfo.scheme` is a single
+ *    string (e.g. `'Bearer'`); v0.3
+ *    `PushNotificationAuthenticationInfo.schemes` is a string array. Going
+ *    v0.3 → v1.0 we take the first scheme (lossy when more than one is
+ *    declared) Going v1.0 → v0.3 we wrap
+ *    the single scheme into a one-element array (empty when the v1.0
+ *    `scheme` is empty).
+ *
+ *  - **TaskPushNotificationConfig nesting.** v1.0 flattens
+ *    `(taskId, id, url, token, authentication)` onto a single message;
+ *    v0.3 JSON nests `(id, url, token, authentication)` under
+ *    `pushNotificationConfig` and keeps `taskId` at the outer level.
+ */
+
+import type {
+  AuthenticationInfo as V1AuthenticationInfo,
+  TaskPushNotificationConfig as V1TaskPushNotificationConfig,
+} from '../../../types/pb/a2a.js';
+import type * as legacy from '../types/types.js';
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value !== undefined && value !== '' ? value : undefined;
+}
+
+/**
+ * Converts a v0.3 JSON `PushNotificationAuthenticationInfo` into a v1.0
+ * proto `AuthenticationInfo`.
+ *
+ * **Lossy when `schemes.length > 1`** — only the first scheme is kept.
+ * Callers that need to preserve all declared schemes must do so out-of-band.
+ */
+export function toCoreAuthenticationInfo(
+  compat: legacy.PushNotificationAuthenticationInfo
+): V1AuthenticationInfo {
+  return {
+    scheme: compat.schemes && compat.schemes.length > 0 ? compat.schemes[0]! : '',
+    credentials: compat.credentials ?? '',
+  };
+}
+
+/**
+ * Converts a v1.0 proto `AuthenticationInfo` into a v0.3 JSON
+ * `PushNotificationAuthenticationInfo`.
+ *
+ * The single v1.0 `scheme` is wrapped into a one-element array; an empty
+ * scheme becomes an empty array. Empty credentials collapse to `undefined`.
+ */
+export function toCompatAuthenticationInfo(
+  core: V1AuthenticationInfo
+): legacy.PushNotificationAuthenticationInfo {
+  const result: legacy.PushNotificationAuthenticationInfo = {
+    schemes: core.scheme !== '' ? [core.scheme] : [],
+  };
+  const credentials = nonEmpty(core.credentials);
+  if (credentials !== undefined) result.credentials = credentials;
+  return result;
+}
+
+/**
+ * Converts a v0.3 JSON `PushNotificationConfig` (the inner record) into a
+ * v1.0 proto `TaskPushNotificationConfig` minus its `taskId` (the caller
+ * supplies that when stitching together a full
+ * `TaskPushNotificationConfig`). The result has `taskId` and `tenant` set
+ * to the proto3 empty-string default — typically overridden by
+ * `toCoreTaskPushNotificationConfig`.
+ */
+export function toCorePushNotificationConfig(
+  compat: legacy.PushNotificationConfig | legacy.PushNotificationConfig1
+): V1TaskPushNotificationConfig {
+  return {
+    tenant: '',
+    taskId: '',
+    id: compat.id ?? '',
+    url: compat.url,
+    token: compat.token ?? '',
+    authentication: compat.authentication
+      ? toCoreAuthenticationInfo(compat.authentication)
+      : undefined,
+  };
+}
+
+/**
+ * Converts a v1.0 proto `TaskPushNotificationConfig` into the inner v0.3
+ * JSON `PushNotificationConfig` record (drops the `taskId`, which v0.3
+ * stores at the outer `TaskPushNotificationConfig` level).
+ */
+export function toCompatPushNotificationConfig(
+  core: V1TaskPushNotificationConfig
+): legacy.PushNotificationConfig {
+  const result: legacy.PushNotificationConfig = { url: core.url };
+
+  const id = nonEmpty(core.id);
+  if (id !== undefined) result.id = id;
+
+  const token = nonEmpty(core.token);
+  if (token !== undefined) result.token = token;
+
+  if (core.authentication) {
+    result.authentication = toCompatAuthenticationInfo(core.authentication);
+  }
+
+  return result;
+}
+
+/**
+ * Converts a v0.3 JSON `TaskPushNotificationConfig` (with the nested
+ * `pushNotificationConfig`) into a v1.0 proto flat
+ * `TaskPushNotificationConfig`.
+ */
+export function toCoreTaskPushNotificationConfig(
+  compat: legacy.TaskPushNotificationConfig
+): V1TaskPushNotificationConfig {
+  return {
+    tenant: '',
+    taskId: compat.taskId,
+    id: compat.pushNotificationConfig.id ?? '',
+    url: compat.pushNotificationConfig.url,
+    token: compat.pushNotificationConfig.token ?? '',
+    authentication: compat.pushNotificationConfig.authentication
+      ? toCoreAuthenticationInfo(compat.pushNotificationConfig.authentication)
+      : undefined,
+  };
+}
+
+/**
+ * Converts a v1.0 proto `TaskPushNotificationConfig` into a v0.3 JSON
+ * `TaskPushNotificationConfig` (re-nesting the per-config fields under
+ * `pushNotificationConfig`).
+ */
+export function toCompatTaskPushNotificationConfig(
+  core: V1TaskPushNotificationConfig
+): legacy.TaskPushNotificationConfig {
+  return {
+    taskId: core.taskId,
+    pushNotificationConfig: toCompatPushNotificationConfig(core),
+  };
+}

--- a/src/compat/v0_3/translate/push_notifications.ts
+++ b/src/compat/v0_3/translate/push_notifications.ts
@@ -37,6 +37,11 @@ function nonEmpty(value: string | undefined): string | undefined {
 export function toCoreAuthenticationInfo(
   compat: legacy.PushNotificationAuthenticationInfo
 ): V1AuthenticationInfo {
+  if (compat.schemes && compat.schemes.length > 1) {
+    console.warn(
+      `toCoreAuthenticationInfo: Lossy conversion from v0.3 PushNotificationAuthenticationInfo to v1.0 AuthenticationInfo. Multiple schemes declared (${compat.schemes.join(', ')}), but only the first one ('${compat.schemes[0]}') will be kept.`
+    );
+  }
   return {
     scheme: compat.schemes && compat.schemes.length > 0 ? compat.schemes[0]! : '',
     credentials: compat.credentials ?? '',

--- a/src/compat/v0_3/translate/requests.ts
+++ b/src/compat/v0_3/translate/requests.ts
@@ -76,9 +76,16 @@ export function toCompatSendMessageConfiguration(
   const result: legacy.MessageSendConfiguration = {
     blocking: !core.returnImmediately,
   };
-  if (core.acceptedOutputModes.length > 0) {
-    result.acceptedOutputModes = [...core.acceptedOutputModes];
-  }
+  // Always emit `acceptedOutputModes`, even when empty. v1.0 proto types
+  // it as a required `string[]` (no `undefined` representation), and both
+  // the v1.0 JSON serializer (`SendMessageConfiguration.toJSON`) and gRPC
+  // `encode` treat `[]` and "absent" as wire-identical. Preserving the
+  // empty array here keeps an explicit v0.3 `acceptedOutputModes: []`
+  // round-trip-stable; the only observable cost is that a v0.3 caller
+  // who originally omitted the field will see `[]` on the return path
+  // rather than `undefined`, which carries no semantic change because
+  // the v1.0 layer has already collapsed the distinction.
+  result.acceptedOutputModes = [...core.acceptedOutputModes];
   if (core.historyLength !== undefined) result.historyLength = core.historyLength;
   if (core.taskPushNotificationConfig) {
     result.pushNotificationConfig = toCompatPushNotificationConfig(core.taskPushNotificationConfig);
@@ -185,9 +192,9 @@ export function toCompatSendMessageResponse(
   }
   let result: legacy.Task2 | legacy.Message1;
   if (payload.$case === 'task') {
-    result = toCompatTask(payload.value) as unknown as legacy.Task2;
+    result = toCompatTask(payload.value);
   } else if (payload.$case === 'message') {
-    result = toCompatMessage(payload.value) as unknown as legacy.Message1;
+    result = toCompatMessage(payload.value);
   } else {
     throw A2AError.internalError('SendMessageResponse has unknown payload case');
   }
@@ -197,15 +204,22 @@ export function toCompatSendMessageResponse(
 /* --------------------------------- StreamResponse --------------------------------- */
 
 /**
- * v0.3 `SendStreamingMessageSuccessResponse` → v1.0 proto
- * `StreamResponse`.
+ * v0.3 `SendStreamingMessageResponse` → v1.0 proto `StreamResponse`.
  *
- * The four cases mirror the v1.0 oneof:
+ * The four success cases mirror the v1.0 oneof:
  * `Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent`.
+ *
+ * Throws if the v0.3 response is an error envelope (callers should
+ * surface errors via the v1.0 typed error classes instead).
  */
 export function toCoreStreamResponse(
-  compat: legacy.SendStreamingMessageSuccessResponse
+  compat: legacy.SendStreamingMessageResponse
 ): V1StreamResponse {
+  if ('error' in compat) {
+    throw A2AError.internalError(
+      'Cannot translate a v0.3 error response into a v1.0 StreamResponse'
+    );
+  }
   const result = compat.result;
   switch (result.kind) {
     case 'message':
@@ -241,10 +255,10 @@ export function toCompatStreamResponse(
   let result: legacy.SendStreamingMessageSuccessResponse['result'];
   switch (payload.$case) {
     case 'message':
-      result = toCompatMessage(payload.value) as unknown as legacy.Message1;
+      result = toCompatMessage(payload.value);
       break;
     case 'task':
-      result = toCompatTask(payload.value) as unknown as legacy.Task2;
+      result = toCompatTask(payload.value);
       break;
     case 'statusUpdate':
       result = toCompatTaskStatusUpdateEvent(payload.value);
@@ -430,9 +444,7 @@ export function toCoreListTaskPushNotificationConfigsResponse(
   compat: legacy.ListTaskPushNotificationConfigSuccessResponse
 ): V1ListTaskPushNotificationConfigsResponse {
   return {
-    configs: compat.result.map((entry) =>
-      toCoreTaskPushNotificationConfig(entry as unknown as legacy.TaskPushNotificationConfig)
-    ),
+    configs: compat.result.map((entry) => toCoreTaskPushNotificationConfig(entry)),
     nextPageToken: '',
   };
 }
@@ -445,10 +457,7 @@ export function toCompatListTaskPushNotificationConfigSuccessResponse(
   return {
     id: requestId,
     jsonrpc: '2.0',
-    result: core.configs.map(
-      (cfg) =>
-        toCompatTaskPushNotificationConfig(cfg) as unknown as legacy.TaskPushNotificationConfig3
-    ),
+    result: core.configs.map((cfg) => toCompatTaskPushNotificationConfig(cfg)),
   };
 }
 

--- a/src/compat/v0_3/translate/requests.ts
+++ b/src/compat/v0_3/translate/requests.ts
@@ -1,0 +1,480 @@
+/**
+ * RPC request/response translators between v1.0 proto and v0.3 JSON.
+ *
+ * Each v0.3 JSON-RPC request type wraps its parameters under
+ * `.params`; the v1.0 proto types are flat. These helpers cross that
+ * boundary so transport layers can call into a v1.0 handler with the v1
+ * proto types while presenting/parsing the v0.3 JSON-RPC wire format to
+ * legacy clients.
+ *
+ * **`returnImmediately` ↔ `blocking` polarity inversion.** The v1.0
+ * `SendMessageConfiguration.returnImmediately` field is the logical
+ * inverse of v0.3 `MessageSendConfiguration.blocking`. We translate as
+ * `return_immediately = !blocking` (and back)
+ *
+ * Going v1.0 → v0.3 we need a JSON-RPC `id` to populate the response
+ * envelope; callers supply it explicitly as the `requestId` argument.
+ */
+
+import { A2AError } from '../server/error.js';
+import { toCompatMessage, toCoreMessage } from './messages.js';
+import {
+  toCompatPushNotificationConfig,
+  toCompatTaskPushNotificationConfig,
+  toCorePushNotificationConfig,
+  toCoreTaskPushNotificationConfig,
+} from './push_notifications.js';
+import {
+  toCompatTask,
+  toCompatTaskArtifactUpdateEvent,
+  toCompatTaskStatusUpdateEvent,
+  toCoreTask,
+  toCoreTaskArtifactUpdateEvent,
+  toCoreTaskStatusUpdateEvent,
+} from './tasks.js';
+import type {
+  CancelTaskRequest as V1CancelTaskRequest,
+  DeleteTaskPushNotificationConfigRequest as V1DeleteTaskPushNotificationConfigRequest,
+  GetExtendedAgentCardRequest as V1GetExtendedAgentCardRequest,
+  GetTaskPushNotificationConfigRequest as V1GetTaskPushNotificationConfigRequest,
+  GetTaskRequest as V1GetTaskRequest,
+  ListTaskPushNotificationConfigsRequest as V1ListTaskPushNotificationConfigsRequest,
+  ListTaskPushNotificationConfigsResponse as V1ListTaskPushNotificationConfigsResponse,
+  SendMessageConfiguration as V1SendMessageConfiguration,
+  SendMessageRequest as V1SendMessageRequest,
+  SendMessageResponse as V1SendMessageResponse,
+  StreamResponse as V1StreamResponse,
+  SubscribeToTaskRequest as V1SubscribeToTaskRequest,
+  TaskPushNotificationConfig as V1TaskPushNotificationConfig,
+} from '../../../types/pb/a2a.js';
+import type * as legacy from '../types/types.js';
+
+type RequestId = string | number;
+type ResponseId = string | number | null;
+
+function cloneMetadata(
+  metadata: { [k: string]: unknown } | undefined
+): { [k: string]: unknown } | undefined {
+  if (metadata === undefined) return undefined;
+  return { ...metadata };
+}
+
+/* --------------------------------- SendMessageConfiguration --------------------------------- */
+
+/** v0.3 `MessageSendConfiguration` → v1.0 proto `SendMessageConfiguration`. */
+export function toCoreSendMessageConfiguration(
+  compat: legacy.MessageSendConfiguration
+): V1SendMessageConfiguration {
+  return {
+    acceptedOutputModes: compat.acceptedOutputModes ? [...compat.acceptedOutputModes] : [],
+    taskPushNotificationConfig: compat.pushNotificationConfig
+      ? toCorePushNotificationConfig(compat.pushNotificationConfig)
+      : undefined,
+    historyLength: compat.historyLength,
+    returnImmediately: compat.blocking === undefined ? true : !compat.blocking,
+  };
+}
+
+/** v1.0 proto `SendMessageConfiguration` → v0.3 `MessageSendConfiguration`. */
+export function toCompatSendMessageConfiguration(
+  core: V1SendMessageConfiguration
+): legacy.MessageSendConfiguration {
+  const result: legacy.MessageSendConfiguration = {
+    blocking: !core.returnImmediately,
+  };
+  if (core.acceptedOutputModes.length > 0) {
+    result.acceptedOutputModes = [...core.acceptedOutputModes];
+  }
+  if (core.historyLength !== undefined) result.historyLength = core.historyLength;
+  if (core.taskPushNotificationConfig) {
+    result.pushNotificationConfig = toCompatPushNotificationConfig(core.taskPushNotificationConfig);
+  }
+  return result;
+}
+
+/* --------------------------------- SendMessage --------------------------------- */
+
+/**
+ * v0.3 `SendMessageRequest` (or `SendStreamingMessageRequest`) →
+ * v1.0 proto `SendMessageRequest`.
+ */
+export function toCoreSendMessageRequest(
+  compat: legacy.SendMessageRequest | legacy.SendStreamingMessageRequest
+): V1SendMessageRequest {
+  return {
+    tenant: '',
+    message: toCoreMessage(compat.params.message),
+    configuration: compat.params.configuration
+      ? toCoreSendMessageConfiguration(compat.params.configuration)
+      : undefined,
+    metadata: cloneMetadata(compat.params.metadata),
+  };
+}
+
+/**
+ * v1.0 proto `SendMessageRequest` → v0.3 `SendMessageRequest`.
+ *
+ * The caller supplies the JSON-RPC `id` since the proto carries none.
+ */
+export function toCompatSendMessageRequest(
+  core: V1SendMessageRequest,
+  requestId: RequestId
+): legacy.SendMessageRequest {
+  if (!core.message) {
+    throw A2AError.invalidParams('SendMessageRequest missing message');
+  }
+  const params: legacy.MessageSendParams = {
+    message: toCompatMessage(core.message),
+  };
+  if (core.configuration) {
+    params.configuration = toCompatSendMessageConfiguration(core.configuration);
+  }
+  const metadata = cloneMetadata(core.metadata);
+  if (metadata !== undefined) params.metadata = metadata;
+  return { id: requestId, jsonrpc: '2.0', method: 'message/send', params };
+}
+
+/**
+ * v1.0 proto `SendMessageRequest` → v0.3 `SendStreamingMessageRequest`.
+ *
+ * Identical to `toCompatSendMessageRequest` except the method name is
+ * `message/stream`.
+ */
+export function toCompatSendStreamingMessageRequest(
+  core: V1SendMessageRequest,
+  requestId: RequestId
+): legacy.SendStreamingMessageRequest {
+  const inner = toCompatSendMessageRequest(core, requestId);
+  return { ...inner, method: 'message/stream' };
+}
+
+/* --------------------------------- SendMessageResponse --------------------------------- */
+
+/**
+ * v0.3 `SendMessageResponse` → v1.0 proto `SendMessageResponse`.
+ *
+ * Throws if the v0.3 response is an error envelope (callers should
+ * surface errors via the v1.0 typed error classes instead).
+ */
+export function toCoreSendMessageResponse(
+  compat: legacy.SendMessageResponse
+): V1SendMessageResponse {
+  if ('error' in compat) {
+    throw A2AError.internalError(
+      'Cannot translate a v0.3 error response into a v1.0 SendMessageResponse'
+    );
+  }
+  const result = compat.result;
+  if (result.kind === 'task') {
+    return { payload: { $case: 'task', value: toCoreTask(result) } };
+  }
+  if (result.kind === 'message') {
+    return { payload: { $case: 'message', value: toCoreMessage(result) } };
+  }
+  throw A2AError.invalidParams('Invalid v0.3 SendMessageResponse result');
+}
+
+/**
+ * v1.0 proto `SendMessageResponse` → v0.3 success envelope
+ * `SendMessageSuccessResponse`.
+ *
+ * Errors should be wrapped via the v0.3 JSON-RPC error envelope at the
+ * transport layer rather than here.
+ */
+export function toCompatSendMessageResponse(
+  core: V1SendMessageResponse,
+  requestId: ResponseId = null
+): legacy.SendMessageSuccessResponse {
+  const payload = core.payload;
+  if (!payload) {
+    throw A2AError.internalError('SendMessageResponse missing payload');
+  }
+  let result: legacy.Task2 | legacy.Message1;
+  if (payload.$case === 'task') {
+    result = toCompatTask(payload.value) as unknown as legacy.Task2;
+  } else if (payload.$case === 'message') {
+    result = toCompatMessage(payload.value) as unknown as legacy.Message1;
+  } else {
+    throw A2AError.internalError('SendMessageResponse has unknown payload case');
+  }
+  return { id: requestId, jsonrpc: '2.0', result };
+}
+
+/* --------------------------------- StreamResponse --------------------------------- */
+
+/**
+ * v0.3 `SendStreamingMessageSuccessResponse` → v1.0 proto
+ * `StreamResponse`.
+ *
+ * The four cases mirror the v1.0 oneof:
+ * `Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent`.
+ */
+export function toCoreStreamResponse(
+  compat: legacy.SendStreamingMessageSuccessResponse
+): V1StreamResponse {
+  const result = compat.result;
+  switch (result.kind) {
+    case 'message':
+      return { payload: { $case: 'message', value: toCoreMessage(result) } };
+    case 'task':
+      return { payload: { $case: 'task', value: toCoreTask(result) } };
+    case 'status-update':
+      return {
+        payload: { $case: 'statusUpdate', value: toCoreTaskStatusUpdateEvent(result) },
+      };
+    case 'artifact-update':
+      return {
+        payload: { $case: 'artifactUpdate', value: toCoreTaskArtifactUpdateEvent(result) },
+      };
+    default:
+      throw A2AError.invalidParams(
+        `Unknown v0.3 stream event kind: ${String((result as { kind?: string }).kind)}`
+      );
+  }
+}
+
+/**
+ * v1.0 proto `StreamResponse` → v0.3 `SendStreamingMessageSuccessResponse`.
+ */
+export function toCompatStreamResponse(
+  core: V1StreamResponse,
+  requestId: ResponseId = null
+): legacy.SendStreamingMessageSuccessResponse {
+  const payload = core.payload;
+  if (!payload) {
+    throw A2AError.internalError('StreamResponse missing payload');
+  }
+  let result: legacy.SendStreamingMessageSuccessResponse['result'];
+  switch (payload.$case) {
+    case 'message':
+      result = toCompatMessage(payload.value) as unknown as legacy.Message1;
+      break;
+    case 'task':
+      result = toCompatTask(payload.value) as unknown as legacy.Task2;
+      break;
+    case 'statusUpdate':
+      result = toCompatTaskStatusUpdateEvent(payload.value);
+      break;
+    case 'artifactUpdate':
+      result = toCompatTaskArtifactUpdateEvent(payload.value);
+      break;
+    default:
+      throw A2AError.internalError('StreamResponse has unknown payload case');
+  }
+  return { id: requestId, jsonrpc: '2.0', result };
+}
+
+/* --------------------------------- GetTask --------------------------------- */
+
+/** v0.3 `GetTaskRequest` → v1.0 proto `GetTaskRequest`. */
+export function toCoreGetTaskRequest(compat: legacy.GetTaskRequest): V1GetTaskRequest {
+  return {
+    tenant: '',
+    id: compat.params.id,
+    historyLength: compat.params.historyLength,
+  };
+}
+
+/** v1.0 proto `GetTaskRequest` → v0.3 `GetTaskRequest`. */
+export function toCompatGetTaskRequest(
+  core: V1GetTaskRequest,
+  requestId: RequestId
+): legacy.GetTaskRequest {
+  const params: legacy.TaskQueryParams = { id: core.id };
+  if (core.historyLength !== undefined) params.historyLength = core.historyLength;
+  return { id: requestId, jsonrpc: '2.0', method: 'tasks/get', params };
+}
+
+/* --------------------------------- CancelTask --------------------------------- */
+
+/** v0.3 `CancelTaskRequest` → v1.0 proto `CancelTaskRequest`. */
+export function toCoreCancelTaskRequest(compat: legacy.CancelTaskRequest): V1CancelTaskRequest {
+  return {
+    tenant: '',
+    id: compat.params.id,
+    metadata: cloneMetadata(compat.params.metadata),
+  };
+}
+
+/** v1.0 proto `CancelTaskRequest` → v0.3 `CancelTaskRequest`. */
+export function toCompatCancelTaskRequest(
+  core: V1CancelTaskRequest,
+  requestId: RequestId
+): legacy.CancelTaskRequest {
+  const params: legacy.TaskIdParams = { id: core.id };
+  const metadata = cloneMetadata(core.metadata);
+  if (metadata !== undefined) params.metadata = metadata;
+  return { id: requestId, jsonrpc: '2.0', method: 'tasks/cancel', params };
+}
+
+/* --------------------------------- SubscribeToTask --------------------------------- */
+
+/** v0.3 `TaskResubscriptionRequest` → v1.0 proto `SubscribeToTaskRequest`. */
+export function toCoreSubscribeToTaskRequest(
+  compat: legacy.TaskResubscriptionRequest
+): V1SubscribeToTaskRequest {
+  return { tenant: '', id: compat.params.id };
+}
+
+/** v1.0 proto `SubscribeToTaskRequest` → v0.3 `TaskResubscriptionRequest`. */
+export function toCompatTaskResubscriptionRequest(
+  core: V1SubscribeToTaskRequest,
+  requestId: RequestId
+): legacy.TaskResubscriptionRequest {
+  return {
+    id: requestId,
+    jsonrpc: '2.0',
+    method: 'tasks/resubscribe',
+    params: { id: core.id },
+  };
+}
+
+/* --------------------------------- PushNotificationConfig RPCs --------------------------------- */
+
+/**
+ * v0.3 `SetTaskPushNotificationConfigRequest` → v1.0 proto
+ * `TaskPushNotificationConfig` (used as the request body for
+ * `CreateTaskPushNotificationConfig`).
+ */
+export function toCoreCreateTaskPushNotificationConfigRequest(
+  compat: legacy.SetTaskPushNotificationConfigRequest
+): V1TaskPushNotificationConfig {
+  return toCoreTaskPushNotificationConfig(compat.params);
+}
+
+/**
+ * v1.0 proto `TaskPushNotificationConfig` (create request body) →
+ * v0.3 `SetTaskPushNotificationConfigRequest`.
+ */
+export function toCompatSetTaskPushNotificationConfigRequest(
+  core: V1TaskPushNotificationConfig,
+  requestId: RequestId
+): legacy.SetTaskPushNotificationConfigRequest {
+  return {
+    id: requestId,
+    jsonrpc: '2.0',
+    method: 'tasks/pushNotificationConfig/set',
+    params: toCompatTaskPushNotificationConfig(core),
+  };
+}
+
+/** v0.3 `GetTaskPushNotificationConfigRequest` → v1.0 proto request. */
+export function toCoreGetTaskPushNotificationConfigRequest(
+  compat: legacy.GetTaskPushNotificationConfigRequest
+): V1GetTaskPushNotificationConfigRequest {
+  const params = compat.params;
+  // Both `GetTaskPushNotificationConfigParams` and `TaskIdParams1` carry `id`.
+  // The former additionally carries `pushNotificationConfigId`.
+  const configId =
+    'pushNotificationConfigId' in params ? params.pushNotificationConfigId : undefined;
+  return { tenant: '', taskId: params.id, id: configId ?? '' };
+}
+
+/** v1.0 proto request → v0.3 `GetTaskPushNotificationConfigRequest`. */
+export function toCompatGetTaskPushNotificationConfigRequest(
+  core: V1GetTaskPushNotificationConfigRequest,
+  requestId: RequestId
+): legacy.GetTaskPushNotificationConfigRequest {
+  const params: legacy.GetTaskPushNotificationConfigParams | legacy.TaskIdParams1 =
+    core.id !== '' ? { id: core.taskId, pushNotificationConfigId: core.id } : { id: core.taskId };
+  return {
+    id: requestId,
+    jsonrpc: '2.0',
+    method: 'tasks/pushNotificationConfig/get',
+    params,
+  };
+}
+
+/** v0.3 `DeleteTaskPushNotificationConfigRequest` → v1.0 proto request. */
+export function toCoreDeleteTaskPushNotificationConfigRequest(
+  compat: legacy.DeleteTaskPushNotificationConfigRequest
+): V1DeleteTaskPushNotificationConfigRequest {
+  return {
+    tenant: '',
+    taskId: compat.params.id,
+    id: compat.params.pushNotificationConfigId,
+  };
+}
+
+/** v1.0 proto request → v0.3 `DeleteTaskPushNotificationConfigRequest`. */
+export function toCompatDeleteTaskPushNotificationConfigRequest(
+  core: V1DeleteTaskPushNotificationConfigRequest,
+  requestId: RequestId
+): legacy.DeleteTaskPushNotificationConfigRequest {
+  return {
+    id: requestId,
+    jsonrpc: '2.0',
+    method: 'tasks/pushNotificationConfig/delete',
+    params: { id: core.taskId, pushNotificationConfigId: core.id },
+  };
+}
+
+/** v0.3 `ListTaskPushNotificationConfigRequest` → v1.0 proto request. */
+export function toCoreListTaskPushNotificationConfigsRequest(
+  compat: legacy.ListTaskPushNotificationConfigRequest
+): V1ListTaskPushNotificationConfigsRequest {
+  return { tenant: '', taskId: compat.params.id, pageSize: 0, pageToken: '' };
+}
+
+/** v1.0 proto request → v0.3 `ListTaskPushNotificationConfigRequest`. */
+export function toCompatListTaskPushNotificationConfigRequest(
+  core: V1ListTaskPushNotificationConfigsRequest,
+  requestId: RequestId
+): legacy.ListTaskPushNotificationConfigRequest {
+  return {
+    id: requestId,
+    jsonrpc: '2.0',
+    method: 'tasks/pushNotificationConfig/list',
+    params: { id: core.taskId },
+  };
+}
+
+/* --------------------------------- ListTaskPushNotificationConfigsResponse --------------------------------- */
+
+/** v0.3 list-success response → v1.0 proto `ListTaskPushNotificationConfigsResponse`. */
+export function toCoreListTaskPushNotificationConfigsResponse(
+  compat: legacy.ListTaskPushNotificationConfigSuccessResponse
+): V1ListTaskPushNotificationConfigsResponse {
+  return {
+    configs: compat.result.map((entry) =>
+      toCoreTaskPushNotificationConfig(entry as unknown as legacy.TaskPushNotificationConfig)
+    ),
+    nextPageToken: '',
+  };
+}
+
+/** v1.0 proto `ListTaskPushNotificationConfigsResponse` → v0.3 list-success response. */
+export function toCompatListTaskPushNotificationConfigSuccessResponse(
+  core: V1ListTaskPushNotificationConfigsResponse,
+  requestId: ResponseId = null
+): legacy.ListTaskPushNotificationConfigSuccessResponse {
+  return {
+    id: requestId,
+    jsonrpc: '2.0',
+    result: core.configs.map(
+      (cfg) =>
+        toCompatTaskPushNotificationConfig(cfg) as unknown as legacy.TaskPushNotificationConfig3
+    ),
+  };
+}
+
+/* --------------------------------- GetExtendedAgentCard --------------------------------- */
+
+/** v0.3 `GetAuthenticatedExtendedCardRequest` → v1.0 proto `GetExtendedAgentCardRequest`. */
+export function toCoreGetExtendedAgentCardRequest(
+  _compat: legacy.GetAuthenticatedExtendedCardRequest
+): V1GetExtendedAgentCardRequest {
+  return { tenant: '' };
+}
+
+/** v1.0 proto `GetExtendedAgentCardRequest` → v0.3 `GetAuthenticatedExtendedCardRequest`. */
+export function toCompatGetAuthenticatedExtendedCardRequest(
+  _core: V1GetExtendedAgentCardRequest,
+  requestId: RequestId
+): legacy.GetAuthenticatedExtendedCardRequest {
+  return {
+    id: requestId,
+    jsonrpc: '2.0',
+    method: 'agent/getAuthenticatedExtendedCard',
+  };
+}

--- a/src/compat/v0_3/translate/requests.ts
+++ b/src/compat/v0_3/translate/requests.ts
@@ -48,16 +48,10 @@ import type {
   TaskPushNotificationConfig as V1TaskPushNotificationConfig,
 } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
+import { deepCloneMetadata } from './_clone.js';
 
 type RequestId = string | number;
 type ResponseId = string | number | null;
-
-function cloneMetadata(
-  metadata: { [k: string]: unknown } | undefined
-): { [k: string]: unknown } | undefined {
-  if (metadata === undefined) return undefined;
-  return { ...metadata };
-}
 
 /* --------------------------------- SendMessageConfiguration --------------------------------- */
 
@@ -107,7 +101,7 @@ export function toCoreSendMessageRequest(
     configuration: compat.params.configuration
       ? toCoreSendMessageConfiguration(compat.params.configuration)
       : undefined,
-    metadata: cloneMetadata(compat.params.metadata),
+    metadata: deepCloneMetadata(compat.params.metadata),
   };
 }
 
@@ -129,7 +123,7 @@ export function toCompatSendMessageRequest(
   if (core.configuration) {
     params.configuration = toCompatSendMessageConfiguration(core.configuration);
   }
-  const metadata = cloneMetadata(core.metadata);
+  const metadata = deepCloneMetadata(core.metadata);
   if (metadata !== undefined) params.metadata = metadata;
   return { id: requestId, jsonrpc: '2.0', method: 'message/send', params };
 }
@@ -292,7 +286,7 @@ export function toCoreCancelTaskRequest(compat: legacy.CancelTaskRequest): V1Can
   return {
     tenant: '',
     id: compat.params.id,
-    metadata: cloneMetadata(compat.params.metadata),
+    metadata: deepCloneMetadata(compat.params.metadata),
   };
 }
 
@@ -302,7 +296,7 @@ export function toCompatCancelTaskRequest(
   requestId: RequestId
 ): legacy.CancelTaskRequest {
   const params: legacy.TaskIdParams = { id: core.id };
-  const metadata = cloneMetadata(core.metadata);
+  const metadata = deepCloneMetadata(core.metadata);
   if (metadata !== undefined) params.metadata = metadata;
   return { id: requestId, jsonrpc: '2.0', method: 'tasks/cancel', params };
 }

--- a/src/compat/v0_3/translate/security.ts
+++ b/src/compat/v0_3/translate/security.ts
@@ -138,7 +138,11 @@ function buildCompatApiKey(core: V1APIKeySecurityScheme): legacy.APIKeySecurityS
   const result: legacy.APIKeySecurityScheme = {
     type: 'apiKey',
     name: core.name,
-    in: (core.location as legacy.APIKeySecurityScheme['in']) ?? 'header',
+    // v1 proto widens `location` to a free-form `string`; v0.3 narrows it to a
+    // literal union. Unknown / empty values silently map to `'header'` (the most
+    // common API-key location and the effective OpenAPI default) so a
+    // misconfigured v1 server doesn't break the entire v0.3 translation path.
+    in: core.location === 'cookie' || core.location === 'query' ? core.location : 'header',
   };
   const description = nonEmpty(core.description);
   if (description !== undefined) result.description = description;

--- a/src/compat/v0_3/translate/security.ts
+++ b/src/compat/v0_3/translate/security.ts
@@ -1,0 +1,328 @@
+/**
+ * Security-related translators between v1.0 proto and v0.3 JSON:
+ * `SecurityRequirement`, `SecurityScheme`, and `OAuthFlows`.
+ *
+ * Key shape differences handled here:
+ *
+ *  - **SecurityRequirement.** v1.0 wraps scope lists in a `StringList`
+ *    proto message (`{ schemes: { [k]: { list: string[] } } }`); v0.3
+ *    JSON stores plain `{ [k]: string[] }`.
+ *  - **SecurityScheme discriminator.** v1.0 uses
+ *    `scheme.$case: 'apiKeySecurityScheme' | ...`; v0.3 JSON uses a flat
+ *    `type: 'apiKey' | 'http' | 'oauth2' | 'openIdConnect' | 'mutualTLS'`
+ *    string.
+ *  - **OAuthFlows.** v1.0 expresses the four classic flows plus
+ *    `deviceCode` via a `flow.$case` oneof; v0.3 JSON keeps each flow as
+ *    an optional sibling field. **`deviceCode` is silently dropped going
+ *    v1.0 → v0.3** (v0.3 has no equivalent).
+ */
+
+import { A2AError } from '../server/error.js';
+import type {
+  APIKeySecurityScheme as V1APIKeySecurityScheme,
+  AuthorizationCodeOAuthFlow as V1AuthorizationCodeOAuthFlow,
+  ClientCredentialsOAuthFlow as V1ClientCredentialsOAuthFlow,
+  HTTPAuthSecurityScheme as V1HTTPAuthSecurityScheme,
+  ImplicitOAuthFlow as V1ImplicitOAuthFlow,
+  MutualTlsSecurityScheme as V1MutualTlsSecurityScheme,
+  OAuth2SecurityScheme as V1OAuth2SecurityScheme,
+  OAuthFlows as V1OAuthFlows,
+  OpenIdConnectSecurityScheme as V1OpenIdConnectSecurityScheme,
+  PasswordOAuthFlow as V1PasswordOAuthFlow,
+  SecurityRequirement as V1SecurityRequirement,
+  SecurityScheme as V1SecurityScheme,
+} from '../../../types/pb/a2a.js';
+import type * as legacy from '../types/types.js';
+
+function nonEmpty(value: string | undefined): string | undefined {
+  return value !== undefined && value !== '' ? value : undefined;
+}
+
+/**
+ * Converts a v0.3 JSON security-requirement entry (`{ [k]: string[] }`)
+ * into a v1.0 proto `SecurityRequirement` (with `StringList` wrappers).
+ */
+export function toCoreSecurityRequirement(compat: {
+  [k: string]: string[];
+}): V1SecurityRequirement {
+  return {
+    schemes: Object.fromEntries(
+      Object.entries(compat).map(([scheme, scopes]) => [scheme, { list: [...scopes] }])
+    ),
+  };
+}
+
+/**
+ * Converts a v1.0 proto `SecurityRequirement` into the v0.3 JSON
+ * `{ [k]: string[] }` shape by unwrapping the `StringList` records.
+ */
+export function toCompatSecurityRequirement(core: V1SecurityRequirement): {
+  [k: string]: string[];
+} {
+  return Object.fromEntries(
+    Object.entries(core.schemes).map(([scheme, stringList]) => [scheme, [...stringList.list]])
+  );
+}
+
+function buildV1ApiKeyScheme(scheme: legacy.APIKeySecurityScheme): V1APIKeySecurityScheme {
+  return {
+    description: scheme.description ?? '',
+    location: scheme.in,
+    name: scheme.name,
+  };
+}
+
+function buildV1HttpScheme(scheme: legacy.HTTPAuthSecurityScheme): V1HTTPAuthSecurityScheme {
+  return {
+    description: scheme.description ?? '',
+    scheme: scheme.scheme,
+    bearerFormat: scheme.bearerFormat ?? '',
+  };
+}
+
+function buildV1MtlsScheme(scheme: legacy.MutualTLSSecurityScheme): V1MutualTlsSecurityScheme {
+  return { description: scheme.description ?? '' };
+}
+
+function buildV1Oauth2Scheme(scheme: legacy.OAuth2SecurityScheme): V1OAuth2SecurityScheme {
+  return {
+    description: scheme.description ?? '',
+    flows: toCoreOAuthFlows(scheme.flows),
+    oauth2MetadataUrl: scheme.oauth2MetadataUrl ?? '',
+  };
+}
+
+function buildV1OidcScheme(
+  scheme: legacy.OpenIdConnectSecurityScheme
+): V1OpenIdConnectSecurityScheme {
+  return {
+    description: scheme.description ?? '',
+    openIdConnectUrl: scheme.openIdConnectUrl,
+  };
+}
+
+/**
+ * Converts a v0.3 JSON `SecurityScheme` (a `type`-tagged union) into a
+ * v1.0 proto `SecurityScheme` (a `$case`-tagged oneof).
+ */
+export function toCoreSecurityScheme(compat: legacy.SecurityScheme): V1SecurityScheme {
+  switch (compat.type) {
+    case 'apiKey':
+      return {
+        scheme: { $case: 'apiKeySecurityScheme', value: buildV1ApiKeyScheme(compat) },
+      };
+    case 'http':
+      return {
+        scheme: { $case: 'httpAuthSecurityScheme', value: buildV1HttpScheme(compat) },
+      };
+    case 'oauth2':
+      return {
+        scheme: { $case: 'oauth2SecurityScheme', value: buildV1Oauth2Scheme(compat) },
+      };
+    case 'openIdConnect':
+      return {
+        scheme: { $case: 'openIdConnectSecurityScheme', value: buildV1OidcScheme(compat) },
+      };
+    case 'mutualTLS':
+      return {
+        scheme: { $case: 'mtlsSecurityScheme', value: buildV1MtlsScheme(compat) },
+      };
+    default:
+      throw A2AError.invalidParams(
+        `Unsupported v0.3 security scheme type: ${String((compat as { type?: string }).type)}`
+      );
+  }
+}
+
+function buildCompatApiKey(core: V1APIKeySecurityScheme): legacy.APIKeySecurityScheme {
+  const result: legacy.APIKeySecurityScheme = {
+    type: 'apiKey',
+    name: core.name,
+    in: (core.location as legacy.APIKeySecurityScheme['in']) ?? 'header',
+  };
+  const description = nonEmpty(core.description);
+  if (description !== undefined) result.description = description;
+  return result;
+}
+
+function buildCompatHttp(core: V1HTTPAuthSecurityScheme): legacy.HTTPAuthSecurityScheme {
+  const result: legacy.HTTPAuthSecurityScheme = { type: 'http', scheme: core.scheme };
+  const description = nonEmpty(core.description);
+  if (description !== undefined) result.description = description;
+  const bearerFormat = nonEmpty(core.bearerFormat);
+  if (bearerFormat !== undefined) result.bearerFormat = bearerFormat;
+  return result;
+}
+
+function buildCompatMtls(core: V1MutualTlsSecurityScheme): legacy.MutualTLSSecurityScheme {
+  const result: legacy.MutualTLSSecurityScheme = { type: 'mutualTLS' };
+  const description = nonEmpty(core.description);
+  if (description !== undefined) result.description = description;
+  return result;
+}
+
+function buildCompatOauth2(core: V1OAuth2SecurityScheme): legacy.OAuth2SecurityScheme {
+  if (!core.flows) {
+    throw A2AError.invalidParams('OAuth2 security scheme missing flows');
+  }
+  const result: legacy.OAuth2SecurityScheme = {
+    type: 'oauth2',
+    flows: toCompatOAuthFlows(core.flows),
+  };
+  const description = nonEmpty(core.description);
+  if (description !== undefined) result.description = description;
+  const meta = nonEmpty(core.oauth2MetadataUrl);
+  if (meta !== undefined) result.oauth2MetadataUrl = meta;
+  return result;
+}
+
+function buildCompatOidc(core: V1OpenIdConnectSecurityScheme): legacy.OpenIdConnectSecurityScheme {
+  const result: legacy.OpenIdConnectSecurityScheme = {
+    type: 'openIdConnect',
+    openIdConnectUrl: core.openIdConnectUrl,
+  };
+  const description = nonEmpty(core.description);
+  if (description !== undefined) result.description = description;
+  return result;
+}
+
+/**
+ * Converts a v1.0 proto `SecurityScheme` into a v0.3 JSON `SecurityScheme`.
+ */
+export function toCompatSecurityScheme(core: V1SecurityScheme): legacy.SecurityScheme {
+  const scheme = core.scheme;
+  if (!scheme) {
+    throw A2AError.invalidParams('Invalid v1.0 SecurityScheme: missing inner scheme');
+  }
+  switch (scheme.$case) {
+    case 'apiKeySecurityScheme':
+      return buildCompatApiKey(scheme.value);
+    case 'httpAuthSecurityScheme':
+      return buildCompatHttp(scheme.value);
+    case 'mtlsSecurityScheme':
+      return buildCompatMtls(scheme.value);
+    case 'oauth2SecurityScheme':
+      return buildCompatOauth2(scheme.value);
+    case 'openIdConnectSecurityScheme':
+      return buildCompatOidc(scheme.value);
+    default:
+      throw A2AError.invalidParams(
+        `Unsupported v1.0 SecurityScheme $case: ${(scheme as { $case?: string }).$case ?? 'unknown'}`
+      );
+  }
+}
+
+/**
+ * Converts a v0.3 JSON `OAuthFlows` (a record of optional flows) into a
+ * v1.0 proto `OAuthFlows` (a `flow.$case` oneof).
+ *
+ * The v0.3 schema permits at most one flow to be set in practice, but
+ * the JSON shape allows any combination. We pick in a deterministic order
+ * (authorization code → client credentials → implicit → password) and
+ * throw if none are present (the proto oneof leaves no representation for
+ * "all flows empty").
+ */
+export function toCoreOAuthFlows(compat: legacy.OAuthFlows): V1OAuthFlows {
+  if (compat.authorizationCode) {
+    const authCode = compat.authorizationCode;
+    const value: V1AuthorizationCodeOAuthFlow = {
+      authorizationUrl: authCode.authorizationUrl,
+      tokenUrl: authCode.tokenUrl,
+      refreshUrl: authCode.refreshUrl ?? '',
+      scopes: { ...authCode.scopes },
+      pkceRequired: false,
+    };
+    return { flow: { $case: 'authorizationCode', value } };
+  }
+  if (compat.clientCredentials) {
+    const clientCreds = compat.clientCredentials;
+    const value: V1ClientCredentialsOAuthFlow = {
+      tokenUrl: clientCreds.tokenUrl,
+      refreshUrl: clientCreds.refreshUrl ?? '',
+      scopes: { ...clientCreds.scopes },
+    };
+    return { flow: { $case: 'clientCredentials', value } };
+  }
+  if (compat.implicit) {
+    const value: V1ImplicitOAuthFlow = {
+      authorizationUrl: compat.implicit.authorizationUrl,
+      refreshUrl: compat.implicit.refreshUrl ?? '',
+      scopes: { ...compat.implicit.scopes },
+    };
+    return { flow: { $case: 'implicit', value } };
+  }
+  if (compat.password) {
+    const value: V1PasswordOAuthFlow = {
+      tokenUrl: compat.password.tokenUrl,
+      refreshUrl: compat.password.refreshUrl ?? '',
+      scopes: { ...compat.password.scopes },
+    };
+    return { flow: { $case: 'password', value } };
+  }
+  throw A2AError.invalidParams('OAuthFlows must declare at least one flow');
+}
+
+/**
+ * Converts a v1.0 proto `OAuthFlows` into a v0.3 JSON `OAuthFlows`.
+ *
+ * v1.0's `deviceCode` flow has no v0.3 equivalent and is **silently
+ * dropped**. When `deviceCode` is the only declared flow the result is an
+ * empty `{}` object — callers that need to reject this can guard via
+ * `Object.keys(result).length === 0`.
+ */
+export function toCompatOAuthFlows(core: V1OAuthFlows): legacy.OAuthFlows {
+  const result: legacy.OAuthFlows = {};
+  const flow = core.flow;
+  if (!flow) return result;
+
+  switch (flow.$case) {
+    case 'authorizationCode': {
+      const v = flow.value;
+      result.authorizationCode = {
+        authorizationUrl: v.authorizationUrl,
+        tokenUrl: v.tokenUrl,
+        scopes: { ...v.scopes },
+      };
+      const refresh = nonEmpty(v.refreshUrl);
+      if (refresh !== undefined) result.authorizationCode.refreshUrl = refresh;
+      break;
+    }
+    case 'clientCredentials': {
+      const v = flow.value;
+      result.clientCredentials = {
+        tokenUrl: v.tokenUrl,
+        scopes: { ...v.scopes },
+      };
+      const refresh = nonEmpty(v.refreshUrl);
+      if (refresh !== undefined) result.clientCredentials.refreshUrl = refresh;
+      break;
+    }
+    case 'implicit': {
+      const v = flow.value;
+      result.implicit = {
+        authorizationUrl: v.authorizationUrl,
+        scopes: { ...v.scopes },
+      };
+      const refresh = nonEmpty(v.refreshUrl);
+      if (refresh !== undefined) result.implicit.refreshUrl = refresh;
+      break;
+    }
+    case 'password': {
+      const v = flow.value;
+      result.password = {
+        tokenUrl: v.tokenUrl,
+        scopes: { ...v.scopes },
+      };
+      const refresh = nonEmpty(v.refreshUrl);
+      if (refresh !== undefined) result.password.refreshUrl = refresh;
+      break;
+    }
+    case 'deviceCode':
+      // Intentionally dropped: v0.3 has no `deviceCode` flow representation.
+      break;
+    default:
+      // Unknown / future flow $case — also silently dropped.
+      break;
+  }
+  return result;
+}

--- a/src/compat/v0_3/translate/tasks.ts
+++ b/src/compat/v0_3/translate/tasks.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
 import { deepCloneMetadata } from './_clone.js';
+import { A2AError } from '../server/error.js';
 
 /**
  * Terminal v0.3 task states for which a `status-update` event should be
@@ -184,9 +185,7 @@ export function toCompatTaskArtifactUpdateEvent(
   coreEvent: V1TaskArtifactUpdateEvent
 ): legacy.TaskArtifactUpdateEvent {
   if (!coreEvent.artifact) {
-    // The v0.3 schema requires the `artifact` field; without one we can't
-    // construct a valid legacy event.
-    throw new Error('Invalid TaskArtifactUpdateEvent: missing artifact');
+    throw A2AError.invalidParams('Invalid TaskArtifactUpdateEvent: missing artifact');
   }
 
   const result: legacy.TaskArtifactUpdateEvent = {

--- a/src/compat/v0_3/translate/tasks.ts
+++ b/src/compat/v0_3/translate/tasks.ts
@@ -1,0 +1,209 @@
+/**
+ * `Task`, `TaskStatus`, and streaming-update event translators between
+ * v1.0 proto and v0.3 JSON.
+ *
+ * The notable mismatch handled here is `TaskStatusUpdateEvent.final`:
+ * v0.3 JSON requires it, v1.0 proto has no equivalent field. Going
+ * v1.0 → v0.3 we compute `final` from the task state using the rule that
+ * `final = state ∈ {completed, canceled, failed, rejected}`. Going
+ * v0.3 → v1.0 we simply drop the field.
+ */
+
+import { toCompatTaskState, toCoreTaskState } from './enums.js';
+import { toCompatArtifact, toCompatMessage, toCoreArtifact, toCoreMessage } from './messages.js';
+import type {
+  Task as V1Task,
+  TaskArtifactUpdateEvent as V1TaskArtifactUpdateEvent,
+  TaskStatus as V1TaskStatus,
+  TaskStatusUpdateEvent as V1TaskStatusUpdateEvent,
+} from '../../../types/pb/a2a.js';
+import type * as legacy from '../types/types.js';
+
+/**
+ * Terminal v0.3 task states for which a `status-update` event should be
+ * marked as `final: true`.
+ *
+ * Note: interrupted states (`'input-required'`, `'auth-required'`) are
+ * intentionally NOT considered final.
+ */
+const FINAL_LEGACY_STATES: ReadonlySet<legacy.TaskStatus['state']> = new Set([
+  'completed',
+  'canceled',
+  'failed',
+  'rejected',
+]);
+
+function cloneMetadata(
+  metadata: { [k: string]: unknown } | undefined
+): { [k: string]: unknown } | undefined {
+  if (metadata === undefined) return undefined;
+  return { ...metadata };
+}
+
+/**
+ * Converts a v0.3 JSON `TaskStatus` into a v1.0 proto `TaskStatus`.
+ */
+export function toCoreTaskStatus(compatStatus: legacy.TaskStatus): V1TaskStatus {
+  return {
+    state: toCoreTaskState(compatStatus.state),
+    message: compatStatus.message ? toCoreMessage(compatStatus.message) : undefined,
+    timestamp: compatStatus.timestamp,
+  };
+}
+
+/**
+ * Converts a v1.0 proto `TaskStatus` into a v0.3 JSON `TaskStatus`.
+ *
+ * Empty `timestamp` strings collapse to `undefined` since v0.3 JSON marks
+ * the field optional.
+ */
+export function toCompatTaskStatus(coreStatus: V1TaskStatus): legacy.TaskStatus {
+  const result: legacy.TaskStatus = { state: toCompatTaskState(coreStatus.state) };
+  if (coreStatus.message) {
+    result.message = toCompatMessage(coreStatus.message);
+  }
+  if (coreStatus.timestamp !== undefined && coreStatus.timestamp !== '') {
+    result.timestamp = coreStatus.timestamp;
+  }
+  return result;
+}
+
+/**
+ * Converts a v0.3 JSON `Task` into a v1.0 proto `Task`.
+ *
+ * Optional `artifacts` / `history` arrays collapse to empty arrays.
+ * If `status` is missing the result carries a `TASK_STATE_UNSPECIFIED`
+ * placeholder.
+ */
+export function toCoreTask(compatTask: legacy.Task): V1Task {
+  return {
+    id: compatTask.id,
+    contextId: compatTask.contextId,
+    status: toCoreTaskStatus(compatTask.status),
+    artifacts: compatTask.artifacts ? compatTask.artifacts.map(toCoreArtifact) : [],
+    history: compatTask.history ? compatTask.history.map(toCoreMessage) : [],
+    metadata: cloneMetadata(compatTask.metadata),
+  };
+}
+
+/**
+ * Converts a v1.0 proto `Task` into a v0.3 JSON `Task`.
+ *
+ * Adds the `kind: 'task'` discriminator. Empty arrays are pruned so
+ * v0.3 consumers see truly-optional fields when nothing was provided.
+ * A missing `status` is replaced with `{ state: 'unknown' }` so the
+ * v0.3 schema (which requires `status`) remains satisfied.
+ */
+export function toCompatTask(coreTask: V1Task): legacy.Task {
+  const result: legacy.Task = {
+    kind: 'task',
+    id: coreTask.id,
+    contextId: coreTask.contextId,
+    status: coreTask.status ? toCompatTaskStatus(coreTask.status) : { state: 'unknown' },
+  };
+
+  if (coreTask.history.length > 0) {
+    result.history = coreTask.history.map(toCompatMessage);
+  }
+  if (coreTask.artifacts.length > 0) {
+    result.artifacts = coreTask.artifacts.map(toCompatArtifact);
+  }
+  const metadata = cloneMetadata(coreTask.metadata);
+  if (metadata !== undefined) result.metadata = metadata;
+
+  return result;
+}
+
+/**
+ * Converts a v0.3 JSON `TaskStatusUpdateEvent` into a v1.0 proto
+ * `TaskStatusUpdateEvent`.
+ *
+ * Drops the v0.3-only `final` field — v1.0 has no equivalent and the
+ * receiver computes terminality from the status state.
+ */
+export function toCoreTaskStatusUpdateEvent(
+  compatEvent: legacy.TaskStatusUpdateEvent
+): V1TaskStatusUpdateEvent {
+  return {
+    taskId: compatEvent.taskId,
+    contextId: compatEvent.contextId,
+    status: toCoreTaskStatus(compatEvent.status),
+    metadata: cloneMetadata(compatEvent.metadata),
+  };
+}
+
+/**
+ * Converts a v1.0 proto `TaskStatusUpdateEvent` into a v0.3 JSON
+ * `TaskStatusUpdateEvent`.
+ *
+ * Computes `final` from the (translated) status state. The legacy
+ * `kind: 'status-update'` discriminator is added so the result can be
+ * embedded in the v0.3 streaming-response union.
+ */
+export function toCompatTaskStatusUpdateEvent(
+  coreEvent: V1TaskStatusUpdateEvent
+): legacy.TaskStatusUpdateEvent {
+  const status: legacy.TaskStatus = coreEvent.status
+    ? toCompatTaskStatus(coreEvent.status)
+    : { state: 'unknown' };
+
+  const result: legacy.TaskStatusUpdateEvent = {
+    kind: 'status-update',
+    taskId: coreEvent.taskId,
+    contextId: coreEvent.contextId,
+    status,
+    final: FINAL_LEGACY_STATES.has(status.state),
+  };
+  const metadata = cloneMetadata(coreEvent.metadata);
+  if (metadata !== undefined) result.metadata = metadata;
+  return result;
+}
+
+/**
+ * Converts a v0.3 JSON `TaskArtifactUpdateEvent` into a v1.0 proto
+ * `TaskArtifactUpdateEvent`.
+ *
+ * Optional boolean fields default to `false` (proto3 convention).
+ */
+export function toCoreTaskArtifactUpdateEvent(
+  compatEvent: legacy.TaskArtifactUpdateEvent
+): V1TaskArtifactUpdateEvent {
+  return {
+    taskId: compatEvent.taskId,
+    contextId: compatEvent.contextId,
+    artifact: toCoreArtifact(compatEvent.artifact),
+    append: compatEvent.append ?? false,
+    lastChunk: compatEvent.lastChunk ?? false,
+    metadata: cloneMetadata(compatEvent.metadata),
+  };
+}
+
+/**
+ * Converts a v1.0 proto `TaskArtifactUpdateEvent` into a v0.3 JSON
+ * `TaskArtifactUpdateEvent`.
+ *
+ * The legacy `kind: 'artifact-update'` discriminator is added.
+ * The optional `append` / `lastChunk` booleans are preserved as-is so a
+ * server explicitly emitting `false` is round-trip-stable.
+ */
+export function toCompatTaskArtifactUpdateEvent(
+  coreEvent: V1TaskArtifactUpdateEvent
+): legacy.TaskArtifactUpdateEvent {
+  if (!coreEvent.artifact) {
+    // The v0.3 schema requires the `artifact` field; without one we can't
+    // construct a valid legacy event.
+    throw new Error('Invalid TaskArtifactUpdateEvent: missing artifact');
+  }
+
+  const result: legacy.TaskArtifactUpdateEvent = {
+    kind: 'artifact-update',
+    taskId: coreEvent.taskId,
+    contextId: coreEvent.contextId,
+    artifact: toCompatArtifact(coreEvent.artifact),
+    append: coreEvent.append,
+    lastChunk: coreEvent.lastChunk,
+  };
+  const metadata = cloneMetadata(coreEvent.metadata);
+  if (metadata !== undefined) result.metadata = metadata;
+  return result;
+}

--- a/src/compat/v0_3/translate/tasks.ts
+++ b/src/compat/v0_3/translate/tasks.ts
@@ -10,7 +10,8 @@
  */
 
 import { toCompatTaskState, toCoreTaskState } from './enums.js';
-import { toCompatArtifact, toCompatMessage, toCoreArtifact, toCoreMessage } from './messages.js';
+import { toCompatMessage, toCoreMessage } from './messages.js';
+import { toCompatArtifact, toCoreArtifact } from './artifacts.js';
 import type {
   Task as V1Task,
   TaskArtifactUpdateEvent as V1TaskArtifactUpdateEvent,

--- a/src/compat/v0_3/translate/tasks.ts
+++ b/src/compat/v0_3/translate/tasks.ts
@@ -18,6 +18,7 @@ import type {
   TaskStatusUpdateEvent as V1TaskStatusUpdateEvent,
 } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
+import { deepCloneMetadata } from './_clone.js';
 
 /**
  * Terminal v0.3 task states for which a `status-update` event should be
@@ -32,13 +33,6 @@ const FINAL_LEGACY_STATES: ReadonlySet<legacy.TaskStatus['state']> = new Set([
   'failed',
   'rejected',
 ]);
-
-function cloneMetadata(
-  metadata: { [k: string]: unknown } | undefined
-): { [k: string]: unknown } | undefined {
-  if (metadata === undefined) return undefined;
-  return { ...metadata };
-}
 
 /**
  * Converts a v0.3 JSON `TaskStatus` into a v1.0 proto `TaskStatus`.
@@ -82,7 +76,7 @@ export function toCoreTask(compatTask: legacy.Task): V1Task {
     status: toCoreTaskStatus(compatTask.status),
     artifacts: compatTask.artifacts ? compatTask.artifacts.map(toCoreArtifact) : [],
     history: compatTask.history ? compatTask.history.map(toCoreMessage) : [],
-    metadata: cloneMetadata(compatTask.metadata),
+    metadata: deepCloneMetadata(compatTask.metadata),
   };
 }
 
@@ -108,7 +102,7 @@ export function toCompatTask(coreTask: V1Task): legacy.Task {
   if (coreTask.artifacts.length > 0) {
     result.artifacts = coreTask.artifacts.map(toCompatArtifact);
   }
-  const metadata = cloneMetadata(coreTask.metadata);
+  const metadata = deepCloneMetadata(coreTask.metadata);
   if (metadata !== undefined) result.metadata = metadata;
 
   return result;
@@ -128,7 +122,7 @@ export function toCoreTaskStatusUpdateEvent(
     taskId: compatEvent.taskId,
     contextId: compatEvent.contextId,
     status: toCoreTaskStatus(compatEvent.status),
-    metadata: cloneMetadata(compatEvent.metadata),
+    metadata: deepCloneMetadata(compatEvent.metadata),
   };
 }
 
@@ -154,7 +148,7 @@ export function toCompatTaskStatusUpdateEvent(
     status,
     final: FINAL_LEGACY_STATES.has(status.state),
   };
-  const metadata = cloneMetadata(coreEvent.metadata);
+  const metadata = deepCloneMetadata(coreEvent.metadata);
   if (metadata !== undefined) result.metadata = metadata;
   return result;
 }
@@ -174,7 +168,7 @@ export function toCoreTaskArtifactUpdateEvent(
     artifact: toCoreArtifact(compatEvent.artifact),
     append: compatEvent.append ?? false,
     lastChunk: compatEvent.lastChunk ?? false,
-    metadata: cloneMetadata(compatEvent.metadata),
+    metadata: deepCloneMetadata(compatEvent.metadata),
   };
 }
 
@@ -203,7 +197,7 @@ export function toCompatTaskArtifactUpdateEvent(
     append: coreEvent.append,
     lastChunk: coreEvent.lastChunk,
   };
-  const metadata = cloneMetadata(coreEvent.metadata);
+  const metadata = deepCloneMetadata(coreEvent.metadata);
   if (metadata !== undefined) result.metadata = metadata;
   return result;
 }

--- a/src/compat/v0_3/translate/versions.ts
+++ b/src/compat/v0_3/translate/versions.ts
@@ -1,0 +1,66 @@
+/**
+ * Utility helpers for protocol-version comparison.
+ */
+
+import { A2A_PROTOCOL_VERSION } from '../../../constants.js';
+import { A2A_LEGACY_PROTOCOL_VERSION } from '../constants.js';
+
+/** The legacy A2A protocol version string targeted by this compat layer. */
+export const PROTOCOL_VERSION_0_3 = A2A_LEGACY_PROTOCOL_VERSION;
+
+/** The current A2A protocol version string. */
+export const PROTOCOL_VERSION_1_0 = A2A_PROTOCOL_VERSION;
+
+interface NumericVersion {
+  readonly major: number;
+  readonly minor: number;
+}
+
+/**
+ * Parses a `Major.Minor[.Patch...]` version string into its leading
+ * `(major, minor)` pair.
+ *
+ * Returns `undefined` for empty / unparseable inputs so callers can fall back
+ * to a default policy.
+ */
+function parseVersion(version: string): NumericVersion | undefined {
+  const trimmed = version.trim();
+  if (trimmed === '') return undefined;
+
+  const segments = trimmed.split('.');
+  if (segments.length === 0) return undefined;
+
+  const major = Number.parseInt(segments[0]!, 10);
+  if (!Number.isFinite(major) || major < 0) return undefined;
+
+  // Minor is optional; default to 0 to match `packaging.Version("1") == 1.0`.
+  const minorRaw = segments[1];
+  const minor = minorRaw === undefined ? 0 : Number.parseInt(minorRaw, 10);
+  if (!Number.isFinite(minor) || minor < 0) return undefined;
+
+  return { major, minor };
+}
+
+function compareVersions(a: NumericVersion, b: NumericVersion): number {
+  if (a.major !== b.major) return a.major - b.major;
+  return a.minor - b.minor;
+}
+
+/**
+ * Returns `true` when `version` is a non-empty, parseable string that falls
+ * inside the legacy range `[0.3, 1.0)`.
+ *
+ * Empty / nullish / unparseable inputs return `false`.
+ */
+export function isLegacyVersion(version: string | null | undefined): boolean {
+  if (!version) return false;
+  const v = parseVersion(version);
+  if (!v) return false;
+
+  const lower = parseVersion(PROTOCOL_VERSION_0_3);
+  const upper = parseVersion(PROTOCOL_VERSION_1_0);
+  // Defensive: both bounds are constants, so they should always parse.
+  if (!lower || !upper) return false;
+
+  return compareVersions(v, lower) >= 0 && compareVersions(v, upper) < 0;
+}

--- a/test/compat/v0_3/translate/agent_card.spec.ts
+++ b/test/compat/v0_3/translate/agent_card.spec.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from 'vitest';
+import {
+  toCompatAgentCapabilities,
+  toCompatAgentCard,
+  toCompatAgentCardSignature,
+  toCompatAgentExtension,
+  toCompatAgentInterface,
+  toCompatAgentProvider,
+  toCompatAgentSkill,
+  toCoreAgentCapabilities,
+  toCoreAgentCard,
+  toCoreAgentCardSignature,
+  toCoreAgentExtension,
+  toCoreAgentInterface,
+  toCoreAgentProvider,
+  toCoreAgentSkill,
+} from '../../../../src/compat/v0_3/translate/agent_card.js';
+import { VersionNotSupportedError } from '../../../../src/errors.js';
+import type { AgentCard as V1AgentCard } from '../../../../src/types/pb/a2a.js';
+import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
+
+describe('agent_card', () => {
+  describe('AgentInterface', () => {
+    it('maps transport ↔ protocolBinding', () => {
+      const compat: legacy.AgentInterface = { url: 'https://x', transport: 'JSONRPC' };
+      const core = toCoreAgentInterface(compat);
+      expect(core.protocolBinding).toBe('JSONRPC');
+      expect(core.protocolVersion).toBe('0.3');
+      expect(toCompatAgentInterface(core)).toEqual(compat);
+    });
+  });
+
+  describe('AgentProvider', () => {
+    it('round-trips', () => {
+      const compat: legacy.AgentProvider = { url: 'https://p', organization: 'Org' };
+      expect(toCompatAgentProvider(toCoreAgentProvider(compat))).toEqual(compat);
+    });
+  });
+
+  describe('AgentExtension', () => {
+    it('round-trips', () => {
+      const compat: legacy.AgentExtension = {
+        uri: 'https://ext.example/a',
+        description: 'desc',
+        required: true,
+        params: { p: 'v' },
+      };
+      expect(toCompatAgentExtension(toCoreAgentExtension(compat))).toEqual(compat);
+    });
+
+    it('defaults required=false going compat → core', () => {
+      const compat: legacy.AgentExtension = { uri: 'https://ext.example/a' };
+      const core = toCoreAgentExtension(compat);
+      expect(core.required).toBe(false);
+    });
+  });
+
+  describe('AgentCapabilities', () => {
+    it('drops stateTransitionHistory (v0.3-only) going core → compat', () => {
+      const core = toCoreAgentCapabilities({
+        streaming: true,
+        pushNotifications: false,
+        stateTransitionHistory: true,
+      });
+      const compat = toCompatAgentCapabilities(core);
+      expect(compat.streaming).toBe(true);
+      expect(compat.pushNotifications).toBe(false);
+      expect(compat.stateTransitionHistory).toBeUndefined();
+    });
+
+    it('does not propagate extendedAgentCard from capabilities (card handles it)', () => {
+      const compat = toCompatAgentCapabilities({
+        streaming: undefined,
+        pushNotifications: undefined,
+        extensions: [],
+        extendedAgentCard: true,
+      });
+      // The capabilities-level translator must NOT introduce a v0.3
+      // field for the extended-card flag — that lives on the card.
+      expect(Object.keys(compat)).not.toContain('extendedAgentCard');
+      expect(Object.keys(compat)).not.toContain('supportsAuthenticatedExtendedCard');
+    });
+  });
+
+  describe('AgentSkill', () => {
+    it('round-trips with security', () => {
+      const compat: legacy.AgentSkill = {
+        id: 's1',
+        name: 'Skill',
+        description: 'desc',
+        tags: ['t'],
+        examples: ['ex'],
+        inputModes: ['text/plain'],
+        outputModes: ['text/plain'],
+        security: [{ oauth2: ['read'] }],
+      };
+      expect(toCompatAgentSkill(toCoreAgentSkill(compat))).toEqual(compat);
+    });
+
+    it('drops empty optional arrays going core → compat', () => {
+      const core = toCoreAgentSkill({
+        id: 's1',
+        name: 'Skill',
+        description: 'desc',
+        tags: ['t'],
+      });
+      const compat = toCompatAgentSkill(core);
+      expect(compat.examples).toBeUndefined();
+      expect(compat.inputModes).toBeUndefined();
+      expect(compat.outputModes).toBeUndefined();
+      expect(compat.security).toBeUndefined();
+    });
+  });
+
+  describe('AgentCardSignature', () => {
+    it('round-trips', () => {
+      const compat: legacy.AgentCardSignature = {
+        protected: 'eyJhbGciOi...',
+        signature: 'sig...',
+        header: { kid: 'key-1' },
+      };
+      expect(toCompatAgentCardSignature(toCoreAgentCardSignature(compat))).toEqual(compat);
+    });
+  });
+
+  describe('AgentCard', () => {
+    function minimalCompatCard(): legacy.AgentCard {
+      return {
+        name: 'Agent',
+        description: 'desc',
+        version: '1.2.3',
+        url: 'https://api.example/a2a',
+        preferredTransport: 'JSONRPC',
+        protocolVersion: '0.3',
+        capabilities: { streaming: true },
+        defaultInputModes: ['text/plain'],
+        defaultOutputModes: ['text/plain'],
+        skills: [{ id: 's1', name: 'Skill', description: 'desc', tags: [] }],
+      };
+    }
+
+    it('round-trips a minimal card', () => {
+      const compat = minimalCompatCard();
+      expect(toCompatAgentCard(toCoreAgentCard(compat))).toEqual(compat);
+    });
+
+    it('folds supportsAuthenticatedExtendedCard into capabilities.extendedAgentCard', () => {
+      const compat: legacy.AgentCard = {
+        ...minimalCompatCard(),
+        supportsAuthenticatedExtendedCard: true,
+      };
+      const core = toCoreAgentCard(compat);
+      expect(core.capabilities?.extendedAgentCard).toBe(true);
+    });
+
+    it('unfolds extendedAgentCard back to the card level going core → compat', () => {
+      const core = toCoreAgentCard({
+        ...minimalCompatCard(),
+        supportsAuthenticatedExtendedCard: true,
+      });
+      const back = toCompatAgentCard(core);
+      expect(back.supportsAuthenticatedExtendedCard).toBe(true);
+    });
+
+    it('puts additional interfaces in supportedInterfaces after the primary one', () => {
+      const compat: legacy.AgentCard = {
+        ...minimalCompatCard(),
+        additionalInterfaces: [{ url: 'https://api.example/grpc', transport: 'GRPC' }],
+      };
+      const core = toCoreAgentCard(compat);
+      expect(core.supportedInterfaces).toHaveLength(2);
+      expect(core.supportedInterfaces[0]!.url).toBe('https://api.example/a2a');
+      expect(core.supportedInterfaces[1]!.url).toBe('https://api.example/grpc');
+    });
+
+    it('filters out interfaces with non-legacy protocolVersion', () => {
+      const core: V1AgentCard = {
+        name: 'Agent',
+        description: 'desc',
+        version: '1.2.3',
+        supportedInterfaces: [
+          {
+            url: 'https://api.example/v1',
+            protocolBinding: 'JSONRPC',
+            tenant: '',
+            protocolVersion: '1.0',
+          },
+          {
+            url: 'https://api.example/legacy',
+            protocolBinding: 'JSONRPC',
+            tenant: '',
+            protocolVersion: '0.3',
+          },
+        ],
+        provider: undefined,
+        capabilities: {
+          streaming: undefined,
+          pushNotifications: undefined,
+          extensions: [],
+          extendedAgentCard: undefined,
+        },
+        securitySchemes: {},
+        securityRequirements: [],
+        defaultInputModes: [],
+        defaultOutputModes: [],
+        skills: [],
+        signatures: [],
+      };
+      const compat = toCompatAgentCard(core);
+      expect(compat.url).toBe('https://api.example/legacy');
+      expect(compat.additionalInterfaces).toBeUndefined();
+    });
+
+    it('throws VersionNotSupportedError if no interface qualifies', () => {
+      const core: V1AgentCard = {
+        name: 'Agent',
+        description: 'desc',
+        version: '1.2.3',
+        supportedInterfaces: [
+          {
+            url: 'https://api.example/v1',
+            protocolBinding: 'JSONRPC',
+            tenant: '',
+            protocolVersion: '1.0',
+          },
+        ],
+        provider: undefined,
+        capabilities: {
+          streaming: undefined,
+          pushNotifications: undefined,
+          extensions: [],
+          extendedAgentCard: undefined,
+        },
+        securitySchemes: {},
+        securityRequirements: [],
+        defaultInputModes: [],
+        defaultOutputModes: [],
+        skills: [],
+        signatures: [],
+      };
+      expect(() => toCompatAgentCard(core)).toThrow(VersionNotSupportedError);
+    });
+
+    it('keeps an interface with empty protocolVersion (treated as compatible)', () => {
+      const core: V1AgentCard = {
+        name: 'Agent',
+        description: 'desc',
+        version: '1.2.3',
+        supportedInterfaces: [
+          {
+            url: 'https://api.example/legacy',
+            protocolBinding: 'JSONRPC',
+            tenant: '',
+            protocolVersion: '',
+          },
+        ],
+        provider: undefined,
+        capabilities: {
+          streaming: undefined,
+          pushNotifications: undefined,
+          extensions: [],
+          extendedAgentCard: undefined,
+        },
+        securitySchemes: {},
+        securityRequirements: [],
+        defaultInputModes: [],
+        defaultOutputModes: [],
+        skills: [],
+        signatures: [],
+      };
+      const compat = toCompatAgentCard(core);
+      expect(compat.url).toBe('https://api.example/legacy');
+      // Falls back to PROTOCOL_VERSION_0_3 for the card-level version.
+      expect(compat.protocolVersion).toBe('0.3');
+    });
+
+    it('defaults preferredTransport to JSONRPC when omitted on compat side', () => {
+      const compat: legacy.AgentCard = { ...minimalCompatCard() };
+      delete (compat as Partial<legacy.AgentCard>).preferredTransport;
+      const core = toCoreAgentCard(compat);
+      expect(core.supportedInterfaces[0]!.protocolBinding).toBe('JSONRPC');
+    });
+  });
+});

--- a/test/compat/v0_3/translate/artifacts.spec.ts
+++ b/test/compat/v0_3/translate/artifacts.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  toCompatArtifact,
+  toCoreArtifact,
+} from '../../../../src/compat/v0_3/translate/artifacts.js';
+import type { Artifact as V1Artifact } from '../../../../src/types/pb/a2a.js';
+import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
+
+describe('artifacts', () => {
+  describe('toCoreArtifact', () => {
+    it('coerces missing optional fields to proto3 defaults', () => {
+      const compat: legacy.Artifact = {
+        artifactId: 'art-1',
+        parts: [{ kind: 'text', text: 'x' }],
+      };
+      const core = toCoreArtifact(compat);
+      expect(core.artifactId).toBe('art-1');
+      expect(core.name).toBe('');
+      expect(core.description).toBe('');
+      expect(core.metadata).toBeUndefined();
+      expect(core.extensions).toEqual([]);
+      expect(core.parts).toHaveLength(1);
+    });
+
+    it('preserves optional fields', () => {
+      const compat: legacy.Artifact = {
+        artifactId: 'art-1',
+        name: 'name',
+        description: 'desc',
+        parts: [],
+        metadata: { k: 'v' },
+        extensions: ['ext-uri'],
+      };
+      const core = toCoreArtifact(compat);
+      expect(core.name).toBe('name');
+      expect(core.description).toBe('desc');
+      expect(core.metadata).toEqual({ k: 'v' });
+      expect(core.extensions).toEqual(['ext-uri']);
+    });
+  });
+
+  describe('toCompatArtifact', () => {
+    it('prunes empty proto3 defaults', () => {
+      const core: V1Artifact = {
+        artifactId: 'art-1',
+        name: '',
+        description: '',
+        parts: [],
+        metadata: undefined,
+        extensions: [],
+      };
+      expect(toCompatArtifact(core)).toEqual({ artifactId: 'art-1', parts: [] });
+    });
+
+    it('keeps non-empty optionals', () => {
+      const core: V1Artifact = {
+        artifactId: 'art-1',
+        name: 'name',
+        description: 'desc',
+        parts: [],
+        metadata: { k: 'v' },
+        extensions: ['ext'],
+      };
+      expect(toCompatArtifact(core)).toEqual({
+        artifactId: 'art-1',
+        parts: [],
+        name: 'name',
+        description: 'desc',
+        metadata: { k: 'v' },
+        extensions: ['ext'],
+      });
+    });
+  });
+
+  describe('round-tripping', () => {
+    it('round-trips a fully-populated artifact', () => {
+      const compat: legacy.Artifact = {
+        artifactId: 'art-1',
+        name: 'name',
+        description: 'desc',
+        parts: [{ kind: 'text', text: 'hi' }],
+        metadata: { k: 'v' },
+        extensions: ['ext'],
+      };
+      expect(toCompatArtifact(toCoreArtifact(compat))).toEqual(compat);
+    });
+  });
+});

--- a/test/compat/v0_3/translate/enums.spec.ts
+++ b/test/compat/v0_3/translate/enums.spec.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import {
+  toCoreRole,
+  toCoreTaskState,
+  toCompatRole,
+  toCompatTaskState,
+  TASK_STATE_COMPAT_TO_CORE,
+  TASK_STATE_CORE_TO_COMPAT,
+} from '../../../../src/compat/v0_3/translate/enums.js';
+import { Role, TaskState } from '../../../../src/types/pb/a2a.js';
+import type { TaskStatus } from '../../../../src/compat/v0_3/types/types.js';
+
+type LegacyTaskState = TaskStatus['state'];
+
+const ALL_LEGACY_STATES: LegacyTaskState[] = [
+  'unknown',
+  'submitted',
+  'working',
+  'completed',
+  'failed',
+  'canceled',
+  'input-required',
+  'rejected',
+  'auth-required',
+];
+
+describe('enums', () => {
+  describe('TASK_STATE_COMPAT_TO_CORE', () => {
+    it('contains an entry for every legacy literal', () => {
+      for (const literal of ALL_LEGACY_STATES) {
+        expect(TASK_STATE_COMPAT_TO_CORE[literal]).toBeDefined();
+      }
+    });
+
+    it('maps "canceled" to TASK_STATE_CANCELED (one L, v1.0 spelling)', () => {
+      expect(TASK_STATE_COMPAT_TO_CORE.canceled).toBe(TaskState.TASK_STATE_CANCELED);
+    });
+
+    it('maps "unknown" to TASK_STATE_UNSPECIFIED', () => {
+      expect(TASK_STATE_COMPAT_TO_CORE.unknown).toBe(TaskState.TASK_STATE_UNSPECIFIED);
+    });
+  });
+
+  describe('TASK_STATE_CORE_TO_COMPAT', () => {
+    it('round-trips every legacy literal back to itself', () => {
+      for (const literal of ALL_LEGACY_STATES) {
+        const enumValue = TASK_STATE_COMPAT_TO_CORE[literal];
+        expect(TASK_STATE_CORE_TO_COMPAT.get(enumValue)).toBe(literal);
+      }
+    });
+  });
+
+  describe('toCoreTaskState', () => {
+    it.each(ALL_LEGACY_STATES)('maps %s correctly', (literal) => {
+      expect(toCoreTaskState(literal)).toBe(TASK_STATE_COMPAT_TO_CORE[literal]);
+    });
+  });
+
+  describe('toCompatTaskState', () => {
+    it.each(ALL_LEGACY_STATES)('round-trips %s', (literal) => {
+      expect(toCompatTaskState(TASK_STATE_COMPAT_TO_CORE[literal])).toBe(literal);
+    });
+
+    it('falls back to "unknown" for UNRECOGNIZED', () => {
+      expect(toCompatTaskState(TaskState.UNRECOGNIZED)).toBe('unknown');
+    });
+
+    it('falls back to "unknown" for an out-of-range enum value', () => {
+      expect(toCompatTaskState(999 as TaskState)).toBe('unknown');
+    });
+  });
+
+  describe('toCoreRole', () => {
+    it('maps "user" to ROLE_USER', () => {
+      expect(toCoreRole('user')).toBe(Role.ROLE_USER);
+    });
+
+    it('maps "agent" to ROLE_AGENT', () => {
+      expect(toCoreRole('agent')).toBe(Role.ROLE_AGENT);
+    });
+  });
+
+  describe('toCompatRole', () => {
+    it('maps ROLE_USER to "user"', () => {
+      expect(toCompatRole(Role.ROLE_USER)).toBe('user');
+    });
+
+    it('maps ROLE_AGENT to "agent"', () => {
+      expect(toCompatRole(Role.ROLE_AGENT)).toBe('agent');
+    });
+
+    it('falls back to "agent" for ROLE_UNSPECIFIED', () => {
+      expect(toCompatRole(Role.ROLE_UNSPECIFIED)).toBe('agent');
+    });
+
+    it('falls back to "agent" for UNRECOGNIZED', () => {
+      expect(toCompatRole(Role.UNRECOGNIZED)).toBe('agent');
+    });
+  });
+});

--- a/test/compat/v0_3/translate/enums.spec.ts
+++ b/test/compat/v0_3/translate/enums.spec.ts
@@ -4,8 +4,6 @@ import {
   toCoreTaskState,
   toCompatRole,
   toCompatTaskState,
-  TASK_STATE_COMPAT_TO_CORE,
-  TASK_STATE_CORE_TO_COMPAT,
 } from '../../../../src/compat/v0_3/translate/enums.js';
 import { Role, TaskState } from '../../../../src/types/pb/a2a.js';
 import type { TaskStatus } from '../../../../src/compat/v0_3/types/types.js';
@@ -23,6 +21,24 @@ const ALL_LEGACY_STATES: LegacyTaskState[] = [
   'rejected',
   'auth-required',
 ];
+
+const TASK_STATE_COMPAT_TO_CORE: Record<LegacyTaskState, TaskState> = {
+  unknown: 0,
+  submitted: 1,
+  working: 2,
+  completed: 3,
+  failed: 4,
+  canceled: 5,
+  'input-required': 6,
+  rejected: 7,
+  'auth-required': 8,
+};
+
+const TASK_STATE_CORE_TO_COMPAT: ReadonlyMap<TaskState, LegacyTaskState> = new Map(
+  (Object.entries(TASK_STATE_COMPAT_TO_CORE) as [LegacyTaskState, TaskState][]).map(
+    ([literal, enumValue]) => [enumValue, literal]
+  )
+);
 
 describe('enums', () => {
   describe('TASK_STATE_COMPAT_TO_CORE', () => {

--- a/test/compat/v0_3/translate/messages.spec.ts
+++ b/test/compat/v0_3/translate/messages.spec.ts
@@ -210,4 +210,37 @@ describe('messages', () => {
       expect(toCompatArtifact(toCoreArtifact(compat))).toEqual(compat);
     });
   });
+
+  describe('metadata deep-cloning', () => {
+    it('toCoreMessage isolates nested metadata from the source', () => {
+      const nested = { tags: ['a', 'b'] };
+      const compat: legacy.Message = {
+        kind: 'message',
+        messageId: 'm1',
+        role: 'user',
+        parts: [],
+        metadata: { nested },
+      };
+      const core = toCoreMessage(compat);
+      (core.metadata!.nested as { tags: string[] }).tags.push('c');
+      expect(nested.tags).toEqual(['a', 'b']);
+    });
+
+    it('toCompatMessage isolates nested metadata from the source', () => {
+      const nested = { tags: ['a', 'b'] };
+      const core: V1Message = {
+        messageId: 'm1',
+        contextId: '',
+        taskId: '',
+        role: Role.ROLE_USER,
+        parts: [],
+        metadata: { nested },
+        extensions: [],
+        referenceTaskIds: [],
+      };
+      const compat = toCompatMessage(core);
+      (compat.metadata!.nested as { tags: string[] }).tags.push('c');
+      expect(nested.tags).toEqual(['a', 'b']);
+    });
+  });
 });

--- a/test/compat/v0_3/translate/messages.spec.ts
+++ b/test/compat/v0_3/translate/messages.spec.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+import {
+  toCompatArtifact,
+  toCompatMessage,
+  toCoreArtifact,
+  toCoreMessage,
+} from '../../../../src/compat/v0_3/translate/messages.js';
+import { Role } from '../../../../src/types/pb/a2a.js';
+import type { Artifact as V1Artifact, Message as V1Message } from '../../../../src/types/pb/a2a.js';
+import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
+
+describe('messages', () => {
+  describe('toCoreMessage', () => {
+    it('converts a minimal user message', () => {
+      const compat: legacy.Message = {
+        kind: 'message',
+        messageId: 'msg-1',
+        role: 'user',
+        parts: [{ kind: 'text', text: 'hi' }],
+      };
+      const core = toCoreMessage(compat);
+      expect(core).toEqual({
+        messageId: 'msg-1',
+        contextId: '',
+        taskId: '',
+        role: Role.ROLE_USER,
+        parts: [
+          {
+            content: { $case: 'text', value: 'hi' },
+            metadata: undefined,
+            filename: '',
+            mediaType: '',
+          },
+        ],
+        metadata: undefined,
+        extensions: [],
+        referenceTaskIds: [],
+      });
+    });
+
+    it('coerces missing IDs to empty strings (proto3 default)', () => {
+      const compat: legacy.Message = {
+        kind: 'message',
+        messageId: 'msg-1',
+        role: 'user',
+        parts: [],
+      };
+      const core = toCoreMessage(compat);
+      expect(core.contextId).toBe('');
+      expect(core.taskId).toBe('');
+    });
+
+    it('preserves contextId, taskId, metadata, extensions, referenceTaskIds', () => {
+      const compat: legacy.Message = {
+        kind: 'message',
+        messageId: 'msg-1',
+        role: 'agent',
+        parts: [],
+        contextId: 'ctx-1',
+        taskId: 'task-1',
+        metadata: { source: 'tester' },
+        extensions: ['https://ext.example/a'],
+        referenceTaskIds: ['other-task'],
+      };
+      const core = toCoreMessage(compat);
+      expect(core.role).toBe(Role.ROLE_AGENT);
+      expect(core.contextId).toBe('ctx-1');
+      expect(core.taskId).toBe('task-1');
+      expect(core.metadata).toEqual({ source: 'tester' });
+      expect(core.extensions).toEqual(['https://ext.example/a']);
+      expect(core.referenceTaskIds).toEqual(['other-task']);
+    });
+  });
+
+  describe('toCompatMessage', () => {
+    it('adds the kind discriminator and prunes empty proto3 defaults', () => {
+      const core: V1Message = {
+        messageId: 'msg-1',
+        contextId: '',
+        taskId: '',
+        role: Role.ROLE_USER,
+        parts: [],
+        metadata: undefined,
+        extensions: [],
+        referenceTaskIds: [],
+      };
+      expect(toCompatMessage(core)).toEqual({
+        kind: 'message',
+        messageId: 'msg-1',
+        role: 'user',
+        parts: [],
+      });
+    });
+
+    it('preserves non-empty optional fields', () => {
+      const core: V1Message = {
+        messageId: 'msg-1',
+        contextId: 'ctx-1',
+        taskId: 'task-1',
+        role: Role.ROLE_AGENT,
+        parts: [],
+        metadata: { k: 'v' },
+        extensions: ['https://ext.example/a'],
+        referenceTaskIds: ['other-task'],
+      };
+      expect(toCompatMessage(core)).toEqual({
+        kind: 'message',
+        messageId: 'msg-1',
+        role: 'agent',
+        parts: [],
+        contextId: 'ctx-1',
+        taskId: 'task-1',
+        metadata: { k: 'v' },
+        extensions: ['https://ext.example/a'],
+        referenceTaskIds: ['other-task'],
+      });
+    });
+  });
+
+  describe('toCoreArtifact', () => {
+    it('coerces missing optional fields to proto3 defaults', () => {
+      const compat: legacy.Artifact = {
+        artifactId: 'art-1',
+        parts: [{ kind: 'text', text: 'x' }],
+      };
+      const core = toCoreArtifact(compat);
+      expect(core.artifactId).toBe('art-1');
+      expect(core.name).toBe('');
+      expect(core.description).toBe('');
+      expect(core.metadata).toBeUndefined();
+      expect(core.extensions).toEqual([]);
+      expect(core.parts).toHaveLength(1);
+    });
+
+    it('preserves optional fields', () => {
+      const compat: legacy.Artifact = {
+        artifactId: 'art-1',
+        name: 'name',
+        description: 'desc',
+        parts: [],
+        metadata: { k: 'v' },
+        extensions: ['ext-uri'],
+      };
+      const core = toCoreArtifact(compat);
+      expect(core.name).toBe('name');
+      expect(core.description).toBe('desc');
+      expect(core.metadata).toEqual({ k: 'v' });
+      expect(core.extensions).toEqual(['ext-uri']);
+    });
+  });
+
+  describe('toCompatArtifact', () => {
+    it('prunes empty proto3 defaults', () => {
+      const core: V1Artifact = {
+        artifactId: 'art-1',
+        name: '',
+        description: '',
+        parts: [],
+        metadata: undefined,
+        extensions: [],
+      };
+      expect(toCompatArtifact(core)).toEqual({ artifactId: 'art-1', parts: [] });
+    });
+
+    it('keeps non-empty optionals', () => {
+      const core: V1Artifact = {
+        artifactId: 'art-1',
+        name: 'name',
+        description: 'desc',
+        parts: [],
+        metadata: { k: 'v' },
+        extensions: ['ext'],
+      };
+      expect(toCompatArtifact(core)).toEqual({
+        artifactId: 'art-1',
+        parts: [],
+        name: 'name',
+        description: 'desc',
+        metadata: { k: 'v' },
+        extensions: ['ext'],
+      });
+    });
+  });
+
+  describe('round-tripping', () => {
+    it('round-trips a fully-populated message', () => {
+      const compat: legacy.Message = {
+        kind: 'message',
+        messageId: 'msg-1',
+        role: 'agent',
+        parts: [{ kind: 'text', text: 'hi' }],
+        contextId: 'ctx',
+        taskId: 'task',
+        metadata: { m: 'v' },
+        extensions: ['e1'],
+        referenceTaskIds: ['t2'],
+      };
+      expect(toCompatMessage(toCoreMessage(compat))).toEqual(compat);
+    });
+
+    it('round-trips a fully-populated artifact', () => {
+      const compat: legacy.Artifact = {
+        artifactId: 'art-1',
+        name: 'name',
+        description: 'desc',
+        parts: [{ kind: 'text', text: 'hi' }],
+        metadata: { k: 'v' },
+        extensions: ['ext'],
+      };
+      expect(toCompatArtifact(toCoreArtifact(compat))).toEqual(compat);
+    });
+  });
+});

--- a/test/compat/v0_3/translate/messages.spec.ts
+++ b/test/compat/v0_3/translate/messages.spec.ts
@@ -1,12 +1,7 @@
 import { describe, expect, it } from 'vitest';
-import {
-  toCompatArtifact,
-  toCompatMessage,
-  toCoreArtifact,
-  toCoreMessage,
-} from '../../../../src/compat/v0_3/translate/messages.js';
+import { toCompatMessage, toCoreMessage } from '../../../../src/compat/v0_3/translate/messages.js';
 import { Role } from '../../../../src/types/pb/a2a.js';
-import type { Artifact as V1Artifact, Message as V1Message } from '../../../../src/types/pb/a2a.js';
+import type { Message as V1Message } from '../../../../src/types/pb/a2a.js';
 import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
 
 describe('messages', () => {
@@ -117,71 +112,6 @@ describe('messages', () => {
     });
   });
 
-  describe('toCoreArtifact', () => {
-    it('coerces missing optional fields to proto3 defaults', () => {
-      const compat: legacy.Artifact = {
-        artifactId: 'art-1',
-        parts: [{ kind: 'text', text: 'x' }],
-      };
-      const core = toCoreArtifact(compat);
-      expect(core.artifactId).toBe('art-1');
-      expect(core.name).toBe('');
-      expect(core.description).toBe('');
-      expect(core.metadata).toBeUndefined();
-      expect(core.extensions).toEqual([]);
-      expect(core.parts).toHaveLength(1);
-    });
-
-    it('preserves optional fields', () => {
-      const compat: legacy.Artifact = {
-        artifactId: 'art-1',
-        name: 'name',
-        description: 'desc',
-        parts: [],
-        metadata: { k: 'v' },
-        extensions: ['ext-uri'],
-      };
-      const core = toCoreArtifact(compat);
-      expect(core.name).toBe('name');
-      expect(core.description).toBe('desc');
-      expect(core.metadata).toEqual({ k: 'v' });
-      expect(core.extensions).toEqual(['ext-uri']);
-    });
-  });
-
-  describe('toCompatArtifact', () => {
-    it('prunes empty proto3 defaults', () => {
-      const core: V1Artifact = {
-        artifactId: 'art-1',
-        name: '',
-        description: '',
-        parts: [],
-        metadata: undefined,
-        extensions: [],
-      };
-      expect(toCompatArtifact(core)).toEqual({ artifactId: 'art-1', parts: [] });
-    });
-
-    it('keeps non-empty optionals', () => {
-      const core: V1Artifact = {
-        artifactId: 'art-1',
-        name: 'name',
-        description: 'desc',
-        parts: [],
-        metadata: { k: 'v' },
-        extensions: ['ext'],
-      };
-      expect(toCompatArtifact(core)).toEqual({
-        artifactId: 'art-1',
-        parts: [],
-        name: 'name',
-        description: 'desc',
-        metadata: { k: 'v' },
-        extensions: ['ext'],
-      });
-    });
-  });
-
   describe('round-tripping', () => {
     it('round-trips a fully-populated message', () => {
       const compat: legacy.Message = {
@@ -196,18 +126,6 @@ describe('messages', () => {
         referenceTaskIds: ['t2'],
       };
       expect(toCompatMessage(toCoreMessage(compat))).toEqual(compat);
-    });
-
-    it('round-trips a fully-populated artifact', () => {
-      const compat: legacy.Artifact = {
-        artifactId: 'art-1',
-        name: 'name',
-        description: 'desc',
-        parts: [{ kind: 'text', text: 'hi' }],
-        metadata: { k: 'v' },
-        extensions: ['ext'],
-      };
-      expect(toCompatArtifact(toCoreArtifact(compat))).toEqual(compat);
     });
   });
 

--- a/test/compat/v0_3/translate/parts.spec.ts
+++ b/test/compat/v0_3/translate/parts.spec.ts
@@ -223,4 +223,18 @@ describe('parts', () => {
       expect(back.metadata).toBeUndefined();
     });
   });
+
+  describe('metadata deep-cloning', () => {
+    it('toCorePart deep-clones metadata even when stripping data_part_compat', () => {
+      const nested = { list: [1, 2] };
+      const compat: legacy.Part = {
+        kind: 'data',
+        data: { value: 'wrapped' },
+        metadata: { data_part_compat: true, nested },
+      };
+      const core = toCorePart(compat);
+      (core.metadata!.nested as { list: number[] }).list.push(3);
+      expect(nested.list).toEqual([1, 2]);
+    });
+  });
 });

--- a/test/compat/v0_3/translate/parts.spec.ts
+++ b/test/compat/v0_3/translate/parts.spec.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from 'vitest';
+import { toCompatPart, toCorePart } from '../../../../src/compat/v0_3/translate/parts.js';
+import { A2AError } from '../../../../src/compat/v0_3/server/error.js';
+import type { Part as V1Part } from '../../../../src/types/pb/a2a.js';
+import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
+
+describe('parts', () => {
+  describe('toCorePart', () => {
+    it('converts a text part', () => {
+      const compat: legacy.Part = { kind: 'text', text: 'hello' };
+      const core = toCorePart(compat);
+      expect(core).toEqual({
+        content: { $case: 'text', value: 'hello' },
+        metadata: undefined,
+        filename: '',
+        mediaType: '',
+      });
+    });
+
+    it('preserves metadata on a text part', () => {
+      const compat: legacy.Part = { kind: 'text', text: 'hi', metadata: { foo: 'bar' } };
+      const core = toCorePart(compat);
+      expect(core.metadata).toEqual({ foo: 'bar' });
+    });
+
+    it('converts a file-with-bytes part, decoding base64', () => {
+      const bytes = Buffer.from('payload');
+      const compat: legacy.Part = {
+        kind: 'file',
+        file: { bytes: bytes.toString('base64'), mimeType: 'text/plain', name: 'p.txt' },
+      };
+      const core = toCorePart(compat);
+      expect(core.content).toEqual({ $case: 'raw', value: bytes });
+      expect(core.mediaType).toBe('text/plain');
+      expect(core.filename).toBe('p.txt');
+    });
+
+    it('converts a file-with-uri part', () => {
+      const compat: legacy.Part = {
+        kind: 'file',
+        file: { uri: 'https://example.com/x', mimeType: 'image/png' },
+      };
+      const core = toCorePart(compat);
+      expect(core.content).toEqual({ $case: 'url', value: 'https://example.com/x' });
+      expect(core.mediaType).toBe('image/png');
+      expect(core.filename).toBe('');
+    });
+
+    it('throws when the file part has neither bytes nor uri', () => {
+      const compat = { kind: 'file', file: {} } as unknown as legacy.Part;
+      expect(() => toCorePart(compat)).toThrow(A2AError);
+    });
+
+    it('converts a data part (plain object)', () => {
+      const compat: legacy.Part = { kind: 'data', data: { x: 1 } };
+      const core = toCorePart(compat);
+      expect(core.content).toEqual({ $case: 'data', value: { x: 1 } });
+    });
+
+    it('unwraps a `data_part_compat`-flagged data part to the original primitive', () => {
+      const compat: legacy.Part = {
+        kind: 'data',
+        data: { value: 42 },
+        metadata: { data_part_compat: true, extra: 'preserved' },
+      };
+      const core = toCorePart(compat);
+      expect(core.content).toEqual({ $case: 'data', value: 42 });
+      // The compat flag is stripped, other metadata remains.
+      expect(core.metadata).toEqual({ extra: 'preserved' });
+    });
+
+    it('drops metadata entirely when the only key was the compat flag', () => {
+      const compat: legacy.Part = {
+        kind: 'data',
+        data: { value: 'hi' },
+        metadata: { data_part_compat: true },
+      };
+      const core = toCorePart(compat);
+      expect(core.metadata).toBeUndefined();
+    });
+
+    it('throws for an unknown kind', () => {
+      const compat = { kind: 'unknown' } as unknown as legacy.Part;
+      expect(() => toCorePart(compat)).toThrow(A2AError);
+    });
+  });
+
+  describe('toCompatPart', () => {
+    it('converts a text part', () => {
+      const core: V1Part = {
+        content: { $case: 'text', value: 'hello' },
+        metadata: undefined,
+        filename: '',
+        mediaType: '',
+      };
+      expect(toCompatPart(core)).toEqual({ kind: 'text', text: 'hello' });
+    });
+
+    it('preserves metadata on a text part', () => {
+      const core: V1Part = {
+        content: { $case: 'text', value: 'x' },
+        metadata: { k: 'v' },
+        filename: '',
+        mediaType: '',
+      };
+      expect(toCompatPart(core)).toEqual({ kind: 'text', text: 'x', metadata: { k: 'v' } });
+    });
+
+    it('converts a raw file part, base64-encoding the buffer', () => {
+      const bytes = Buffer.from('payload');
+      const core: V1Part = {
+        content: { $case: 'raw', value: bytes },
+        metadata: undefined,
+        filename: 'p.txt',
+        mediaType: 'text/plain',
+      };
+      expect(toCompatPart(core)).toEqual({
+        kind: 'file',
+        file: { bytes: bytes.toString('base64'), mimeType: 'text/plain', name: 'p.txt' },
+      });
+    });
+
+    it('omits mimeType / name when the corresponding top-level fields are empty', () => {
+      const bytes = Buffer.from('x');
+      const core: V1Part = {
+        content: { $case: 'raw', value: bytes },
+        metadata: undefined,
+        filename: '',
+        mediaType: '',
+      };
+      const result = toCompatPart(core) as legacy.FilePart;
+      expect(result.file).toEqual({ bytes: bytes.toString('base64') });
+    });
+
+    it('converts a url file part', () => {
+      const core: V1Part = {
+        content: { $case: 'url', value: 'https://example.com/x' },
+        metadata: undefined,
+        filename: '',
+        mediaType: 'image/png',
+      };
+      expect(toCompatPart(core)).toEqual({
+        kind: 'file',
+        file: { uri: 'https://example.com/x', mimeType: 'image/png' },
+      });
+    });
+
+    it('converts a plain-object data part directly', () => {
+      const core: V1Part = {
+        content: { $case: 'data', value: { x: 1 } },
+        metadata: undefined,
+        filename: '',
+        mediaType: '',
+      };
+      expect(toCompatPart(core)).toEqual({ kind: 'data', data: { x: 1 } });
+    });
+
+    it('wraps a non-object data value and sets the compat flag in metadata', () => {
+      const core: V1Part = {
+        content: { $case: 'data', value: 'hello' },
+        metadata: undefined,
+        filename: '',
+        mediaType: '',
+      };
+      const compat = toCompatPart(core) as legacy.DataPart;
+      expect(compat.kind).toBe('data');
+      expect(compat.data).toEqual({ value: 'hello' });
+      expect(compat.metadata?.data_part_compat).toBe(true);
+    });
+
+    it('throws when content is missing', () => {
+      const core: V1Part = {
+        content: undefined,
+        metadata: undefined,
+        filename: '',
+        mediaType: '',
+      };
+      expect(() => toCompatPart(core)).toThrow(A2AError);
+    });
+  });
+
+  describe('round-tripping', () => {
+    it('round-trips a text part', () => {
+      const compat: legacy.Part = { kind: 'text', text: 'hello', metadata: { k: 'v' } };
+      expect(toCompatPart(toCorePart(compat))).toEqual(compat);
+    });
+
+    it('round-trips a file-with-bytes part', () => {
+      const compat: legacy.Part = {
+        kind: 'file',
+        file: {
+          bytes: Buffer.from('payload').toString('base64'),
+          mimeType: 'text/plain',
+          name: 'p.txt',
+        },
+      };
+      expect(toCompatPart(toCorePart(compat))).toEqual(compat);
+    });
+
+    it('round-trips a file-with-uri part', () => {
+      const compat: legacy.Part = {
+        kind: 'file',
+        file: { uri: 'https://example.com/x', mimeType: 'image/png', name: 'x.png' },
+      };
+      expect(toCompatPart(toCorePart(compat))).toEqual(compat);
+    });
+
+    it('round-trips a plain-object data part', () => {
+      const compat: legacy.Part = { kind: 'data', data: { x: 1, y: [2, 3] } };
+      expect(toCompatPart(toCorePart(compat))).toEqual(compat);
+    });
+
+    it('round-trips a non-object data value via data_part_compat', () => {
+      const original: V1Part = {
+        content: { $case: 'data', value: 'hello' },
+        metadata: undefined,
+        filename: '',
+        mediaType: '',
+      };
+      const intermediate = toCompatPart(original);
+      const back = toCorePart(intermediate);
+      expect(back.content).toEqual({ $case: 'data', value: 'hello' });
+      expect(back.metadata).toBeUndefined();
+    });
+  });
+});

--- a/test/compat/v0_3/translate/parts.spec.ts
+++ b/test/compat/v0_3/translate/parts.spec.ts
@@ -57,28 +57,6 @@ describe('parts', () => {
       expect(core.content).toEqual({ $case: 'data', value: { x: 1 } });
     });
 
-    it('unwraps a `data_part_compat`-flagged data part to the original primitive', () => {
-      const compat: legacy.Part = {
-        kind: 'data',
-        data: { value: 42 },
-        metadata: { data_part_compat: true, extra: 'preserved' },
-      };
-      const core = toCorePart(compat);
-      expect(core.content).toEqual({ $case: 'data', value: 42 });
-      // The compat flag is stripped, other metadata remains.
-      expect(core.metadata).toEqual({ extra: 'preserved' });
-    });
-
-    it('drops metadata entirely when the only key was the compat flag', () => {
-      const compat: legacy.Part = {
-        kind: 'data',
-        data: { value: 'hi' },
-        metadata: { data_part_compat: true },
-      };
-      const core = toCorePart(compat);
-      expect(core.metadata).toBeUndefined();
-    });
-
     it('throws for an unknown kind', () => {
       const compat = { kind: 'unknown' } as unknown as legacy.Part;
       expect(() => toCorePart(compat)).toThrow(A2AError);
@@ -155,17 +133,17 @@ describe('parts', () => {
       expect(toCompatPart(core)).toEqual({ kind: 'data', data: { x: 1 } });
     });
 
-    it('wraps a non-object data value and sets the compat flag in metadata', () => {
-      const core: V1Part = {
-        content: { $case: 'data', value: 'hello' },
-        metadata: undefined,
-        filename: '',
-        mediaType: '',
-      };
-      const compat = toCompatPart(core) as legacy.DataPart;
-      expect(compat.kind).toBe('data');
-      expect(compat.data).toEqual({ value: 'hello' });
-      expect(compat.metadata?.data_part_compat).toBe(true);
+    it('throws when v1 data part value is not a plain object', () => {
+      const nonObjectValues: unknown[] = ['hello', 42, true, null, [1, 2, 3]];
+      for (const value of nonObjectValues) {
+        const core: V1Part = {
+          content: { $case: 'data', value },
+          metadata: undefined,
+          filename: '',
+          mediaType: '',
+        };
+        expect(() => toCompatPart(core)).toThrow(A2AError);
+      }
     });
 
     it('throws when content is missing', () => {
@@ -209,28 +187,15 @@ describe('parts', () => {
       const compat: legacy.Part = { kind: 'data', data: { x: 1, y: [2, 3] } };
       expect(toCompatPart(toCorePart(compat))).toEqual(compat);
     });
-
-    it('round-trips a non-object data value via data_part_compat', () => {
-      const original: V1Part = {
-        content: { $case: 'data', value: 'hello' },
-        metadata: undefined,
-        filename: '',
-        mediaType: '',
-      };
-      const intermediate = toCompatPart(original);
-      const back = toCorePart(intermediate);
-      expect(back.content).toEqual({ $case: 'data', value: 'hello' });
-      expect(back.metadata).toBeUndefined();
-    });
   });
 
   describe('metadata deep-cloning', () => {
-    it('toCorePart deep-clones metadata even when stripping data_part_compat', () => {
+    it('toCorePart deep-clones metadata on data parts', () => {
       const nested = { list: [1, 2] };
       const compat: legacy.Part = {
         kind: 'data',
-        data: { value: 'wrapped' },
-        metadata: { data_part_compat: true, nested },
+        data: { x: 1 },
+        metadata: { nested },
       };
       const core = toCorePart(compat);
       (core.metadata!.nested as { list: number[] }).list.push(3);

--- a/test/compat/v0_3/translate/push_notifications.spec.ts
+++ b/test/compat/v0_3/translate/push_notifications.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import {
+  toCompatAuthenticationInfo,
+  toCompatPushNotificationConfig,
+  toCompatTaskPushNotificationConfig,
+  toCoreAuthenticationInfo,
+  toCorePushNotificationConfig,
+  toCoreTaskPushNotificationConfig,
+} from '../../../../src/compat/v0_3/translate/push_notifications.js';
+import type { TaskPushNotificationConfig as V1TaskPushNotificationConfig } from '../../../../src/types/pb/a2a.js';
+import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
+
+describe('push_notifications', () => {
+  describe('AuthenticationInfo', () => {
+    it('keeps only the first scheme going to core', () => {
+      const compat: legacy.PushNotificationAuthenticationInfo = {
+        schemes: ['Bearer', 'Basic'],
+        credentials: 'token',
+      };
+      expect(toCoreAuthenticationInfo(compat)).toEqual({ scheme: 'Bearer', credentials: 'token' });
+    });
+
+    it('uses empty string when no schemes are provided', () => {
+      const compat: legacy.PushNotificationAuthenticationInfo = { schemes: [] };
+      expect(toCoreAuthenticationInfo(compat)).toEqual({ scheme: '', credentials: '' });
+    });
+
+    it('wraps the single core scheme into a one-element array going to compat', () => {
+      expect(toCompatAuthenticationInfo({ scheme: 'Bearer', credentials: 'tok' })).toEqual({
+        schemes: ['Bearer'],
+        credentials: 'tok',
+      });
+    });
+
+    it('produces an empty schemes array when the core scheme is empty', () => {
+      expect(toCompatAuthenticationInfo({ scheme: '', credentials: '' })).toEqual({ schemes: [] });
+    });
+
+    it('drops empty credentials going to compat', () => {
+      expect(toCompatAuthenticationInfo({ scheme: 'Bearer', credentials: '' })).toEqual({
+        schemes: ['Bearer'],
+      });
+    });
+  });
+
+  describe('PushNotificationConfig (inner record)', () => {
+    it('converts compat → core with defaults', () => {
+      const compat: legacy.PushNotificationConfig = { url: 'https://notify.example' };
+      const core = toCorePushNotificationConfig(compat);
+      expect(core.url).toBe('https://notify.example');
+      expect(core.id).toBe('');
+      expect(core.token).toBe('');
+      expect(core.authentication).toBeUndefined();
+    });
+
+    it('preserves id, token, and authentication going compat → core', () => {
+      const compat: legacy.PushNotificationConfig = {
+        url: 'https://notify.example',
+        id: 'pnc-1',
+        token: 'tok',
+        authentication: { schemes: ['Bearer'], credentials: 'cred' },
+      };
+      const core = toCorePushNotificationConfig(compat);
+      expect(core.id).toBe('pnc-1');
+      expect(core.token).toBe('tok');
+      expect(core.authentication).toEqual({ scheme: 'Bearer', credentials: 'cred' });
+    });
+
+    it('strips empty fields going core → compat', () => {
+      const core: V1TaskPushNotificationConfig = {
+        tenant: '',
+        taskId: '',
+        id: '',
+        url: 'https://notify.example',
+        token: '',
+        authentication: undefined,
+      };
+      expect(toCompatPushNotificationConfig(core)).toEqual({ url: 'https://notify.example' });
+    });
+
+    it('preserves non-empty fields going core → compat', () => {
+      const core: V1TaskPushNotificationConfig = {
+        tenant: '',
+        taskId: 'task-1',
+        id: 'pnc-1',
+        url: 'https://notify.example',
+        token: 'tok',
+        authentication: { scheme: 'Bearer', credentials: 'cred' },
+      };
+      // The inner-record converter drops taskId.
+      expect(toCompatPushNotificationConfig(core)).toEqual({
+        url: 'https://notify.example',
+        id: 'pnc-1',
+        token: 'tok',
+        authentication: { schemes: ['Bearer'], credentials: 'cred' },
+      });
+    });
+  });
+
+  describe('TaskPushNotificationConfig (nested)', () => {
+    it('flattens nested compat → flat core', () => {
+      const compat: legacy.TaskPushNotificationConfig = {
+        taskId: 'task-1',
+        pushNotificationConfig: {
+          url: 'https://notify.example',
+          id: 'pnc-1',
+          token: 'tok',
+          authentication: { schemes: ['Bearer'], credentials: 'cred' },
+        },
+      };
+      const core = toCoreTaskPushNotificationConfig(compat);
+      expect(core).toEqual({
+        tenant: '',
+        taskId: 'task-1',
+        id: 'pnc-1',
+        url: 'https://notify.example',
+        token: 'tok',
+        authentication: { scheme: 'Bearer', credentials: 'cred' },
+      });
+    });
+
+    it('re-nests flat core → nested compat', () => {
+      const core: V1TaskPushNotificationConfig = {
+        tenant: '',
+        taskId: 'task-1',
+        id: 'pnc-1',
+        url: 'https://notify.example',
+        token: 'tok',
+        authentication: { scheme: 'Bearer', credentials: 'cred' },
+      };
+      expect(toCompatTaskPushNotificationConfig(core)).toEqual({
+        taskId: 'task-1',
+        pushNotificationConfig: {
+          url: 'https://notify.example',
+          id: 'pnc-1',
+          token: 'tok',
+          authentication: { schemes: ['Bearer'], credentials: 'cred' },
+        },
+      });
+    });
+
+    it('round-trips a fully-populated nested config', () => {
+      const compat: legacy.TaskPushNotificationConfig = {
+        taskId: 'task-1',
+        pushNotificationConfig: {
+          url: 'https://notify.example',
+          id: 'pnc-1',
+          token: 'tok',
+          authentication: { schemes: ['Bearer'], credentials: 'cred' },
+        },
+      };
+      expect(toCompatTaskPushNotificationConfig(toCoreTaskPushNotificationConfig(compat))).toEqual(
+        compat
+      );
+    });
+  });
+});

--- a/test/compat/v0_3/translate/push_notifications.spec.ts
+++ b/test/compat/v0_3/translate/push_notifications.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   toCompatAuthenticationInfo,
   toCompatPushNotificationConfig,
@@ -12,17 +12,34 @@ import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
 
 describe('push_notifications', () => {
   describe('AuthenticationInfo', () => {
-    it('keeps only the first scheme going to core', () => {
+    it('keeps only the first scheme going to core and logs a warning', () => {
       const compat: legacy.PushNotificationAuthenticationInfo = {
         schemes: ['Bearer', 'Basic'],
         credentials: 'token',
       };
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
       expect(toCoreAuthenticationInfo(compat)).toEqual({ scheme: 'Bearer', credentials: 'token' });
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenLastCalledWith(
+        expect.stringContaining(
+          'toCoreAuthenticationInfo: Lossy conversion from v0.3 PushNotificationAuthenticationInfo to v1.0 AuthenticationInfo'
+        )
+      );
+
+      warnSpy.mockRestore();
     });
 
-    it('uses empty string when no schemes are provided', () => {
+    it('uses empty string when no schemes are provided and does not warn', () => {
       const compat: legacy.PushNotificationAuthenticationInfo = { schemes: [] };
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
       expect(toCoreAuthenticationInfo(compat)).toEqual({ scheme: '', credentials: '' });
+
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
     });
 
     it('wraps the single core scheme into a one-element array going to compat', () => {

--- a/test/compat/v0_3/translate/requests.spec.ts
+++ b/test/compat/v0_3/translate/requests.spec.ts
@@ -1,0 +1,446 @@
+import { describe, expect, it } from 'vitest';
+import {
+  toCompatCancelTaskRequest,
+  toCompatDeleteTaskPushNotificationConfigRequest,
+  toCompatGetAuthenticatedExtendedCardRequest,
+  toCompatGetTaskPushNotificationConfigRequest,
+  toCompatGetTaskRequest,
+  toCompatListTaskPushNotificationConfigRequest,
+  toCompatListTaskPushNotificationConfigSuccessResponse,
+  toCompatSendMessageRequest,
+  toCompatSendMessageResponse,
+  toCompatSendStreamingMessageRequest,
+  toCompatSendMessageConfiguration,
+  toCompatSetTaskPushNotificationConfigRequest,
+  toCompatStreamResponse,
+  toCompatTaskResubscriptionRequest,
+  toCoreCancelTaskRequest,
+  toCoreCreateTaskPushNotificationConfigRequest,
+  toCoreDeleteTaskPushNotificationConfigRequest,
+  toCoreGetExtendedAgentCardRequest,
+  toCoreGetTaskPushNotificationConfigRequest,
+  toCoreGetTaskRequest,
+  toCoreListTaskPushNotificationConfigsRequest,
+  toCoreListTaskPushNotificationConfigsResponse,
+  toCoreSendMessageConfiguration,
+  toCoreSendMessageRequest,
+  toCoreSendMessageResponse,
+  toCoreStreamResponse,
+  toCoreSubscribeToTaskRequest,
+} from '../../../../src/compat/v0_3/translate/requests.js';
+import { A2AError } from '../../../../src/compat/v0_3/server/error.js';
+import { Role, TaskState } from '../../../../src/types/pb/a2a.js';
+import type {
+  SendMessageRequest as V1SendMessageRequest,
+  SendMessageResponse as V1SendMessageResponse,
+  StreamResponse as V1StreamResponse,
+  TaskPushNotificationConfig as V1TaskPushNotificationConfig,
+} from '../../../../src/types/pb/a2a.js';
+import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
+
+describe('requests', () => {
+  describe('SendMessageConfiguration polarity inversion', () => {
+    it('compat blocking=true → core returnImmediately=false', () => {
+      const core = toCoreSendMessageConfiguration({ blocking: true });
+      expect(core.returnImmediately).toBe(false);
+    });
+
+    it('compat blocking=false → core returnImmediately=true', () => {
+      const core = toCoreSendMessageConfiguration({ blocking: false });
+      expect(core.returnImmediately).toBe(true);
+    });
+
+    it('compat blocking undefined → core returnImmediately=true (v0.3 default is non-blocking)', () => {
+      const core = toCoreSendMessageConfiguration({});
+      expect(core.returnImmediately).toBe(true);
+    });
+
+    it('core returnImmediately=true → compat blocking=false', () => {
+      const compat = toCompatSendMessageConfiguration({
+        acceptedOutputModes: [],
+        taskPushNotificationConfig: undefined,
+        historyLength: undefined,
+        returnImmediately: true,
+      });
+      expect(compat.blocking).toBe(false);
+    });
+
+    it('core returnImmediately=false → compat blocking=true', () => {
+      const compat = toCompatSendMessageConfiguration({
+        acceptedOutputModes: [],
+        taskPushNotificationConfig: undefined,
+        historyLength: undefined,
+        returnImmediately: false,
+      });
+      expect(compat.blocking).toBe(true);
+    });
+
+    it('drops empty acceptedOutputModes going core → compat', () => {
+      const compat = toCompatSendMessageConfiguration({
+        acceptedOutputModes: [],
+        taskPushNotificationConfig: undefined,
+        historyLength: undefined,
+        returnImmediately: false,
+      });
+      expect(compat.acceptedOutputModes).toBeUndefined();
+    });
+  });
+
+  describe('SendMessageRequest', () => {
+    function sampleCompatRequest(): legacy.SendMessageRequest {
+      return {
+        id: 'req-1',
+        jsonrpc: '2.0',
+        method: 'message/send',
+        params: {
+          message: {
+            kind: 'message',
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ kind: 'text', text: 'hi' }],
+          },
+          configuration: { blocking: true },
+          metadata: { source: 'tester' },
+        },
+      };
+    }
+
+    it('unwraps params and translates message + config', () => {
+      const core = toCoreSendMessageRequest(sampleCompatRequest());
+      expect(core.message?.role).toBe(Role.ROLE_USER);
+      expect(core.configuration?.returnImmediately).toBe(false);
+      expect(core.metadata).toEqual({ source: 'tester' });
+    });
+
+    it('builds a v0.3 envelope using the supplied requestId', () => {
+      const core: V1SendMessageRequest = {
+        tenant: '',
+        message: {
+          messageId: 'msg-1',
+          contextId: '',
+          taskId: '',
+          role: Role.ROLE_USER,
+          parts: [],
+          metadata: undefined,
+          extensions: [],
+          referenceTaskIds: [],
+        },
+        configuration: undefined,
+        metadata: undefined,
+      };
+      const compat = toCompatSendMessageRequest(core, 'req-99');
+      expect(compat.id).toBe('req-99');
+      expect(compat.jsonrpc).toBe('2.0');
+      expect(compat.method).toBe('message/send');
+      expect(compat.params.message.messageId).toBe('msg-1');
+    });
+
+    it('uses message/stream when building a streaming envelope', () => {
+      const core: V1SendMessageRequest = {
+        tenant: '',
+        message: {
+          messageId: 'msg-1',
+          contextId: '',
+          taskId: '',
+          role: Role.ROLE_USER,
+          parts: [],
+          metadata: undefined,
+          extensions: [],
+          referenceTaskIds: [],
+        },
+        configuration: undefined,
+        metadata: undefined,
+      };
+      const compat = toCompatSendStreamingMessageRequest(core, 'req-1');
+      expect(compat.method).toBe('message/stream');
+    });
+
+    it('throws when v1 SendMessageRequest is missing the message', () => {
+      expect(() =>
+        toCompatSendMessageRequest(
+          {
+            tenant: '',
+            message: undefined,
+            configuration: undefined,
+            metadata: undefined,
+          },
+          'r1'
+        )
+      ).toThrow(A2AError);
+    });
+  });
+
+  describe('SendMessageResponse', () => {
+    it('translates a task result both ways', () => {
+      const core: V1SendMessageResponse = {
+        payload: {
+          $case: 'task',
+          value: {
+            id: 't-1',
+            contextId: 'ctx',
+            status: {
+              state: TaskState.TASK_STATE_WORKING,
+              message: undefined,
+              timestamp: undefined,
+            },
+            artifacts: [],
+            history: [],
+            metadata: undefined,
+          },
+        },
+      };
+      const compat = toCompatSendMessageResponse(core, 'req-1');
+      expect(compat.id).toBe('req-1');
+      expect((compat.result as legacy.Task2).kind).toBe('task');
+      expect(toCoreSendMessageResponse({ ...compat })).toEqual(core);
+    });
+
+    it('translates a message result both ways', () => {
+      const core: V1SendMessageResponse = {
+        payload: {
+          $case: 'message',
+          value: {
+            messageId: 'm-1',
+            contextId: '',
+            taskId: '',
+            role: Role.ROLE_AGENT,
+            parts: [],
+            metadata: undefined,
+            extensions: [],
+            referenceTaskIds: [],
+          },
+        },
+      };
+      const compat = toCompatSendMessageResponse(core, null);
+      expect((compat.result as legacy.Message1).kind).toBe('message');
+      expect(toCoreSendMessageResponse(compat)).toEqual(core);
+    });
+
+    it('throws when translating an error envelope to core', () => {
+      const compatError: legacy.SendMessageResponse = {
+        jsonrpc: '2.0',
+        id: 'r-1',
+        error: { code: -32603, message: 'boom' } as unknown as legacy.JSONRPCError,
+      };
+      expect(() => toCoreSendMessageResponse(compatError)).toThrow(A2AError);
+    });
+  });
+
+  describe('StreamResponse', () => {
+    it.each<V1StreamResponse['payload']>([
+      {
+        $case: 'message',
+        value: {
+          messageId: 'm-1',
+          contextId: '',
+          taskId: '',
+          role: Role.ROLE_AGENT,
+          parts: [],
+          metadata: undefined,
+          extensions: [],
+          referenceTaskIds: [],
+        },
+      },
+      {
+        $case: 'task',
+        value: {
+          id: 't-1',
+          contextId: 'ctx',
+          status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
+          artifacts: [],
+          history: [],
+          metadata: undefined,
+        },
+      },
+      {
+        $case: 'statusUpdate',
+        value: {
+          taskId: 't-1',
+          contextId: 'ctx',
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: undefined,
+        },
+      },
+      {
+        $case: 'artifactUpdate',
+        value: {
+          taskId: 't-1',
+          contextId: 'ctx',
+          artifact: {
+            artifactId: 'a-1',
+            name: '',
+            description: '',
+            parts: [],
+            metadata: undefined,
+            extensions: [],
+          },
+          append: false,
+          lastChunk: true,
+          metadata: undefined,
+        },
+      },
+    ])('round-trips %#', (payload) => {
+      const core: V1StreamResponse = { payload };
+      const compat = toCompatStreamResponse(core, 'req-1');
+      const back = toCoreStreamResponse(compat);
+      expect(back).toEqual(core);
+    });
+  });
+
+  describe('GetTaskRequest', () => {
+    it('round-trips', () => {
+      const compat: legacy.GetTaskRequest = {
+        id: 'r-1',
+        jsonrpc: '2.0',
+        method: 'tasks/get',
+        params: { id: 't-1', historyLength: 5 },
+      };
+      const core = toCoreGetTaskRequest(compat);
+      expect(core).toEqual({ tenant: '', id: 't-1', historyLength: 5 });
+      expect(toCompatGetTaskRequest(core, 'r-1')).toEqual(compat);
+    });
+  });
+
+  describe('CancelTaskRequest', () => {
+    it('round-trips', () => {
+      const compat: legacy.CancelTaskRequest = {
+        id: 'r-1',
+        jsonrpc: '2.0',
+        method: 'tasks/cancel',
+        params: { id: 't-1', metadata: { reason: 'user-request' } },
+      };
+      expect(toCompatCancelTaskRequest(toCoreCancelTaskRequest(compat), 'r-1')).toEqual(compat);
+    });
+  });
+
+  describe('TaskResubscriptionRequest', () => {
+    it('round-trips', () => {
+      const compat: legacy.TaskResubscriptionRequest = {
+        id: 'r-1',
+        jsonrpc: '2.0',
+        method: 'tasks/resubscribe',
+        params: { id: 't-1' },
+      };
+      expect(
+        toCompatTaskResubscriptionRequest(toCoreSubscribeToTaskRequest(compat), 'r-1')
+      ).toEqual(compat);
+    });
+  });
+
+  describe('SetTaskPushNotificationConfigRequest', () => {
+    it('round-trips', () => {
+      const compat: legacy.SetTaskPushNotificationConfigRequest = {
+        id: 'r-1',
+        jsonrpc: '2.0',
+        method: 'tasks/pushNotificationConfig/set',
+        params: {
+          taskId: 't-1',
+          pushNotificationConfig: {
+            url: 'https://notify.example',
+            id: 'cfg-1',
+            token: 'tok',
+            authentication: { schemes: ['Bearer'], credentials: 'cred' },
+          },
+        },
+      };
+      const core = toCoreCreateTaskPushNotificationConfigRequest(compat);
+      expect(toCompatSetTaskPushNotificationConfigRequest(core, 'r-1')).toEqual(compat);
+    });
+  });
+
+  describe('GetTaskPushNotificationConfigRequest', () => {
+    it('round-trips with explicit pushNotificationConfigId', () => {
+      const compat: legacy.GetTaskPushNotificationConfigRequest = {
+        id: 'r-1',
+        jsonrpc: '2.0',
+        method: 'tasks/pushNotificationConfig/get',
+        params: { id: 't-1', pushNotificationConfigId: 'cfg-1' },
+      };
+      const core = toCoreGetTaskPushNotificationConfigRequest(compat);
+      expect(core).toEqual({ tenant: '', taskId: 't-1', id: 'cfg-1' });
+      expect(toCompatGetTaskPushNotificationConfigRequest(core, 'r-1')).toEqual(compat);
+    });
+
+    it('uses TaskIdParams when no configId is provided', () => {
+      const compat: legacy.GetTaskPushNotificationConfigRequest = {
+        id: 'r-1',
+        jsonrpc: '2.0',
+        method: 'tasks/pushNotificationConfig/get',
+        params: { id: 't-1' },
+      };
+      const core = toCoreGetTaskPushNotificationConfigRequest(compat);
+      expect(core.id).toBe('');
+      const back = toCompatGetTaskPushNotificationConfigRequest(core, 'r-1');
+      expect(back.params).toEqual({ id: 't-1' });
+    });
+  });
+
+  describe('DeleteTaskPushNotificationConfigRequest', () => {
+    it('round-trips', () => {
+      const compat: legacy.DeleteTaskPushNotificationConfigRequest = {
+        id: 'r-1',
+        jsonrpc: '2.0',
+        method: 'tasks/pushNotificationConfig/delete',
+        params: { id: 't-1', pushNotificationConfigId: 'cfg-1' },
+      };
+      expect(
+        toCompatDeleteTaskPushNotificationConfigRequest(
+          toCoreDeleteTaskPushNotificationConfigRequest(compat),
+          'r-1'
+        )
+      ).toEqual(compat);
+    });
+  });
+
+  describe('ListTaskPushNotificationConfigRequest', () => {
+    it('round-trips', () => {
+      const compat: legacy.ListTaskPushNotificationConfigRequest = {
+        id: 'r-1',
+        jsonrpc: '2.0',
+        method: 'tasks/pushNotificationConfig/list',
+        params: { id: 't-1' },
+      };
+      expect(
+        toCompatListTaskPushNotificationConfigRequest(
+          toCoreListTaskPushNotificationConfigsRequest(compat),
+          'r-1'
+        )
+      ).toEqual(compat);
+    });
+  });
+
+  describe('ListTaskPushNotificationConfigSuccessResponse', () => {
+    it('round-trips a list of configs', () => {
+      const cfg: V1TaskPushNotificationConfig = {
+        tenant: '',
+        taskId: 't-1',
+        id: 'cfg-1',
+        url: 'https://notify.example',
+        token: '',
+        authentication: undefined,
+      };
+      const core = { configs: [cfg], nextPageToken: '' };
+      const compat = toCompatListTaskPushNotificationConfigSuccessResponse(core, 'r-1');
+      expect(compat.result).toHaveLength(1);
+      const back = toCoreListTaskPushNotificationConfigsResponse(compat);
+      expect(back.configs).toEqual(core.configs);
+    });
+  });
+
+  describe('GetExtendedAgentCardRequest', () => {
+    it('round-trips', () => {
+      const compat: legacy.GetAuthenticatedExtendedCardRequest = {
+        id: 'r-1',
+        jsonrpc: '2.0',
+        method: 'agent/getAuthenticatedExtendedCard',
+      };
+      const core = toCoreGetExtendedAgentCardRequest(compat);
+      expect(core).toEqual({ tenant: '' });
+      expect(toCompatGetAuthenticatedExtendedCardRequest(core, 'r-1')).toEqual(compat);
+    });
+  });
+});

--- a/test/compat/v0_3/translate/requests.spec.ts
+++ b/test/compat/v0_3/translate/requests.spec.ts
@@ -75,14 +75,23 @@ describe('requests', () => {
       expect(compat.blocking).toBe(true);
     });
 
-    it('drops empty acceptedOutputModes going core → compat', () => {
+    it('preserves empty acceptedOutputModes going core → compat', () => {
       const compat = toCompatSendMessageConfiguration({
         acceptedOutputModes: [],
         taskPushNotificationConfig: undefined,
         historyLength: undefined,
         returnImmediately: false,
       });
-      expect(compat.acceptedOutputModes).toBeUndefined();
+      expect(compat.acceptedOutputModes).toEqual([]);
+    });
+
+    it('round-trips an explicit empty acceptedOutputModes through v1', () => {
+      const compat: legacy.MessageSendConfiguration = {
+        blocking: true,
+        acceptedOutputModes: [],
+      };
+      const back = toCompatSendMessageConfiguration(toCoreSendMessageConfiguration(compat));
+      expect(back.acceptedOutputModes).toEqual([]);
     });
   });
 
@@ -288,6 +297,15 @@ describe('requests', () => {
       const compat = toCompatStreamResponse(core, 'req-1');
       const back = toCoreStreamResponse(compat);
       expect(back).toEqual(core);
+    });
+
+    it('throws when translating an error envelope to core', () => {
+      const compatError: legacy.SendStreamingMessageResponse = {
+        jsonrpc: '2.0',
+        id: 'r-1',
+        error: { code: -32603, message: 'boom' } as unknown as legacy.JSONRPCError,
+      };
+      expect(() => toCoreStreamResponse(compatError)).toThrow(A2AError);
     });
   });
 

--- a/test/compat/v0_3/translate/security.spec.ts
+++ b/test/compat/v0_3/translate/security.spec.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest';
+import {
+  toCompatOAuthFlows,
+  toCompatSecurityRequirement,
+  toCompatSecurityScheme,
+  toCoreOAuthFlows,
+  toCoreSecurityRequirement,
+  toCoreSecurityScheme,
+} from '../../../../src/compat/v0_3/translate/security.js';
+import { A2AError } from '../../../../src/compat/v0_3/server/error.js';
+import type {
+  OAuthFlows as V1OAuthFlows,
+  SecurityScheme as V1SecurityScheme,
+} from '../../../../src/types/pb/a2a.js';
+import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
+
+describe('security', () => {
+  describe('SecurityRequirement', () => {
+    it('wraps and unwraps StringList', () => {
+      const compat = { oauth2: ['read', 'write'] };
+      const core = toCoreSecurityRequirement(compat);
+      expect(core).toEqual({ schemes: { oauth2: { list: ['read', 'write'] } } });
+      expect(toCompatSecurityRequirement(core)).toEqual(compat);
+    });
+  });
+
+  describe('SecurityScheme', () => {
+    it('round-trips an apiKey scheme', () => {
+      const compat: legacy.SecurityScheme = {
+        type: 'apiKey',
+        name: 'X-API-Key',
+        in: 'header',
+        description: 'my key',
+      };
+      expect(toCompatSecurityScheme(toCoreSecurityScheme(compat))).toEqual(compat);
+    });
+
+    it('round-trips an http bearer scheme', () => {
+      const compat: legacy.SecurityScheme = {
+        type: 'http',
+        scheme: 'Bearer',
+        bearerFormat: 'JWT',
+        description: 'http auth',
+      };
+      expect(toCompatSecurityScheme(toCoreSecurityScheme(compat))).toEqual(compat);
+    });
+
+    it('round-trips an mutualTLS scheme', () => {
+      const compat: legacy.SecurityScheme = { type: 'mutualTLS', description: 'mtls' };
+      expect(toCompatSecurityScheme(toCoreSecurityScheme(compat))).toEqual(compat);
+    });
+
+    it('round-trips an openIdConnect scheme', () => {
+      const compat: legacy.SecurityScheme = {
+        type: 'openIdConnect',
+        openIdConnectUrl: 'https://oidc.example/.well-known/openid-configuration',
+      };
+      expect(toCompatSecurityScheme(toCoreSecurityScheme(compat))).toEqual(compat);
+    });
+
+    it('round-trips an oauth2 scheme with one flow', () => {
+      const compat: legacy.SecurityScheme = {
+        type: 'oauth2',
+        flows: {
+          clientCredentials: {
+            tokenUrl: 'https://auth.example/token',
+            scopes: { read: 'Read access' },
+          },
+        },
+      };
+      expect(toCompatSecurityScheme(toCoreSecurityScheme(compat))).toEqual(compat);
+    });
+
+    it('throws when v1.0 OAuth2 scheme has no flows', () => {
+      const core: V1SecurityScheme = {
+        scheme: {
+          $case: 'oauth2SecurityScheme',
+          value: { description: '', flows: undefined, oauth2MetadataUrl: '' },
+        },
+      };
+      expect(() => toCompatSecurityScheme(core)).toThrow(A2AError);
+    });
+
+    it('throws when v1.0 SecurityScheme has no inner scheme', () => {
+      const core: V1SecurityScheme = { scheme: undefined };
+      expect(() => toCompatSecurityScheme(core)).toThrow(A2AError);
+    });
+
+    it('throws for unsupported compat scheme type', () => {
+      const compat = { type: 'magic' } as unknown as legacy.SecurityScheme;
+      expect(() => toCoreSecurityScheme(compat)).toThrow(A2AError);
+    });
+  });
+
+  describe('OAuthFlows', () => {
+    it('round-trips authorizationCode', () => {
+      const compat: legacy.OAuthFlows = {
+        authorizationCode: {
+          authorizationUrl: 'https://auth.example/auth',
+          tokenUrl: 'https://auth.example/token',
+          scopes: { 'read:tasks': 'Read tasks' },
+          refreshUrl: 'https://auth.example/refresh',
+        },
+      };
+      expect(toCompatOAuthFlows(toCoreOAuthFlows(compat))).toEqual(compat);
+    });
+
+    it('round-trips clientCredentials', () => {
+      const compat: legacy.OAuthFlows = {
+        clientCredentials: {
+          tokenUrl: 'https://auth.example/token',
+          scopes: { admin: 'Admin' },
+        },
+      };
+      expect(toCompatOAuthFlows(toCoreOAuthFlows(compat))).toEqual(compat);
+    });
+
+    it('round-trips implicit', () => {
+      const compat: legacy.OAuthFlows = {
+        implicit: {
+          authorizationUrl: 'https://auth.example/auth',
+          scopes: { foo: 'bar' },
+        },
+      };
+      expect(toCompatOAuthFlows(toCoreOAuthFlows(compat))).toEqual(compat);
+    });
+
+    it('round-trips password', () => {
+      const compat: legacy.OAuthFlows = {
+        password: {
+          tokenUrl: 'https://auth.example/token',
+          scopes: { foo: 'bar' },
+        },
+      };
+      expect(toCompatOAuthFlows(toCoreOAuthFlows(compat))).toEqual(compat);
+    });
+
+    it('silently drops deviceCode going to compat', () => {
+      const core: V1OAuthFlows = {
+        flow: {
+          $case: 'deviceCode',
+          value: {
+            deviceAuthorizationUrl: 'https://auth.example/device',
+            tokenUrl: 'https://auth.example/token',
+            refreshUrl: '',
+            scopes: {},
+          },
+        },
+      };
+      expect(toCompatOAuthFlows(core)).toEqual({});
+    });
+
+    it('throws when compat flows are empty going to core', () => {
+      expect(() => toCoreOAuthFlows({})).toThrow(A2AError);
+    });
+  });
+});

--- a/test/compat/v0_3/translate/security.spec.ts
+++ b/test/compat/v0_3/translate/security.spec.ts
@@ -90,6 +90,44 @@ describe('security', () => {
       const compat = { type: 'magic' } as unknown as legacy.SecurityScheme;
       expect(() => toCoreSecurityScheme(compat)).toThrow(A2AError);
     });
+
+    describe('APIKey location handling (v1 → v0.3)', () => {
+      it.each(['cookie', 'header', 'query'] as const)(
+        'preserves valid APIKey location: %s',
+        (loc) => {
+          const core: V1SecurityScheme = {
+            scheme: {
+              $case: 'apiKeySecurityScheme',
+              value: { description: '', location: loc, name: 'X-API-Key' },
+            },
+          };
+          const compat = toCompatSecurityScheme(core) as legacy.APIKeySecurityScheme;
+          expect(compat.in).toBe(loc);
+        }
+      );
+
+      it('coerces an unknown APIKey location to "header"', () => {
+        const core: V1SecurityScheme = {
+          scheme: {
+            $case: 'apiKeySecurityScheme',
+            value: { description: '', location: 'headerz', name: 'X-API-Key' },
+          },
+        };
+        const compat = toCompatSecurityScheme(core) as legacy.APIKeySecurityScheme;
+        expect(compat.in).toBe('header');
+      });
+
+      it('coerces an empty APIKey location to "header"', () => {
+        const core: V1SecurityScheme = {
+          scheme: {
+            $case: 'apiKeySecurityScheme',
+            value: { description: '', location: '', name: 'X-API-Key' },
+          },
+        };
+        const compat = toCompatSecurityScheme(core) as legacy.APIKeySecurityScheme;
+        expect(compat.in).toBe('header');
+      });
+    });
   });
 
   describe('OAuthFlows', () => {

--- a/test/compat/v0_3/translate/tasks.spec.ts
+++ b/test/compat/v0_3/translate/tasks.spec.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+import {
+  toCompatTask,
+  toCompatTaskArtifactUpdateEvent,
+  toCompatTaskStatus,
+  toCompatTaskStatusUpdateEvent,
+  toCoreTask,
+  toCoreTaskArtifactUpdateEvent,
+  toCoreTaskStatus,
+  toCoreTaskStatusUpdateEvent,
+} from '../../../../src/compat/v0_3/translate/tasks.js';
+import { Role, TaskState } from '../../../../src/types/pb/a2a.js';
+import type {
+  Task as V1Task,
+  TaskArtifactUpdateEvent as V1TaskArtifactUpdateEvent,
+  TaskStatus as V1TaskStatus,
+  TaskStatusUpdateEvent as V1TaskStatusUpdateEvent,
+} from '../../../../src/types/pb/a2a.js';
+import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
+
+describe('tasks', () => {
+  describe('TaskStatus', () => {
+    it('round-trips a basic status', () => {
+      const compat: legacy.TaskStatus = { state: 'working', timestamp: '2024-01-01T00:00:00Z' };
+      expect(toCompatTaskStatus(toCoreTaskStatus(compat))).toEqual(compat);
+    });
+
+    it('round-trips a status with a message', () => {
+      const compat: legacy.TaskStatus = {
+        state: 'completed',
+        message: {
+          kind: 'message',
+          messageId: 'm1',
+          role: 'agent',
+          parts: [{ kind: 'text', text: 'done' }],
+        },
+      };
+      expect(toCompatTaskStatus(toCoreTaskStatus(compat))).toEqual(compat);
+    });
+
+    it('drops empty timestamp going to compat', () => {
+      const core: V1TaskStatus = {
+        state: TaskState.TASK_STATE_WORKING,
+        message: undefined,
+        timestamp: '',
+      };
+      expect(toCompatTaskStatus(core)).toEqual({ state: 'working' });
+    });
+  });
+
+  describe('Task', () => {
+    it('round-trips a fully-populated task', () => {
+      const compat: legacy.Task = {
+        kind: 'task',
+        id: 't1',
+        contextId: 'ctx',
+        status: { state: 'submitted' },
+        artifacts: [{ artifactId: 'a1', parts: [{ kind: 'text', text: 'x' }] }],
+        history: [
+          {
+            kind: 'message',
+            messageId: 'm1',
+            role: 'user',
+            parts: [{ kind: 'text', text: 'hi' }],
+          },
+        ],
+        metadata: { k: 'v' },
+      };
+      expect(toCompatTask(toCoreTask(compat))).toEqual(compat);
+    });
+
+    it('replaces a missing status with an unknown placeholder', () => {
+      const core: V1Task = {
+        id: 't1',
+        contextId: 'ctx',
+        status: undefined,
+        artifacts: [],
+        history: [],
+        metadata: undefined,
+      };
+      expect(toCompatTask(core).status).toEqual({ state: 'unknown' });
+    });
+
+    it('prunes empty arrays going to compat', () => {
+      const core: V1Task = {
+        id: 't1',
+        contextId: 'ctx',
+        status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: '' },
+        artifacts: [],
+        history: [],
+        metadata: undefined,
+      };
+      const compat = toCompatTask(core);
+      expect(compat.artifacts).toBeUndefined();
+      expect(compat.history).toBeUndefined();
+      expect(compat.metadata).toBeUndefined();
+    });
+
+    it('coerces missing arrays to empty going to core', () => {
+      const compat: legacy.Task = {
+        kind: 'task',
+        id: 't1',
+        contextId: 'ctx',
+        status: { state: 'working' },
+      };
+      const core = toCoreTask(compat);
+      expect(core.artifacts).toEqual([]);
+      expect(core.history).toEqual([]);
+    });
+  });
+
+  describe('TaskStatusUpdateEvent', () => {
+    it('drops `final` going to core', () => {
+      const compat: legacy.TaskStatusUpdateEvent = {
+        kind: 'status-update',
+        taskId: 't1',
+        contextId: 'ctx',
+        status: { state: 'completed' },
+        final: true,
+      };
+      const core = toCoreTaskStatusUpdateEvent(compat);
+      // v1.0 has no `final` field; presence-check is structural.
+      expect('final' in core).toBe(false);
+      expect(core.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+    });
+
+    it.each<[legacy.TaskStatus['state'], boolean]>([
+      ['completed', true],
+      ['canceled', true],
+      ['failed', true],
+      ['rejected', true],
+      ['working', false],
+      ['submitted', false],
+      ['input-required', false],
+      ['auth-required', false],
+      ['unknown', false],
+    ])('computes final=%s for state=%s going to compat', (state, expected) => {
+      const core: V1TaskStatusUpdateEvent = {
+        taskId: 't1',
+        contextId: 'ctx',
+        status: { state: TaskState.TASK_STATE_UNSPECIFIED, message: undefined, timestamp: '' },
+        metadata: undefined,
+      };
+      // Reuse the table-driven test by translating the literal back into a core enum.
+      const enumValue = (
+        {
+          completed: TaskState.TASK_STATE_COMPLETED,
+          canceled: TaskState.TASK_STATE_CANCELED,
+          failed: TaskState.TASK_STATE_FAILED,
+          rejected: TaskState.TASK_STATE_REJECTED,
+          working: TaskState.TASK_STATE_WORKING,
+          submitted: TaskState.TASK_STATE_SUBMITTED,
+          'input-required': TaskState.TASK_STATE_INPUT_REQUIRED,
+          'auth-required': TaskState.TASK_STATE_AUTH_REQUIRED,
+          unknown: TaskState.TASK_STATE_UNSPECIFIED,
+        } satisfies Record<legacy.TaskStatus['state'], TaskState>
+      )[state];
+      core.status = { state: enumValue, message: undefined, timestamp: '' };
+      expect(toCompatTaskStatusUpdateEvent(core).final).toBe(expected);
+    });
+
+    it('sets the legacy discriminator kind to "status-update"', () => {
+      const core: V1TaskStatusUpdateEvent = {
+        taskId: 't1',
+        contextId: 'ctx',
+        status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: '' },
+        metadata: undefined,
+      };
+      expect(toCompatTaskStatusUpdateEvent(core).kind).toBe('status-update');
+    });
+  });
+
+  describe('TaskArtifactUpdateEvent', () => {
+    it('defaults missing booleans to false going to core', () => {
+      const compat: legacy.TaskArtifactUpdateEvent = {
+        kind: 'artifact-update',
+        taskId: 't1',
+        contextId: 'ctx',
+        artifact: { artifactId: 'a1', parts: [] },
+      };
+      const core = toCoreTaskArtifactUpdateEvent(compat);
+      expect(core.append).toBe(false);
+      expect(core.lastChunk).toBe(false);
+    });
+
+    it('preserves explicit booleans going to compat', () => {
+      const core: V1TaskArtifactUpdateEvent = {
+        taskId: 't1',
+        contextId: 'ctx',
+        artifact: {
+          artifactId: 'a1',
+          name: '',
+          description: '',
+          parts: [],
+          metadata: undefined,
+          extensions: [],
+        },
+        append: true,
+        lastChunk: false,
+        metadata: undefined,
+      };
+      const compat = toCompatTaskArtifactUpdateEvent(core);
+      expect(compat.kind).toBe('artifact-update');
+      expect(compat.append).toBe(true);
+      expect(compat.lastChunk).toBe(false);
+    });
+
+    it('throws when the artifact is missing', () => {
+      const core: V1TaskArtifactUpdateEvent = {
+        taskId: 't1',
+        contextId: 'ctx',
+        artifact: undefined,
+        append: false,
+        lastChunk: false,
+        metadata: undefined,
+      };
+      expect(() => toCompatTaskArtifactUpdateEvent(core)).toThrow();
+    });
+
+    it('uses the right discriminator kind', () => {
+      const compat: legacy.TaskArtifactUpdateEvent = {
+        kind: 'artifact-update',
+        taskId: 't1',
+        contextId: 'ctx',
+        artifact: { artifactId: 'a1', parts: [] },
+      };
+      const core = toCoreTaskArtifactUpdateEvent(compat);
+      expect(toCompatTaskArtifactUpdateEvent(core).kind).toBe('artifact-update');
+    });
+  });
+
+  describe('round-tripping', () => {
+    it('round-trips a message inside a task', () => {
+      const compat: legacy.Task = {
+        kind: 'task',
+        id: 't1',
+        contextId: 'ctx',
+        status: {
+          state: 'working',
+          message: {
+            kind: 'message',
+            messageId: 'm1',
+            role: Role.ROLE_USER === 1 ? 'user' : 'agent',
+            parts: [{ kind: 'text', text: 'x' }],
+          },
+        },
+      };
+      expect(toCompatTask(toCoreTask(compat))).toEqual(compat);
+    });
+  });
+});

--- a/test/compat/v0_3/translate/versions.spec.ts
+++ b/test/compat/v0_3/translate/versions.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PROTOCOL_VERSION_0_3,
+  PROTOCOL_VERSION_1_0,
+  isLegacyVersion,
+} from '../../../../src/compat/v0_3/translate/versions.js';
+
+describe('versions', () => {
+  describe('constants', () => {
+    it('exposes the v0.3 protocol version string', () => {
+      expect(PROTOCOL_VERSION_0_3).toBe('0.3');
+    });
+
+    it('exposes the v1.0 protocol version string', () => {
+      expect(PROTOCOL_VERSION_1_0).toBe('1.0');
+    });
+  });
+
+  describe('isLegacyVersion', () => {
+    it('returns true for the legacy version itself', () => {
+      expect(isLegacyVersion('0.3')).toBe(true);
+    });
+
+    it('returns true for 0.3.5 (patch-level legacy)', () => {
+      expect(isLegacyVersion('0.3.5')).toBe(true);
+    });
+
+    it('returns true for 0.9 (still <1.0)', () => {
+      expect(isLegacyVersion('0.9')).toBe(true);
+    });
+
+    it('returns false for 1.0', () => {
+      expect(isLegacyVersion('1.0')).toBe(false);
+    });
+
+    it('returns false for newer 1.x', () => {
+      expect(isLegacyVersion('1.0.1')).toBe(false);
+      expect(isLegacyVersion('1.5')).toBe(false);
+      expect(isLegacyVersion('2.0')).toBe(false);
+    });
+
+    it('returns false for pre-0.3 versions', () => {
+      expect(isLegacyVersion('0.2')).toBe(false);
+      expect(isLegacyVersion('0.0')).toBe(false);
+    });
+
+    it('returns false for an empty string', () => {
+      expect(isLegacyVersion('')).toBe(false);
+    });
+
+    it('returns false for null/undefined', () => {
+      expect(isLegacyVersion(null)).toBe(false);
+      expect(isLegacyVersion(undefined)).toBe(false);
+    });
+
+    it('returns false for unparseable strings', () => {
+      expect(isLegacyVersion('not-a-version')).toBe(false);
+      expect(isLegacyVersion('abc.def')).toBe(false);
+      expect(isLegacyVersion('-1.0')).toBe(false);
+    });
+
+    it('treats single-component major as M.0', () => {
+      // "0" -> 0.0 -> not legacy
+      expect(isLegacyVersion('0')).toBe(false);
+      // "1" -> 1.0 -> not legacy
+      expect(isLegacyVersion('1')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
# Description

This PR introduces translatios for v0_3 compatibility layer

The `translate/` subdirectory contains bidirectional payload translators between the modern v1.0 protobuf types (in `src/types/pb/a2a.ts`) and the legacy v0.3 JSON types (in `src/compat/v0_3/types/types.ts`).

The naming convention is direction-anchored:

- `toCore<Entity>` converts a v0.3 value into the equivalent v1.0 proto value.
- `toCompat<Entity>` converts a v1.0 proto value into the equivalent v0.3 JSON value.

Translators are split per entity group (`parts.ts`, `messages.ts`, `tasks.ts`, `push_notifications.ts`, `security.ts`, `agent_card.ts`, `requests.ts`, `enums.ts`, `versions.ts`) for clarity and tree-shaking. The full surface is re-exported from `translate/index.ts`.

Notable policy decisions based on [A2A Python SDK compat layer](https://github.com/a2aproject/a2a-python/tree/main/src/a2a/compat/v0_3):

- `PushNotificationAuthenticationInfo.schemes` is truncated to a single scheme going v0.3 → v1.0; only the first entry is kept.
- The v1.0 `OAuthFlows.deviceCode` flow is silently dropped going v1.0 → v0.3 (v0.3 has no equivalent).
- `TaskStatusUpdateEvent.final` is computed from the status state going v1.0 → v0.3 (`true` for `completed`, `canceled`, `failed`, `rejected`).
- `SendMessageConfiguration.returnImmediately` ↔ `MessageSendConfiguration.blocking` with inverted polarity.
- `toCompatAgentCard` filters `supportedInterfaces` to those whose `protocolVersion` is empty or in `[0.3, 1.0)` and throws `VersionNotSupportedError` if none qualify.

Closes #473 🦕
