### PR TITLE
feat: implement legacy v0.3 JSON-RPC transport handler

### DIFF
--- a/src/compat/v0_3/constants.ts
+++ b/src/compat/v0_3/constants.ts
@@ -155,6 +155,17 @@ export function legacyJsonRpcToV1Method(method: string): string {
 }
 
 /**
+ * Returns `true` if `method` is a known v0.3 JSON-RPC method name.
+ *
+ * Used by the Express JSON-RPC handler to route incoming requests to either
+ * the v1.0 dispatcher (`JsonRpcTransportHandler`) or the v0.3 compat
+ * dispatcher (`LegacyJsonRpcTransportHandler`).
+ */
+export function isLegacyJsonRpcMethod(method: unknown): boolean {
+  return typeof method === 'string' && method in LEGACY_JSONRPC_TO_V1;
+}
+
+/**
  * Translate a v1.0 PascalCase method name to its v0.3 JSON-RPC equivalent.
  *
  * Throws `A2AError.unsupportedOperation` (-32004) if `method` is a v1.0 name

--- a/src/compat/v0_3/index.ts
+++ b/src/compat/v0_3/index.ts
@@ -5,4 +5,4 @@
 
 export * from './constants.js';
 export * from './translate/index.js';
-export { A2AError as LegacyA2AError } from './server/error.js';
+export * from './server/index.js';

--- a/src/compat/v0_3/server/index.ts
+++ b/src/compat/v0_3/server/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Compat-layer server components for v0.3 handlers.
+ */
+
+export { A2AError as LegacyA2AError } from './error.js';
+export { LegacyJsonRpcTransportHandler } from './transports/jsonrpc/jsonrpc_transport_handler.js';

--- a/src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -1,0 +1,355 @@
+/**
+ * v0.3 JSON-RPC transport handler.
+ *
+ * Mirrors `JsonRpcTransportHandler` (the v1.0 handler) but accepts v0.3
+ * method names (e.g. `message/send`, `tasks/get`) and v0.3-shaped params.
+ * Inbound params are translated to v1.0 proto values via the `toCore*`
+ * helpers in `../../../translate/requests.js`, dispatched to the v1.0
+ * `A2ARequestHandler`, and translated back to v0.3 JSON via the
+ * `toCompat*` helpers before being wrapped in a JSON-RPC envelope.
+ *
+ * Designed to share a transport with the v1.0 handler: the Express
+ * dispatcher selects between the two based on the method name (see
+ * `isLegacyJsonRpcMethod`).
+ */
+import {
+  A2A_ERROR_CODE,
+  ContentTypeNotSupportedError,
+  ExtendedAgentCardNotConfiguredError,
+  ExtensionSupportRequiredError,
+  GenericError,
+  InvalidAgentResponseError,
+  PushNotificationNotSupportedError,
+  RequestMalformedError,
+  TaskNotCancelableError,
+  TaskNotFoundError,
+  UnsupportedOperationError,
+  VersionNotSupportedError,
+} from '../../../../../errors.js';
+import type { ServerCallContext } from '../../../../../server/context.js';
+import type { A2ARequestHandler } from '../../../../../server/request_handler/a2a_request_handler.js';
+import { toCompatAgentCard } from '../../../translate/agent_card.js';
+import { toCompatMessage } from '../../../translate/messages.js';
+import { toCompatTaskPushNotificationConfig } from '../../../translate/push_notifications.js';
+import {
+  toCompatListTaskPushNotificationConfigSuccessResponse,
+  toCompatStreamResponse,
+  toCoreCancelTaskRequest,
+  toCoreCreateTaskPushNotificationConfigRequest,
+  toCoreDeleteTaskPushNotificationConfigRequest,
+  toCoreGetExtendedAgentCardRequest,
+  toCoreGetTaskPushNotificationConfigRequest,
+  toCoreGetTaskRequest,
+  toCoreListTaskPushNotificationConfigsRequest,
+  toCoreSendMessageRequest,
+  toCoreSubscribeToTaskRequest,
+} from '../../../translate/requests.js';
+import { toCompatTask } from '../../../translate/tasks.js';
+import type * as legacy from '../../../types/types.js';
+import type { Message as V1Message, Task as V1Task } from '../../../../../types/pb/a2a.js';
+import { A2AError } from '../../error.js';
+
+/**
+ * Minimal v0.3 JSON-RPC request envelope shape used by the handler.
+ */
+type LegacyA2ARequest = {
+  jsonrpc: '2.0';
+  method: string;
+  params?: unknown;
+  id?: string | number | null;
+};
+
+/**
+ * Minimal v0.3 JSON-RPC response envelope shape used by the handler.
+ *
+ * Both success and error responses use this shape; `result` and `error`
+ * are mutually exclusive.
+ */
+type LegacyJSONRPCResponse = {
+  jsonrpc: '2.0';
+  id: string | number | null;
+  result?: unknown;
+  error?: legacy.JSONRPCError;
+};
+
+/**
+ * Handles incoming v0.3 JSON-RPC requests by translating them to v1.0
+ * proto, dispatching to a v1.0 `A2ARequestHandler`, and translating
+ * responses back to the v0.3 JSON wire shape.
+ */
+export class LegacyJsonRpcTransportHandler {
+  private requestHandler: A2ARequestHandler;
+
+  constructor(requestHandler: A2ARequestHandler) {
+    this.requestHandler = requestHandler;
+  }
+
+  /**
+   * Handles an incoming v0.3 JSON-RPC request.
+   *
+   * For streaming methods (`message/stream`, `tasks/resubscribe`),
+   * returns an `AsyncGenerator` of v0.3-shaped JSON-RPC envelopes.
+   * For non-streaming methods, returns a single envelope (either a
+   * success response or a v0.3 error response).
+   */
+  public async handle(
+    requestBody: string | Record<string, unknown>,
+    context: ServerCallContext
+  ): Promise<LegacyJSONRPCResponse | AsyncGenerator<LegacyJSONRPCResponse, void, undefined>> {
+    let rpcRequest: LegacyA2ARequest = { jsonrpc: '2.0', method: '' };
+    try {
+      if (typeof requestBody === 'string') {
+        rpcRequest = JSON.parse(requestBody);
+      } else if (typeof requestBody === 'object' && requestBody !== null) {
+        rpcRequest = requestBody as LegacyA2ARequest;
+      } else {
+        throw A2AError.invalidRequest('Invalid request body type.');
+      }
+
+      if (!this.isRequestValid(rpcRequest)) {
+        throw A2AError.invalidRequest('Invalid JSON-RPC Request.');
+      }
+    } catch (error) {
+      const mappedError = LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError(
+        error instanceof SyntaxError
+          ? A2AError.invalidRequest(error.message || 'Failed to parse JSON request.')
+          : error
+      );
+      return {
+        jsonrpc: '2.0',
+        id: rpcRequest.id ?? null,
+        error: mappedError,
+      };
+    }
+
+    const { method, id: requestId = null } = rpcRequest;
+    try {
+      // `agent/getAuthenticatedExtendedCard` carries no params; every other
+      // legacy method requires a params object.
+      if (
+        method !== 'agent/getAuthenticatedExtendedCard' &&
+        !this.paramsAreValid(rpcRequest.params)
+      ) {
+        throw A2AError.invalidParams('Invalid method parameters.');
+      }
+
+      if (method === 'message/stream' || method === 'tasks/resubscribe') {
+        const agentCard = await this.requestHandler.getAgentCard();
+        if (!agentCard.capabilities?.streaming) {
+          throw A2AError.unsupportedOperation(`Method ${method} requires streaming capability.`);
+        }
+        const agentEventStream =
+          method === 'message/stream'
+            ? this.requestHandler.sendMessageStream(
+                toCoreSendMessageRequest(rpcRequest as legacy.SendStreamingMessageRequest),
+                context
+              )
+            : this.requestHandler.resubscribe(
+                toCoreSubscribeToTaskRequest(rpcRequest as legacy.TaskResubscriptionRequest),
+                context
+              );
+
+        return (async function* legacyJsonRpcEventStream(): AsyncGenerator<
+          LegacyJSONRPCResponse,
+          void,
+          undefined
+        > {
+          try {
+            for await (const event of agentEventStream) {
+              const compat = toCompatStreamResponse(event, requestId);
+              yield {
+                jsonrpc: '2.0',
+                id: requestId,
+                result: compat.result,
+              };
+            }
+          } catch (streamError) {
+            console.error(
+              `Error in agent event stream for ${method} (request ${requestId}):`,
+              streamError
+            );
+            throw streamError;
+          }
+        })();
+      }
+
+      let result: unknown;
+      switch (method) {
+        case 'message/send': {
+          const messageOrTask = await this.requestHandler.sendMessage(
+            toCoreSendMessageRequest(rpcRequest as legacy.SendMessageRequest),
+            context
+          );
+          result =
+            'messageId' in messageOrTask
+              ? toCompatMessage(messageOrTask as V1Message)
+              : toCompatTask(messageOrTask as V1Task);
+          break;
+        }
+        case 'tasks/get':
+          result = toCompatTask(
+            await this.requestHandler.getTask(
+              toCoreGetTaskRequest(rpcRequest as legacy.GetTaskRequest),
+              context
+            )
+          );
+          break;
+        case 'tasks/cancel':
+          result = toCompatTask(
+            await this.requestHandler.cancelTask(
+              toCoreCancelTaskRequest(rpcRequest as legacy.CancelTaskRequest),
+              context
+            )
+          );
+          break;
+        case 'tasks/pushNotificationConfig/set':
+          result = toCompatTaskPushNotificationConfig(
+            await this.requestHandler.createTaskPushNotificationConfig(
+              toCoreCreateTaskPushNotificationConfigRequest(
+                rpcRequest as legacy.SetTaskPushNotificationConfigRequest
+              ),
+              context
+            )
+          );
+          break;
+        case 'tasks/pushNotificationConfig/get':
+          result = toCompatTaskPushNotificationConfig(
+            await this.requestHandler.getTaskPushNotificationConfig(
+              toCoreGetTaskPushNotificationConfigRequest(
+                rpcRequest as legacy.GetTaskPushNotificationConfigRequest
+              ),
+              context
+            )
+          );
+          break;
+        case 'tasks/pushNotificationConfig/list': {
+          const listResponse = toCompatListTaskPushNotificationConfigSuccessResponse(
+            await this.requestHandler.listTaskPushNotificationConfigs(
+              toCoreListTaskPushNotificationConfigsRequest(
+                rpcRequest as legacy.ListTaskPushNotificationConfigRequest
+              ),
+              context
+            ),
+            requestId
+          );
+          result = listResponse.result;
+          break;
+        }
+        case 'tasks/pushNotificationConfig/delete':
+          await this.requestHandler.deleteTaskPushNotificationConfig(
+            toCoreDeleteTaskPushNotificationConfigRequest(
+              rpcRequest as legacy.DeleteTaskPushNotificationConfigRequest
+            ),
+            context
+          );
+          result = null;
+          break;
+        case 'agent/getAuthenticatedExtendedCard':
+          result = toCompatAgentCard(
+            await this.requestHandler.getAuthenticatedExtendedAgentCard(
+              toCoreGetExtendedAgentCardRequest(
+                rpcRequest as legacy.GetAuthenticatedExtendedCardRequest
+              ),
+              context
+            )
+          );
+          break;
+        default:
+          throw A2AError.methodNotFound(method);
+      }
+
+      return {
+        jsonrpc: '2.0',
+        id: requestId,
+        result,
+      };
+    } catch (error) {
+      return {
+        jsonrpc: '2.0',
+        id: requestId,
+        error: LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError(error),
+      };
+    }
+  }
+
+  /** Validates the basic structure of a JSON-RPC request. */
+  private isRequestValid(rpcRequest: LegacyA2ARequest): boolean {
+    if (rpcRequest.jsonrpc !== '2.0') {
+      return false;
+    }
+    if ('id' in rpcRequest) {
+      const id = rpcRequest.id;
+      const isString = typeof id === 'string';
+      const isInteger = typeof id === 'number' && Number.isInteger(id);
+      const isNull = id === null;
+
+      if (!isString && !isInteger && !isNull) {
+        return false;
+      }
+    }
+    if (!rpcRequest.method || typeof rpcRequest.method !== 'string') {
+      return false;
+    }
+
+    return true;
+  }
+
+  /** Validates that `params` is a non-null, non-array object with no empty keys. */
+  private paramsAreValid(params: unknown): boolean {
+    if (typeof params !== 'object' || params === null || Array.isArray(params)) {
+      return false;
+    }
+
+    for (const key of Object.keys(params)) {
+      if (key === '') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Maps an error to a v0.3-shaped `JSONRPCError`.
+   *
+   * Unlike the v1.0 handler, v0.3 typed `JSONRPCError.data` as a plain
+   * `Record<string, unknown>` rather than the structured `ErrorDetail[]`
+   * array introduced in v1.0. To keep the response wire-compatible with
+   * v0.3 clients, this mapper deliberately omits the `data` field even
+   * when the source error would have carried structured details on the
+   * v1.0 path.
+   *
+   * `LegacyA2AError` instances are passed through unchanged via
+   * `toJSONRPCError()`. v1.0 SDK error classes
+   * (`TaskNotFoundError`, …) are mapped to their corresponding numeric
+   * codes (which are identical between v0.3 and v1.0 for the codes that
+   * exist in both). Unknown errors fall through to `INTERNAL_ERROR`.
+   */
+  public static mapToLegacyJSONRPCError(error: unknown): legacy.JSONRPCError {
+    if (error instanceof A2AError) {
+      return error.toJSONRPCError();
+    }
+
+    const codeMap: Array<[abstract new (...args: never[]) => Error, number]> = [
+      [TaskNotFoundError, A2A_ERROR_CODE.TASK_NOT_FOUND],
+      [TaskNotCancelableError, A2A_ERROR_CODE.TASK_NOT_CANCELABLE],
+      [PushNotificationNotSupportedError, A2A_ERROR_CODE.PUSH_NOTIFICATION_NOT_SUPPORTED],
+      [UnsupportedOperationError, A2A_ERROR_CODE.UNSUPPORTED_OPERATION],
+      [ContentTypeNotSupportedError, A2A_ERROR_CODE.CONTENT_TYPE_NOT_SUPPORTED],
+      [InvalidAgentResponseError, A2A_ERROR_CODE.INVALID_AGENT_RESPONSE],
+      [ExtendedAgentCardNotConfiguredError, A2A_ERROR_CODE.EXTENDED_CARD_NOT_CONFIGURED],
+      [ExtensionSupportRequiredError, A2A_ERROR_CODE.EXTENSION_SUPPORT_REQUIRED],
+      [VersionNotSupportedError, A2A_ERROR_CODE.VERSION_NOT_SUPPORTED],
+      [RequestMalformedError, A2A_ERROR_CODE.INVALID_PARAMS],
+      [GenericError, A2A_ERROR_CODE.INTERNAL_ERROR],
+    ];
+
+    for (const [ErrorClass, code] of codeMap) {
+      if (error instanceof ErrorClass) {
+        return { code, message: error.message };
+      }
+    }
+
+    const message = (error instanceof Error && error.message) || 'An unexpected error occurred.';
+    return { code: A2A_ERROR_CODE.INTERNAL_ERROR, message };
+  }
+}

--- a/src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -12,20 +12,7 @@
  * dispatcher selects between the two based on the method name (see
  * `isLegacyJsonRpcMethod`).
  */
-import {
-  A2A_ERROR_CODE,
-  ContentTypeNotSupportedError,
-  ExtendedAgentCardNotConfiguredError,
-  ExtensionSupportRequiredError,
-  GenericError,
-  InvalidAgentResponseError,
-  PushNotificationNotSupportedError,
-  RequestMalformedError,
-  TaskNotCancelableError,
-  TaskNotFoundError,
-  UnsupportedOperationError,
-  VersionNotSupportedError,
-} from '../../../../../errors.js';
+import { A2A_ERROR_CLASS_TO_CODE, A2A_ERROR_CODE } from '../../../../../errors.js';
 import type { ServerCallContext } from '../../../../../server/context.js';
 import type { A2ARequestHandler } from '../../../../../server/request_handler/a2a_request_handler.js';
 import { toCompatAgentCard } from '../../../translate/agent_card.js';
@@ -328,23 +315,9 @@ export class LegacyJsonRpcTransportHandler {
     if (error instanceof A2AError) {
       return error.toJSONRPCError();
     }
-
-    const codeMap: Array<[abstract new (...args: never[]) => Error, number]> = [
-      [TaskNotFoundError, A2A_ERROR_CODE.TASK_NOT_FOUND],
-      [TaskNotCancelableError, A2A_ERROR_CODE.TASK_NOT_CANCELABLE],
-      [PushNotificationNotSupportedError, A2A_ERROR_CODE.PUSH_NOTIFICATION_NOT_SUPPORTED],
-      [UnsupportedOperationError, A2A_ERROR_CODE.UNSUPPORTED_OPERATION],
-      [ContentTypeNotSupportedError, A2A_ERROR_CODE.CONTENT_TYPE_NOT_SUPPORTED],
-      [InvalidAgentResponseError, A2A_ERROR_CODE.INVALID_AGENT_RESPONSE],
-      [ExtendedAgentCardNotConfiguredError, A2A_ERROR_CODE.EXTENDED_CARD_NOT_CONFIGURED],
-      [ExtensionSupportRequiredError, A2A_ERROR_CODE.EXTENSION_SUPPORT_REQUIRED],
-      [VersionNotSupportedError, A2A_ERROR_CODE.VERSION_NOT_SUPPORTED],
-      [RequestMalformedError, A2A_ERROR_CODE.INVALID_PARAMS],
-      [GenericError, A2A_ERROR_CODE.INTERNAL_ERROR],
-    ];
-
-    for (const [ErrorClass, code] of codeMap) {
-      if (error instanceof ErrorClass) {
+    if (error instanceof Error) {
+      const code = A2A_ERROR_CLASS_TO_CODE[error.name];
+      if (code !== undefined) {
         return { code, message: error.message };
       }
     }

--- a/src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -143,12 +143,7 @@ export class LegacyJsonRpcTransportHandler {
         > {
           try {
             for await (const event of agentEventStream) {
-              const compat = toCompatStreamResponse(event, requestId);
-              yield {
-                jsonrpc: '2.0',
-                id: requestId,
-                result: compat.result,
-              };
+              yield toCompatStreamResponse(event, requestId);
             }
           } catch (streamError) {
             console.error(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -105,6 +105,19 @@ export const A2A_ERROR_CODE_TO_CLASS: Record<number, string> = {
 };
 
 /**
+ * Maps error class names to their JSON-RPC error codes.
+ *
+ * Inverse of {@link A2A_ERROR_CODE_TO_CLASS}. Used by JSON-RPC transport
+ * handlers (v1.0 and v0.3 compat) to resolve an error instance to the
+ * numeric code carried in the response envelope's `error.code` field.
+ * The lookup is keyed on `error.name`, consistent with how
+ * `buildErrorInfo` resolves errors to `ErrorInfo.reason`.
+ */
+export const A2A_ERROR_CLASS_TO_CODE: Record<string, number> = Object.fromEntries(
+  Object.entries(A2A_ERROR_CODE_TO_CLASS).map(([code, cls]) => [cls, Number(code)])
+);
+
+/**
  * Builds a `google.rpc.ErrorInfo` detail object from an error instance.
  *
  * @param error - The error to build ErrorInfo from.

--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -16,10 +16,25 @@ import { SSE_HEADERS, formatSSEEvent, formatSSEErrorEvent } from '../../sse_util
 import { Extensions } from '../../extensions.js';
 import { RequestMalformedError } from '../../errors.js';
 import { validateVersion } from '../version.js';
+import { LegacyJsonRpcTransportHandler, isLegacyJsonRpcMethod } from '../../compat/v0_3/index.js';
 
 export interface JsonRpcHandlerOptions {
   requestHandler: A2ARequestHandler;
   userBuilder: UserBuilder;
+}
+
+/**
+ * Returns `true` if the request body looks like a v0.3 JSON-RPC request
+ * (i.e. its `method` field is one of the known v0.3 method names).
+ *
+ * Detection is based on the method name alone; v1.0 method names are
+ * PascalCase identifiers (`SendMessage`, `GetTask`) and v0.3 method
+ * names are `namespace/verb` strings (`message/send`, `tasks/get`), so
+ * the two grammars are disjoint.
+ */
+function isLegacyRequest(body: unknown): boolean {
+  if (typeof body !== 'object' || body === null) return false;
+  return isLegacyJsonRpcMethod((body as { method?: unknown }).method);
 }
 
 /**
@@ -35,12 +50,17 @@ export interface JsonRpcHandlerOptions {
  */
 export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
   const jsonRpcTransportHandler = new JsonRpcTransportHandler(options.requestHandler);
+  const legacyJsonRpcTransportHandler = new LegacyJsonRpcTransportHandler(options.requestHandler);
 
   const router = express.Router();
 
   router.use(express.json(), jsonErrorHandler);
 
   router.post('/', async (req: Request, res: Response) => {
+    const useLegacy = isLegacyRequest(req.body);
+    const mapToError = useLegacy
+      ? LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError
+      : JsonRpcTransportHandler.mapToJSONRPCError;
     try {
       const user = await options.userBuilder(req);
       const requestedVersion = req.header(A2A_VERSION_HEADER) || undefined;
@@ -50,8 +70,14 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
         requestedVersion,
       });
       const agentCard = await options.requestHandler.getAgentCard();
+      // The agent card is the single source of truth for which protocol
+      // versions this transport accepts. `requestedVersion` defaults to
+      // '0.3' when the A2A-Version header is absent (§3.6.2), so a
+      // header-less legacy client will only succeed if the card declares
+      // a v0.3 JSONRPC interface.
       validateVersion(context.requestedVersion, agentCard, 'JSONRPC');
-      const rpcResponseOrStream = await jsonRpcTransportHandler.handle(req.body, context);
+      const transportHandler = useLegacy ? legacyJsonRpcTransportHandler : jsonRpcTransportHandler;
+      const rpcResponseOrStream = await transportHandler.handle(req.body, context);
 
       if (context.activatedExtensions) {
         res.setHeader(HTTP_EXTENSION_HEADER, Array.from(context.activatedExtensions));
@@ -78,7 +104,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
           const errorResponse: JSONRPCErrorResponse = {
             jsonrpc: '2.0',
             id: req.body?.id || null, // Use original request ID if available
-            error: JsonRpcTransportHandler.mapToJSONRPCError(streamError),
+            error: mapToError(streamError),
           };
           if (!res.headersSent) {
             // Should not happen if flushHeaders worked
@@ -104,7 +130,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
       const errorResponse: JSONRPCErrorResponse = {
         jsonrpc: '2.0',
         id: req.body?.id || null,
-        error: JsonRpcTransportHandler.mapToJSONRPCError(error),
+        error: mapToError(error),
       };
       if (!res.headersSent) {
         res.status(500).json(errorResponse);

--- a/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -17,20 +17,12 @@ import {
   AgentCard,
 } from '../../../index.js';
 import {
+  A2A_ERROR_CLASS_TO_CODE,
   A2A_ERROR_CODE,
   RequestMalformedError,
-  TaskNotFoundError,
-  TaskNotCancelableError,
-  PushNotificationNotSupportedError,
   UnsupportedOperationError,
-  ContentTypeNotSupportedError,
-  InvalidAgentResponseError,
-  GenericError,
-  VersionNotSupportedError,
-  ExtendedAgentCardNotConfiguredError,
   buildErrorInfo,
   type ErrorDetail,
-  ExtensionSupportRequiredError,
 } from '../../../errors.js';
 import { JSONRPCErrorResponse } from '../../../core.js';
 
@@ -294,22 +286,9 @@ export class JsonRpcTransportHandler {
     message: string;
     data?: ErrorDetail[];
   } {
-    const codeMap: Array<[abstract new (...args: never[]) => Error, number]> = [
-      [TaskNotFoundError, A2A_ERROR_CODE.TASK_NOT_FOUND],
-      [TaskNotCancelableError, A2A_ERROR_CODE.TASK_NOT_CANCELABLE],
-      [PushNotificationNotSupportedError, A2A_ERROR_CODE.PUSH_NOTIFICATION_NOT_SUPPORTED],
-      [UnsupportedOperationError, A2A_ERROR_CODE.UNSUPPORTED_OPERATION],
-      [ContentTypeNotSupportedError, A2A_ERROR_CODE.CONTENT_TYPE_NOT_SUPPORTED],
-      [InvalidAgentResponseError, A2A_ERROR_CODE.INVALID_AGENT_RESPONSE],
-      [ExtendedAgentCardNotConfiguredError, A2A_ERROR_CODE.EXTENDED_CARD_NOT_CONFIGURED],
-      [ExtensionSupportRequiredError, A2A_ERROR_CODE.EXTENSION_SUPPORT_REQUIRED],
-      [VersionNotSupportedError, A2A_ERROR_CODE.VERSION_NOT_SUPPORTED],
-      [RequestMalformedError, A2A_ERROR_CODE.INVALID_PARAMS],
-      [GenericError, A2A_ERROR_CODE.INTERNAL_ERROR],
-    ];
-
-    for (const [ErrorClass, code] of codeMap) {
-      if (error instanceof ErrorClass) {
+    if (error instanceof Error) {
+      const code = A2A_ERROR_CLASS_TO_CODE[error.name];
+      if (code !== undefined) {
         const data: ErrorDetail[] = [];
         const errorInfo = buildErrorInfo(error);
         if (errorInfo) data.push(errorInfo);

--- a/test/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.spec.ts
+++ b/test/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.spec.ts
@@ -1,0 +1,621 @@
+import { describe, it, beforeEach, afterEach, expect, vi, type Mock } from 'vitest';
+
+import { LegacyJsonRpcTransportHandler } from '../../../../../../src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.js';
+import { A2AError as LegacyA2AError } from '../../../../../../src/compat/v0_3/server/error.js';
+import { A2ARequestHandler } from '../../../../../../src/server/request_handler/a2a_request_handler.js';
+import { ServerCallContext } from '../../../../../../src/server/context.js';
+import {
+  ContentTypeNotSupportedError,
+  ExtendedAgentCardNotConfiguredError,
+  ExtensionSupportRequiredError,
+  GenericError,
+  InvalidAgentResponseError,
+  PushNotificationNotSupportedError,
+  RequestMalformedError,
+  TaskNotCancelableError,
+  TaskNotFoundError,
+  UnsupportedOperationError,
+  VersionNotSupportedError,
+} from '../../../../../../src/errors.js';
+import { Role, TaskState } from '../../../../../../src/types/pb/a2a.js';
+import type {
+  AgentCard as V1AgentCard,
+  Message as V1Message,
+  StreamResponse as V1StreamResponse,
+  Task as V1Task,
+  TaskPushNotificationConfig as V1TaskPushNotificationConfig,
+} from '../../../../../../src/types/pb/a2a.js';
+import type * as legacy from '../../../../../../src/compat/v0_3/types/types.js';
+
+describe('LegacyJsonRpcTransportHandler', () => {
+  let mockRequestHandler: A2ARequestHandler;
+  let transportHandler: LegacyJsonRpcTransportHandler;
+  let defaultContext: ServerCallContext;
+
+  const streamingAgentCard: V1AgentCard = {
+    name: 'Test',
+    description: '',
+    version: '1.0.0',
+    capabilities: { streaming: true, pushNotifications: false, extensions: [] },
+    defaultInputModes: [],
+    defaultOutputModes: [],
+    skills: [],
+    securityRequirements: [],
+    securitySchemes: {},
+    provider: undefined,
+    signatures: [],
+    supportedInterfaces: [
+      { url: 'http://x', protocolBinding: 'JSONRPC', tenant: '', protocolVersion: '0.3' },
+    ],
+    documentationUrl: '',
+    iconUrl: '',
+  };
+
+  const nonStreamingAgentCard: V1AgentCard = {
+    ...streamingAgentCard,
+    capabilities: { ...streamingAgentCard.capabilities, streaming: false },
+  };
+
+  function sampleV1Message(messageId = 'm-1'): V1Message {
+    return {
+      messageId,
+      contextId: '',
+      taskId: '',
+      role: Role.ROLE_AGENT,
+      parts: [],
+      metadata: undefined,
+      extensions: [],
+      referenceTaskIds: [],
+    };
+  }
+
+  function sampleV1Task(id = 't-1'): V1Task {
+    return {
+      id,
+      contextId: 'ctx',
+      status: {
+        state: TaskState.TASK_STATE_WORKING,
+        message: undefined,
+        timestamp: undefined,
+      },
+      artifacts: [],
+      history: [],
+      metadata: undefined,
+    };
+  }
+
+  function sampleV1TaskPushNotificationConfig(): V1TaskPushNotificationConfig {
+    return {
+      tenant: '',
+      id: 'cfg-1',
+      taskId: 't-1',
+      url: 'https://callback.example.com',
+      token: '',
+      authentication: undefined,
+    };
+  }
+
+  beforeEach(() => {
+    mockRequestHandler = {
+      getAgentCard: vi.fn().mockResolvedValue(streamingAgentCard),
+      getAuthenticatedExtendedAgentCard: vi.fn(),
+      sendMessage: vi.fn(),
+      sendMessageStream: vi.fn(),
+      getTask: vi.fn(),
+      cancelTask: vi.fn(),
+      createTaskPushNotificationConfig: vi.fn(),
+      getTaskPushNotificationConfig: vi.fn(),
+      listTaskPushNotificationConfigs: vi.fn(),
+      deleteTaskPushNotificationConfig: vi.fn(),
+      resubscribe: vi.fn(),
+      listTasks: vi.fn(),
+    };
+    transportHandler = new LegacyJsonRpcTransportHandler(mockRequestHandler);
+    defaultContext = new ServerCallContext();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Envelope validation', () => {
+    it('returns invalid-request for trailing-comma JSON string', async () => {
+      const invalidJson = '{ "jsonrpc": "2.0", "method": "tasks/get", "id": 1, }';
+      const response = (await transportHandler.handle(
+        invalidJson,
+        defaultContext
+      )) as legacy.JSONRPCErrorResponse;
+      expect(response.error.code).toBe(-32600);
+    });
+
+    it('returns invalid-request for non-string, non-object body', async () => {
+      const response = (await transportHandler.handle(
+        123 as unknown as Record<string, unknown>,
+        defaultContext
+      )) as legacy.JSONRPCErrorResponse;
+      expect(response.error.code).toBe(-32600);
+      expect(response.error.message).toBe('Invalid request body type.');
+    });
+
+    it('returns invalid-request for missing jsonrpc', async () => {
+      const response = (await transportHandler.handle(
+        { method: 'tasks/get', id: 1, params: { id: 't' } } as Record<string, unknown>,
+        defaultContext
+      )) as legacy.JSONRPCErrorResponse;
+      expect(response.error.code).toBe(-32600);
+      expect(response.error.message).toBe('Invalid JSON-RPC Request.');
+      expect(response.id).toBe(1);
+    });
+
+    it('returns invalid-request for wrong jsonrpc version', async () => {
+      const response = (await transportHandler.handle(
+        { jsonrpc: '1.0', method: 'tasks/get', id: 1, params: { id: 't' } } as Record<
+          string,
+          unknown
+        >,
+        defaultContext
+      )) as legacy.JSONRPCErrorResponse;
+      expect(response.error.code).toBe(-32600);
+    });
+
+    it('returns invalid-request for missing method', async () => {
+      const response = (await transportHandler.handle(
+        { jsonrpc: '2.0', id: 1 } as Record<string, unknown>,
+        defaultContext
+      )) as legacy.JSONRPCErrorResponse;
+      expect(response.error.code).toBe(-32600);
+    });
+
+    it('returns invalid-request for non-string method', async () => {
+      const response = (await transportHandler.handle(
+        { jsonrpc: '2.0', method: 123, id: 1 } as unknown as Record<string, unknown>,
+        defaultContext
+      )) as legacy.JSONRPCErrorResponse;
+      expect(response.error.code).toBe(-32600);
+    });
+
+    it('returns invalid-request for object id', async () => {
+      const response = (await transportHandler.handle(
+        { jsonrpc: '2.0', method: 'tasks/get', id: {} } as unknown as Record<string, unknown>,
+        defaultContext
+      )) as legacy.JSONRPCErrorResponse;
+      expect(response.error.code).toBe(-32600);
+      expect(response.id).toEqual({});
+    });
+
+    it('returns invalid-request for float id', async () => {
+      const response = (await transportHandler.handle(
+        { jsonrpc: '2.0', method: 'tasks/get', id: 1.23 } as Record<string, unknown>,
+        defaultContext
+      )) as legacy.JSONRPCErrorResponse;
+      expect(response.error.code).toBe(-32600);
+      expect(response.id).toBe(1.23);
+    });
+
+    const invalidParamsCases = [
+      { name: 'null', params: null },
+      { name: 'undefined', params: undefined },
+      { name: 'a string', params: 'invalid' },
+      { name: 'an array', params: [1, 2, 3] },
+      { name: 'an object with empty key', params: { '': 'invalid' } },
+    ];
+    invalidParamsCases.forEach(({ name, params }) => {
+      it(`returns invalid-params when params are ${name}`, async () => {
+        const response = (await transportHandler.handle(
+          { jsonrpc: '2.0', method: 'tasks/get', id: 1, params } as Record<string, unknown>,
+          defaultContext
+        )) as legacy.JSONRPCErrorResponse;
+        expect(response.error.code).toBe(-32602);
+        expect(response.error.message).toBe('Invalid method parameters.');
+        expect(response.id).toBe(1);
+      });
+    });
+
+    it('accepts agent/getAuthenticatedExtendedCard without params', async () => {
+      (mockRequestHandler.getAuthenticatedExtendedAgentCard as Mock).mockResolvedValue(
+        streamingAgentCard
+      );
+      const response = (await transportHandler.handle(
+        { jsonrpc: '2.0', method: 'agent/getAuthenticatedExtendedCard', id: 1 } as Record<
+          string,
+          unknown
+        >,
+        defaultContext
+      )) as legacy.JSONRPCSuccessResponse;
+      expect(response.result).toBeDefined();
+    });
+  });
+
+  describe('message/send', () => {
+    function buildRequest(extras: Record<string, unknown> = {}): Record<string, unknown> {
+      return {
+        jsonrpc: '2.0',
+        method: 'message/send',
+        id: 'req-1',
+        params: {
+          message: {
+            kind: 'message',
+            messageId: 'msg-1',
+            role: 'user',
+            parts: [{ kind: 'text', text: 'hello' }],
+          },
+          ...extras,
+        },
+      };
+    }
+
+    it('translates v0.3 params to v1 SendMessageRequest', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockResolvedValue(sampleV1Message());
+      await transportHandler.handle(buildRequest(), defaultContext);
+
+      const call = (mockRequestHandler.sendMessage as Mock).mock.calls[0][0];
+      expect(call.tenant).toBe('');
+      expect(call.message.messageId).toBe('msg-1');
+      expect(call.message.role).toBe(Role.ROLE_USER);
+    });
+
+    it('inverts blocking polarity (blocking=true -> returnImmediately=false)', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockResolvedValue(sampleV1Message());
+      await transportHandler.handle(
+        buildRequest({ configuration: { blocking: true } }),
+        defaultContext
+      );
+
+      const call = (mockRequestHandler.sendMessage as Mock).mock.calls[0][0];
+      expect(call.configuration.returnImmediately).toBe(false);
+    });
+
+    it('returns a v0.3 Message envelope when sendMessage returns a Message', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockResolvedValue(sampleV1Message('m-out'));
+      const response = (await transportHandler.handle(
+        buildRequest(),
+        defaultContext
+      )) as legacy.SendMessageSuccessResponse;
+
+      expect(response.id).toBe('req-1');
+      expect(response.jsonrpc).toBe('2.0');
+      const result = response.result as legacy.Message1;
+      expect(result.kind).toBe('message');
+      expect(result.messageId).toBe('m-out');
+    });
+
+    it('returns a v0.3 Task envelope when sendMessage returns a Task', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockResolvedValue(sampleV1Task('t-out'));
+      const response = (await transportHandler.handle(
+        buildRequest(),
+        defaultContext
+      )) as legacy.SendMessageSuccessResponse;
+
+      const result = response.result as legacy.Task2;
+      expect(result.kind).toBe('task');
+      expect(result.id).toBe('t-out');
+    });
+  });
+
+  describe('tasks/get', () => {
+    it('translates params and wraps the v0.3 Task result', async () => {
+      (mockRequestHandler.getTask as Mock).mockResolvedValue(sampleV1Task('t-99'));
+      const response = (await transportHandler.handle(
+        {
+          jsonrpc: '2.0',
+          method: 'tasks/get',
+          id: 7,
+          params: { id: 't-99', historyLength: 3 },
+        },
+        defaultContext
+      )) as legacy.GetTaskSuccessResponse;
+
+      const call = (mockRequestHandler.getTask as Mock).mock.calls[0][0];
+      expect(call.tenant).toBe('');
+      expect(call.id).toBe('t-99');
+      expect(call.historyLength).toBe(3);
+
+      expect(response.id).toBe(7);
+      expect(response.result.kind).toBe('task');
+      expect(response.result.id).toBe('t-99');
+    });
+  });
+
+  describe('tasks/cancel', () => {
+    it('translates params and wraps the v0.3 Task result', async () => {
+      (mockRequestHandler.cancelTask as Mock).mockResolvedValue(sampleV1Task('t-c'));
+      const response = (await transportHandler.handle(
+        {
+          jsonrpc: '2.0',
+          method: 'tasks/cancel',
+          id: 'r',
+          params: { id: 't-c' },
+        },
+        defaultContext
+      )) as legacy.CancelTaskSuccessResponse;
+
+      expect((mockRequestHandler.cancelTask as Mock).mock.calls[0][0].id).toBe('t-c');
+      expect(response.result.kind).toBe('task');
+      expect(response.result.id).toBe('t-c');
+    });
+  });
+
+  describe('tasks/pushNotificationConfig/set', () => {
+    it('translates the v0.3 config and returns a wrapped v0.3 config', async () => {
+      (mockRequestHandler.createTaskPushNotificationConfig as Mock).mockResolvedValue(
+        sampleV1TaskPushNotificationConfig()
+      );
+      const response = (await transportHandler.handle(
+        {
+          jsonrpc: '2.0',
+          method: 'tasks/pushNotificationConfig/set',
+          id: 1,
+          params: {
+            taskId: 't-1',
+            pushNotificationConfig: {
+              id: 'cfg-1',
+              url: 'https://callback.example.com',
+            },
+          },
+        },
+        defaultContext
+      )) as legacy.SetTaskPushNotificationConfigSuccessResponse;
+
+      const call = (mockRequestHandler.createTaskPushNotificationConfig as Mock).mock.calls[0][0];
+      expect(call.taskId).toBe('t-1');
+      expect(call.url).toBe('https://callback.example.com');
+
+      expect(response.result.taskId).toBe('t-1');
+      expect(response.result.pushNotificationConfig.url).toBe('https://callback.example.com');
+    });
+  });
+
+  describe('tasks/pushNotificationConfig/get', () => {
+    it('translates params and wraps the v0.3 config', async () => {
+      (mockRequestHandler.getTaskPushNotificationConfig as Mock).mockResolvedValue(
+        sampleV1TaskPushNotificationConfig()
+      );
+      const response = (await transportHandler.handle(
+        {
+          jsonrpc: '2.0',
+          method: 'tasks/pushNotificationConfig/get',
+          id: 1,
+          params: { id: 't-1', pushNotificationConfigId: 'cfg-1' },
+        },
+        defaultContext
+      )) as legacy.GetTaskPushNotificationConfigSuccessResponse;
+
+      const call = (mockRequestHandler.getTaskPushNotificationConfig as Mock).mock.calls[0][0];
+      expect(call.taskId).toBe('t-1');
+      expect(call.id).toBe('cfg-1');
+
+      expect(response.result.taskId).toBe('t-1');
+      expect(response.result.pushNotificationConfig.id).toBe('cfg-1');
+    });
+  });
+
+  describe('tasks/pushNotificationConfig/list', () => {
+    it('returns a v0.3 array result', async () => {
+      (mockRequestHandler.listTaskPushNotificationConfigs as Mock).mockResolvedValue({
+        configs: [sampleV1TaskPushNotificationConfig()],
+        nextPageToken: '',
+      });
+      const response = (await transportHandler.handle(
+        {
+          jsonrpc: '2.0',
+          method: 'tasks/pushNotificationConfig/list',
+          id: 1,
+          params: { id: 't-1' },
+        },
+        defaultContext
+      )) as legacy.ListTaskPushNotificationConfigSuccessResponse;
+
+      const call = (mockRequestHandler.listTaskPushNotificationConfigs as Mock).mock.calls[0][0];
+      expect(call.taskId).toBe('t-1');
+
+      expect(Array.isArray(response.result)).toBe(true);
+      expect(response.result).toHaveLength(1);
+      expect(response.result[0].taskId).toBe('t-1');
+    });
+  });
+
+  describe('tasks/pushNotificationConfig/delete', () => {
+    it('returns null result and forwards translated params', async () => {
+      (mockRequestHandler.deleteTaskPushNotificationConfig as Mock).mockResolvedValue(undefined);
+      const response = (await transportHandler.handle(
+        {
+          jsonrpc: '2.0',
+          method: 'tasks/pushNotificationConfig/delete',
+          id: 1,
+          params: { id: 't-1', pushNotificationConfigId: 'cfg-1' },
+        },
+        defaultContext
+      )) as legacy.JSONRPCSuccessResponse;
+
+      const call = (mockRequestHandler.deleteTaskPushNotificationConfig as Mock).mock.calls[0][0];
+      expect(call.taskId).toBe('t-1');
+      expect(call.id).toBe('cfg-1');
+      expect(response.result).toBeNull();
+    });
+  });
+
+  describe('agent/getAuthenticatedExtendedCard', () => {
+    it('returns a v0.3-shaped AgentCard', async () => {
+      (mockRequestHandler.getAuthenticatedExtendedAgentCard as Mock).mockResolvedValue(
+        streamingAgentCard
+      );
+      const response = (await transportHandler.handle(
+        { jsonrpc: '2.0', method: 'agent/getAuthenticatedExtendedCard', id: 1 } as Record<
+          string,
+          unknown
+        >,
+        defaultContext
+      )) as legacy.GetAuthenticatedExtendedCardSuccessResponse;
+
+      expect(response.result.url).toBe('http://x');
+      expect(response.result.protocolVersion).toBe('0.3');
+    });
+  });
+
+  describe('message/stream', () => {
+    it('rejects when streaming is not supported', async () => {
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(nonStreamingAgentCard);
+      const response = (await transportHandler.handle(
+        {
+          jsonrpc: '2.0',
+          method: 'message/stream',
+          id: 1,
+          params: {
+            message: {
+              kind: 'message',
+              messageId: 'm-1',
+              role: 'user',
+              parts: [{ kind: 'text', text: 'hi' }],
+            },
+          },
+        },
+        defaultContext
+      )) as legacy.JSONRPCErrorResponse;
+
+      expect(response.error.code).toBe(-32004);
+    });
+
+    it('translates each v1 StreamResponse event into a v0.3 envelope', async () => {
+      async function* events(): AsyncGenerator<V1StreamResponse, void, undefined> {
+        yield { payload: { $case: 'task', value: sampleV1Task('t-s') } };
+        yield {
+          payload: {
+            $case: 'statusUpdate',
+            value: {
+              taskId: 't-s',
+              contextId: 'ctx',
+              status: {
+                state: TaskState.TASK_STATE_COMPLETED,
+                message: undefined,
+                timestamp: undefined,
+              },
+              metadata: undefined,
+            },
+          },
+        };
+      }
+      (mockRequestHandler.sendMessageStream as Mock).mockReturnValue(events());
+
+      const generator = (await transportHandler.handle(
+        {
+          jsonrpc: '2.0',
+          method: 'message/stream',
+          id: 'stream-1',
+          params: {
+            message: {
+              kind: 'message',
+              messageId: 'm-1',
+              role: 'user',
+              parts: [{ kind: 'text', text: 'hi' }],
+            },
+          },
+        },
+        defaultContext
+      )) as AsyncGenerator<legacy.SendStreamingMessageSuccessResponse, void, undefined>;
+
+      const collected: legacy.SendStreamingMessageSuccessResponse[] = [];
+      for await (const event of generator) {
+        collected.push(event);
+      }
+      expect(collected).toHaveLength(2);
+      expect(collected[0].id).toBe('stream-1');
+      expect((collected[0].result as legacy.Task2).kind).toBe('task');
+      expect((collected[1].result as legacy.TaskStatusUpdateEvent).kind).toBe('status-update');
+      expect((collected[1].result as legacy.TaskStatusUpdateEvent).final).toBe(true);
+    });
+  });
+
+  describe('tasks/resubscribe', () => {
+    it('translates the v0.3 params and forwards to resubscribe', async () => {
+      async function* events(): AsyncGenerator<V1StreamResponse, void, undefined> {
+        yield { payload: { $case: 'task', value: sampleV1Task('t-r') } };
+      }
+      (mockRequestHandler.resubscribe as Mock).mockReturnValue(events());
+
+      const generator = (await transportHandler.handle(
+        {
+          jsonrpc: '2.0',
+          method: 'tasks/resubscribe',
+          id: 'r-1',
+          params: { id: 't-r' },
+        },
+        defaultContext
+      )) as AsyncGenerator<legacy.SendStreamingMessageSuccessResponse, void, undefined>;
+
+      const collected: legacy.SendStreamingMessageSuccessResponse[] = [];
+      for await (const event of generator) {
+        collected.push(event);
+      }
+      const call = (mockRequestHandler.resubscribe as Mock).mock.calls[0][0];
+      expect(call.id).toBe('t-r');
+      expect(collected).toHaveLength(1);
+    });
+  });
+
+  describe('Unknown method', () => {
+    it('returns method-not-found', async () => {
+      const response = (await transportHandler.handle(
+        { jsonrpc: '2.0', method: 'no/such/method', id: 1, params: {} },
+        defaultContext
+      )) as legacy.JSONRPCErrorResponse;
+      expect(response.error.code).toBe(-32601);
+    });
+  });
+
+  describe('Error mapping', () => {
+    it('passes through LegacyA2AError unchanged', () => {
+      const err = LegacyA2AError.taskNotFound('t-1');
+      const mapped = LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError(err);
+      expect(mapped.code).toBe(-32001);
+      expect(mapped.message).toContain('t-1');
+    });
+
+    const v1ToLegacyCodeCases: Array<[Error, number]> = [
+      [new TaskNotFoundError('a'), -32001],
+      [new TaskNotCancelableError('a'), -32002],
+      [new PushNotificationNotSupportedError('a'), -32003],
+      [new UnsupportedOperationError('a'), -32004],
+      [new ContentTypeNotSupportedError('a'), -32005],
+      [new InvalidAgentResponseError('a'), -32006],
+      [new ExtendedAgentCardNotConfiguredError('a'), -32007],
+      [new ExtensionSupportRequiredError('a'), -32008],
+      [new VersionNotSupportedError('a'), -32009],
+      [new RequestMalformedError('a'), -32602],
+      [new GenericError('a'), -32603],
+    ];
+
+    v1ToLegacyCodeCases.forEach(([err, expectedCode]) => {
+      it(`maps ${err.name} to code ${expectedCode}`, () => {
+        const mapped = LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError(err);
+        expect(mapped.code).toBe(expectedCode);
+        expect(mapped.message).toBe('a');
+      });
+    });
+
+    it('omits the data field on v1 SDK errors (v0.3 shape compatibility)', () => {
+      const mapped = LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError(
+        new TaskNotFoundError('t')
+      );
+      expect(mapped).not.toHaveProperty('data');
+    });
+
+    it('falls back to INTERNAL_ERROR for unknown errors', () => {
+      const mapped = LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError(new Error('unexpected'));
+      expect(mapped.code).toBe(-32603);
+      expect(mapped.message).toBe('unexpected');
+    });
+  });
+
+  describe('Error surfacing via handle()', () => {
+    it('returns a v0.3 error envelope when the request handler throws a v1 SDK error', async () => {
+      (mockRequestHandler.getTask as Mock).mockRejectedValue(new TaskNotFoundError('missing'));
+      const response = (await transportHandler.handle(
+        { jsonrpc: '2.0', method: 'tasks/get', id: 9, params: { id: 'missing' } },
+        defaultContext
+      )) as legacy.JSONRPCErrorResponse;
+      expect(response.error.code).toBe(-32001);
+      expect(response.error.message).toBe('missing');
+      expect(response.id).toBe(9);
+    });
+  });
+});

--- a/test/server/express/express_app.spec.ts
+++ b/test/server/express/express_app.spec.ts
@@ -24,6 +24,7 @@ import { agentCardHandler } from '../../../src/server/express/agent_card_handler
 import { UserBuilder } from '../../../src/server/express/common.js';
 import { A2ARequestHandler } from '../../../src/server/request_handler/a2a_request_handler.js';
 import { JsonRpcTransportHandler } from '../../../src/server/transports/jsonrpc/jsonrpc_transport_handler.js';
+import { LegacyJsonRpcTransportHandler } from '../../../src/compat/v0_3/index.js';
 import { AgentCard } from '../../../src/index.js';
 import { JSONRPCErrorResponse } from '../../../src/core.js';
 import { AGENT_CARD_PATH, HTTP_EXTENSION_HEADER } from '../../../src/constants.js';
@@ -56,7 +57,7 @@ describe('A2AExpressApp', () => {
   };
 
   // Helper function to create JSON-RPC request bodies
-  const createRpcRequest = (id: string | null, method = 'message/send', params: object = {}) => ({
+  const createRpcRequest = (id: string | null, method = 'SendMessage', params: object = {}) => ({
     jsonrpc: '2.0',
     method,
     id,
@@ -185,7 +186,7 @@ describe('A2AExpressApp', () => {
 
       handleStub.mockResolvedValue(mockStreamResponse);
 
-      const requestBody = createRpcRequest('stream-test', 'message/stream');
+      const requestBody = createRpcRequest('stream-test', 'SendStreamingMessage');
 
       const response = await request(expressApp)
         .post('/')
@@ -212,7 +213,7 @@ describe('A2AExpressApp', () => {
 
       handleStub.mockResolvedValue(mockErrorStream);
 
-      const requestBody = createRpcRequest('stream-error-test', 'message/stream');
+      const requestBody = createRpcRequest('stream-error-test', 'SendStreamingMessage');
 
       const response = await request(expressApp)
         .post('/')
@@ -235,7 +236,7 @@ describe('A2AExpressApp', () => {
 
       handleStub.mockResolvedValue(mockImmediateErrorStream);
 
-      const requestBody = createRpcRequest('immediate-stream-error-test', 'message/stream');
+      const requestBody = createRpcRequest('immediate-stream-error-test', 'SendStreamingMessage');
 
       const response = await request(expressApp)
         .post('/')
@@ -588,7 +589,7 @@ describe('A2AExpressApp', () => {
       const jsonApp = express();
       setupA2ARoutes(jsonApp, mockRequestHandler);
 
-      const requestBody = createRpcRequest('test-id', 'message/send', {
+      const requestBody = createRpcRequest('test-id', 'SendMessage', {
         test: 'data',
       });
 
@@ -666,6 +667,139 @@ describe('A2AExpressApp', () => {
       assert.property(response.body, 'error');
       assert.equal(response.body.error.code, A2A_ERROR_CODE.VERSION_NOT_SUPPORTED);
       assert.include(response.body.error.message, '9.9');
+    });
+  });
+
+  describe('legacy v0.3 JSON-RPC dispatch', () => {
+    let legacyHandleStub: MockInstance;
+
+    // An agent card that advertises both v1.0 and v0.3 JSONRPC interfaces,
+    // so version validation accepts both.
+    const dualVersionAgentCard: AgentCard = {
+      ...testAgentCard,
+      supportedInterfaces: [
+        {
+          url: 'http://localhost:8080/jsonrpc',
+          protocolBinding: 'JSONRPC',
+          tenant: '',
+          protocolVersion: '1.0',
+        },
+        {
+          url: 'http://localhost:8080/jsonrpc',
+          protocolBinding: 'JSONRPC',
+          tenant: '',
+          protocolVersion: '0.3',
+        },
+      ],
+    };
+
+    beforeEach(() => {
+      legacyHandleStub = vi.spyOn(LegacyJsonRpcTransportHandler.prototype, 'handle');
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(dualVersionAgentCard);
+      setupA2ARoutes(expressApp, mockRequestHandler);
+    });
+
+    it('routes a v0.3 method to the legacy handler', async () => {
+      legacyHandleStub.mockResolvedValue({
+        jsonrpc: '2.0',
+        id: 'req-1',
+        result: { kind: 'task' },
+      });
+
+      await request(expressApp)
+        .post('/')
+        .set('A2A-Version', '0.3')
+        .send(createRpcRequest('req-1', 'message/send'))
+        .expect(200);
+
+      expect(legacyHandleStub).toHaveBeenCalledTimes(1);
+      expect(handleStub).not.toHaveBeenCalled();
+    });
+
+    it('routes a v1.0 method to the v1 handler', async () => {
+      handleStub.mockResolvedValue({
+        jsonrpc: '2.0',
+        id: 'req-2',
+        result: { task: { id: 't' } },
+      });
+
+      await request(expressApp)
+        .post('/')
+        .set('A2A-Version', '1.0')
+        .send(createRpcRequest('req-2', 'SendMessage'))
+        .expect(200);
+
+      expect(handleStub).toHaveBeenCalledTimes(1);
+      expect(legacyHandleStub).not.toHaveBeenCalled();
+    });
+
+    it('accepts header-less legacy requests when the card advertises v0.3', async () => {
+      legacyHandleStub.mockResolvedValue({
+        jsonrpc: '2.0',
+        id: 'req-3',
+        result: { kind: 'task' },
+      });
+
+      // No A2A-Version header → requestedVersion defaults to '0.3' per §3.6.2.
+      // Card declares v0.3 so validateVersion passes.
+      await request(expressApp)
+        .post('/')
+        .send(createRpcRequest('req-3', 'message/send'))
+        .expect(200);
+
+      expect(legacyHandleStub).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects legacy requests when the card declares no v0.3 interface', async () => {
+      // testAgentCard only declares the v1.0 interface; no compat opt-in.
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(testAgentCard);
+
+      const response = await request(expressApp)
+        .post('/')
+        .send(createRpcRequest('req-4', 'message/send'))
+        .expect(500);
+
+      expect(response.body.error.code).to.equal(A2A_ERROR_CODE.VERSION_NOT_SUPPORTED);
+      expect(legacyHandleStub).not.toHaveBeenCalled();
+    });
+
+    it('streams SSE responses on the legacy path', async () => {
+      const legacyStream = {
+        async *[Symbol.asyncIterator]() {
+          yield {
+            jsonrpc: '2.0',
+            id: 'stream-1',
+            result: { kind: 'task', id: 't-1', contextId: 'ctx', status: { state: 'working' } },
+          };
+        },
+      };
+      legacyHandleStub.mockResolvedValue(legacyStream);
+
+      const response = await request(expressApp)
+        .post('/')
+        .set('A2A-Version', '0.3')
+        .send(createRpcRequest('stream-legacy', 'message/stream'))
+        .expect(200);
+
+      assert.include(response.headers['content-type'], 'text/event-stream');
+      assert.include(response.text, '"kind":"task"');
+      expect(legacyHandleStub).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the legacy error mapper (omits data field) on legacy-path errors', async () => {
+      legacyHandleStub.mockRejectedValue(new GenericError('legacy boom'));
+
+      const response = await request(expressApp)
+        .post('/')
+        .set('A2A-Version', '0.3')
+        .send(createRpcRequest('err-1', 'message/send'))
+        .expect(500);
+
+      expect(response.body.error.code).to.equal(A2A_ERROR_CODE.INTERNAL_ERROR);
+      expect(response.body.error.message).to.equal('legacy boom');
+      // v0.3 JSONRPCError.data is `Record<string,unknown>` not the v1.0
+      // ErrorDetail[] array. The legacy mapper omits the field entirely.
+      expect(response.body.error).to.not.have.property('data');
     });
   });
 });


### PR DESCRIPTION
# Description

This pull request introduces a compatibility layer to support legacy v0.3 JSON-RPC requests alongside the existing v1.0 handler. The main changes include implementing a `LegacyJsonRpcTransportHandler` that translates between v0.3 and v1.0 protocols, updating the Express.js middleware to route requests to the appropriate handler based on the method name, and refactoring exports and tests to accommodate the new functionality.

**Legacy protocol support:**

* Implemented `LegacyJsonRpcTransportHandler` in `src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.ts`, which translates v0.3 JSON-RPC requests/responses to and from the v1.0 protocol, including error mapping and streaming support.
* Added `isLegacyJsonRpcMethod` utility to detect v0.3 method names and updated the Express JSON-RPC handler (`jsonRpcHandler`) to dispatch requests to either the legacy or v1.0 handler accordingly.

**Code organization and exports:**

* Refactored exports in `src/compat/v0_3/index.ts` and added a new `src/compat/v0_3/server/index.ts` to expose legacy server components, including the new handler and error class.

**Testing and test utilities:**

* Updated tests in `test/server/express/express_app.spec.ts` to use v1.0 method names by default and import the new legacy handler where appropriate, ensuring test coverage for both protocol versions. 

Fixes #475 🦕
