### PR TITLE
feat: implement legacy v0.3 REST support with compatible transport handler and middleware routing

### DIFF
--- a/src/compat/v0_3/server/express/rest_handler.ts
+++ b/src/compat/v0_3/server/express/rest_handler.ts
@@ -22,7 +22,7 @@ import express, {
   type Response,
 } from 'express';
 
-import { A2A_VERSION_HEADER } from '../../../../constants.js';
+import { A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER } from '../../../../constants.js';
 import { Extensions } from '../../../../extensions.js';
 import { ServerCallContext } from '../../../../server/context.js';
 import { UserBuilder } from '../../../../server/express/common.js';
@@ -34,6 +34,7 @@ import {
   LEGACY_HTTP_EXTENSION_HEADER,
   LEGACY_JSON_CONTENT_TYPE,
 } from '../../constants.js';
+import { isLegacyVersion } from '../../translate/versions.js';
 import type * as legacy from '../../types/types.js';
 import { A2AError as LegacyA2AError } from '../error.js';
 import {
@@ -81,18 +82,26 @@ type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
 /**
  * Creates an Express router exposing the v0.3 HTTP+JSON/REST endpoints.
  *
- * The routes are mount-relative (no `/v1` prefix on the route literals
- * themselves). The caller is expected to mount the router under `/v1`,
- * which is the path prefix used by the v0.3 reference implementation.
- * The core `restHandler` does this automatically; standalone callers
- * must do it explicitly.
+ * The router uses **header-based dispatch**, not path-based: a
+ * middleware at the top of the chain parses `A2A-Version` (defaulting
+ * to `'0.3'` per §3.6.2 when absent) and short-circuits any request
+ * whose version is not in the legacy range `[0.3, 1.0)` by calling
+ * `next('router')`, falling through to the parent's v1.0 middleware.
+ *
+ * The routes are registered at the canonical v0.3 reference URLs
+ * (`/v1/card`, `/v1/message:send`, `/v1/tasks/:taskId`, …). The router
+ * is mounted path-less by the core `restHandler` so the v1.0 spec's
+ * tenant routes (`/:tenant/...`) remain free to use `v1` (or any other
+ * label) as a tenant identifier.
  *
  * The router:
  *   - Parses `application/json` bodies via {@link LEGACY_JSON_CONTENT_TYPE}.
- *   - Reads protocol extensions from the {@link LEGACY_HTTP_EXTENSION_HEADER}
- *     (`X-A2A-Extensions`) header (v0.3 used the `X-` prefix; v1.0 dropped it).
- *   - Defaults a missing `A2A-Version` header to {@link A2A_LEGACY_PROTOCOL_VERSION}
- *     (`'0.3'`).
+ *   - Reads protocol extensions from `X-A2A-Extensions` (the v0.3
+ *     header) OR `A2A-Extensions` (the v1.0 header) for tolerance with
+ *     v1.0-shaped clients hitting the legacy endpoints; if both are
+ *     present the legacy header wins. Responses use the v0.3 spelling.
+ *   - Defaults a missing `A2A-Version` header to
+ *     {@link A2A_LEGACY_PROTOCOL_VERSION} (`'0.3'`).
  *   - Sets the response `Content-Type` to {@link LEGACY_JSON_CONTENT_TYPE}
  *     (`application/json`, not `application/a2a+json`).
  *   - Returns errors in the bare v0.3 `{ code, message, data? }` shape.
@@ -100,15 +109,30 @@ type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
  * @example
  * ```ts
  * import { legacyRestRouter } from '@a2a-js/sdk/compat/v0_3';
- * app.use('/api/v1', legacyRestRouter({ requestHandler, userBuilder }));
- * // → POST /api/v1/message:send
- * // → GET  /api/v1/tasks/:taskId
+ * app.use(legacyRestRouter({ requestHandler, userBuilder }));
+ * // → POST /v1/message:send
+ * // → GET  /v1/tasks/:taskId
  * // …
  * ```
  */
 export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHandler {
   const router = express.Router();
   const transportHandler = new LegacyRestTransportHandler(options.requestHandler);
+
+  // Version-based dispatch: short-circuit anything that isn't in the
+  // legacy range `[0.3, 1.0)` (per `isLegacyVersion`) by handing off to
+  // the parent router via `next('router')`. Header-less requests
+  // default to `'0.3'` per §3.6.2 and stay in this router. This ensures
+  // body parser, content-type setter and error handler below NEVER run
+  // for non-legacy requests, preserving wire-shape isolation.
+  router.use((req: Request, _res: Response, next: NextFunction) => {
+    const requestedVersion = req.header(A2A_VERSION_HEADER) || A2A_LEGACY_PROTOCOL_VERSION;
+    if (isLegacyVersion(requestedVersion)) {
+      next();
+    } else {
+      next('router');
+    }
+  });
 
   router.use(
     (_req: Request, res: Response, next: NextFunction) => {
@@ -125,12 +149,18 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
 
   /**
    * Builds a {@link ServerCallContext} from the Express request.
-   * - Extracts protocol extensions from the legacy `X-A2A-Extensions`
-   *   header.
+   * - Extracts protocol extensions from `X-A2A-Extensions` (v0.3
+   *   spelling, preferred) OR `A2A-Extensions` (v1.0 spelling,
+   *   fallback) — server-side tolerance for v1.0-shaped clients
+   *   hitting the legacy endpoints.
    * - Resolves the authenticated user.
    * - Defaults the A2A version to {@link A2A_LEGACY_PROTOCOL_VERSION}
    *   when the `A2A-Version` header is absent or empty (matches the
    *   v0.3 default specified in §3.6.2).
+   * - Propagates the URL tenant (if any) via `context.tenant`. The
+   *   legacy router doesn't currently register `:tenant` parameter
+   *   routes, so this is a no-op today but stays forward-compatible
+   *   for future tenant-aware route registrations.
    * - Validates the requested version against the agent card's
    *   `HTTP+JSON` interface list.
    */
@@ -139,10 +169,11 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
     const requestedVersion = req.header(A2A_VERSION_HEADER) || A2A_LEGACY_PROTOCOL_VERSION;
     const context = new ServerCallContext({
       requestedExtensions: Extensions.parseServiceParameter(
-        req.header(LEGACY_HTTP_EXTENSION_HEADER)
+        req.header(LEGACY_HTTP_EXTENSION_HEADER) ?? req.header(HTTP_EXTENSION_HEADER)
       ),
       user,
       requestedVersion,
+      tenant: (req.params.tenant as string) || undefined,
     });
     const agentCard = await transportHandler.getAgentCard();
     validateVersion(context.requestedVersion, agentCard, 'HTTP+JSON');
@@ -257,19 +288,21 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   // Route Handlers
   // ==========================================================================
 
-  // The routes below are mount-relative: they assume the router is mounted
-  // by the caller under the v0.3 `/v1` prefix (the core `restHandler` does
-  // this; standalone callers must `app.use('/v1', legacyRestRouter(...))`).
-  // Keeping the routes prefix-free makes the legacy router path-agnostic
-  // and ensures the parent owns the path-prefix dispatch decision.
+  // The routes below use the canonical v0.3 reference URLs (`/v1/...`).
+  // The router is mounted path-less by the core `restHandler`; the
+  // version-dispatch middleware above ensures only legacy-range requests
+  // reach these routes. Requests with `A2A-Version: 1.0` (or any other
+  // non-legacy version) targeting the same paths fall through to the
+  // v1.0 router, where `/v1/...` is interpreted as `/:tenant/...` with
+  // `tenant='v1'` per v1.0 tenant semantics.
 
   /**
-   * GET /card
+   * GET /v1/card
    *
    * Retrieves the authenticated extended agent card.
    */
   router.get(
-    '/card',
+    '/v1/card',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await transportHandler.getAuthenticatedExtendedAgentCard(context);
@@ -278,13 +311,13 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * POST /message:send
+   * POST /v1/message:send
    *
    * Sends a message synchronously. Returns either a v0.3 `Task` or `Message`.
    * The colon is escaped to satisfy Express's path-to-regexp parser.
    */
   router.post(
-    '/message\\:send',
+    '/v1/message\\:send',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const params = req.body as legacy.MessageSendParams;
@@ -295,12 +328,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * POST /message:stream
+   * POST /v1/message:stream
    *
    * Sends a message with a streaming SSE response.
    */
   router.post(
-    '/message\\:stream',
+    '/v1/message\\:stream',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const params = req.body as legacy.MessageSendParams;
@@ -310,14 +343,14 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * GET /tasks/:taskId
+   * GET /v1/tasks/:taskId
    *
    * Retrieves a task. Accepts both `?historyLength=` and `?history_length=`
    * for compatibility with the v0.3 reference (which used snake_case query
    * parameters in places).
    */
   router.get(
-    '/tasks/:taskId',
+    '/v1/tasks/:taskId',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const historyLength = req.query.historyLength ?? req.query.history_length;
@@ -327,12 +360,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * POST /tasks/:taskId:cancel
+   * POST /v1/tasks/:taskId:cancel
    *
    * Attempts to cancel a task. Returns 202 Accepted on success.
    */
   router.post(
-    '/tasks/:taskId\\:cancel',
+    '/v1/tasks/:taskId\\:cancel',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await transportHandler.cancelTask(req.params.taskId!, context);
@@ -341,12 +374,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * POST /tasks/:taskId:subscribe
+   * POST /v1/tasks/:taskId:subscribe
    *
    * Resubscribes to a task's update stream via SSE.
    */
   router.post(
-    '/tasks/:taskId\\:subscribe',
+    '/v1/tasks/:taskId\\:subscribe',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const stream = await transportHandler.resubscribe(req.params.taskId!, context);
@@ -355,12 +388,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * POST /tasks/:taskId/pushNotificationConfigs
+   * POST /v1/tasks/:taskId/pushNotificationConfigs
    *
    * Creates a push notification configuration. Returns 201 Created.
    */
   router.post(
-    '/tasks/:taskId/pushNotificationConfigs',
+    '/v1/tasks/:taskId/pushNotificationConfigs',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const params = req.body as legacy.TaskPushNotificationConfig;
@@ -370,12 +403,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * GET /tasks/:taskId/pushNotificationConfigs
+   * GET /v1/tasks/:taskId/pushNotificationConfigs
    *
    * Lists all push notification configurations for a task.
    */
   router.get(
-    '/tasks/:taskId/pushNotificationConfigs',
+    '/v1/tasks/:taskId/pushNotificationConfigs',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await transportHandler.listTaskPushNotificationConfigs(
@@ -387,12 +420,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * GET /tasks/:taskId/pushNotificationConfigs/:configId
+   * GET /v1/tasks/:taskId/pushNotificationConfigs/:configId
    *
    * Retrieves a specific push notification configuration.
    */
   router.get(
-    '/tasks/:taskId/pushNotificationConfigs/:configId',
+    '/v1/tasks/:taskId/pushNotificationConfigs/:configId',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await transportHandler.getTaskPushNotificationConfig(
@@ -405,12 +438,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * DELETE /tasks/:taskId/pushNotificationConfigs/:configId
+   * DELETE /v1/tasks/:taskId/pushNotificationConfigs/:configId
    *
    * Deletes a push notification configuration. Returns 204 No Content.
    */
   router.delete(
-    '/tasks/:taskId/pushNotificationConfigs/:configId',
+    '/v1/tasks/:taskId/pushNotificationConfigs/:configId',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       await transportHandler.deleteTaskPushNotificationConfig(
@@ -422,11 +455,14 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
     })
   );
 
-  // Note: `/tasks` (ListTasks) is intentionally NOT registered.
+  // Note: `/v1/tasks` (ListTasks) is intentionally NOT registered.
   // Per `V1_METHODS_WITHOUT_LEGACY_EQUIVALENT` (in `compat/v0_3/constants.ts`),
-  // the v0.3 protocol has no REST endpoint for listing tasks, so an
-  // attempt to GET `/tasks` under the legacy mount falls through to the
-  // parent router (or, ultimately, Express's default 404).
+  // the v0.3 protocol has no REST endpoint for listing tasks. A
+  // request to `GET /v1/tasks` with `A2A-Version: 0.3` therefore
+  // matches no legacy route and falls through to the parent router
+  // (where v1.0 may handle it as `/:tenant/tasks` with `tenant='v1'`,
+  // and version validation against the agent card will reject it
+  // unless the operator explicitly opted into a hybrid configuration).
 
   return router;
 }

--- a/src/compat/v0_3/server/express/rest_handler.ts
+++ b/src/compat/v0_3/server/express/rest_handler.ts
@@ -1,0 +1,424 @@
+/**
+ * v0.3 HTTP+JSON (REST) Express handler.
+ *
+ * Mounts the v0.3 REST endpoints (under the `/v1/...` path prefix used
+ * by the v0.3 reference implementation) onto an Express router and
+ * delegates to {@link LegacyRestTransportHandler} for the actual
+ * v0.3 ↔ v1.0 translation work.
+ *
+ * Designed to share an `A2ARequestHandler` instance with the v1.0
+ * `restHandler`: the core `restHandler` mounts this legacy router as a
+ * sub-router so a single Express app exposes both v0.3 (`/v1/...`) and
+ * v1.0 paths from one mount point. The two route sets are disjoint by
+ * path prefix, so Express's matcher routes correctly without any body
+ * inspection.
+ */
+
+import express, {
+  type ErrorRequestHandler,
+  type NextFunction,
+  type Request,
+  type RequestHandler,
+  type Response,
+} from 'express';
+
+import { A2A_VERSION_HEADER } from '../../../../constants.js';
+import { Extensions } from '../../../../extensions.js';
+import { ServerCallContext } from '../../../../server/context.js';
+import { UserBuilder } from '../../../../server/express/common.js';
+import { type A2ARequestHandler } from '../../../../server/request_handler/a2a_request_handler.js';
+import { SSE_HEADERS, formatSSEEvent, formatSSEErrorEvent } from '../../../../sse_utils.js';
+import { validateVersion } from '../../../../server/version.js';
+import {
+  A2A_LEGACY_PROTOCOL_VERSION,
+  LEGACY_HTTP_EXTENSION_HEADER,
+  LEGACY_JSON_CONTENT_TYPE,
+} from '../../constants.js';
+import type * as legacy from '../../types/types.js';
+import { A2AError as LegacyA2AError } from '../error.js';
+import {
+  HTTP_STATUS,
+  LegacyRestTransportHandler,
+  mapErrorToStatus,
+  toLegacyHTTPError,
+} from '../transports/rest/rest_transport_handler.js';
+
+/**
+ * Options for configuring the legacy v0.3 HTTP+JSON/REST handler.
+ */
+export interface LegacyRestHandlerOptions {
+  requestHandler: A2ARequestHandler;
+  userBuilder: UserBuilder;
+}
+
+/**
+ * Express error middleware that converts JSON parse errors from
+ * `express.json()` to v0.3-shaped 400 responses.
+ */
+const legacyRestErrorHandler: ErrorRequestHandler = (
+  err: Error,
+  _req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  if (err instanceof SyntaxError && 'body' in err) {
+    return res
+      .status(HTTP_STATUS.BAD_REQUEST)
+      .json(toLegacyHTTPError(LegacyA2AError.parseError('Invalid JSON payload.')));
+  }
+  next(err);
+};
+
+/**
+ * Type alias for async Express route handlers used in this module.
+ */
+type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
+
+// ============================================================================
+// Legacy REST Handler - Main Export
+// ============================================================================
+
+/**
+ * Creates an Express router exposing the v0.3 HTTP+JSON/REST endpoints.
+ *
+ * All endpoints are mounted under the `/v1/...` prefix used by the v0.3
+ * reference implementation, so the router can be safely composed with
+ * the v1.0 `restHandler` on the same mount point without path
+ * collisions.
+ *
+ * The router:
+ *   - Parses `application/json` bodies via {@link LEGACY_JSON_CONTENT_TYPE}.
+ *   - Reads protocol extensions from the {@link LEGACY_HTTP_EXTENSION_HEADER}
+ *     (`X-A2A-Extensions`) header (v0.3 used the `X-` prefix; v1.0 dropped it).
+ *   - Defaults a missing `A2A-Version` header to {@link A2A_LEGACY_PROTOCOL_VERSION}
+ *     (`'0.3'`).
+ *   - Sets the response `Content-Type` to {@link LEGACY_JSON_CONTENT_TYPE}
+ *     (`application/json`, not `application/a2a+json`).
+ *   - Returns errors in the bare v0.3 `{ code, message, data? }` shape.
+ *
+ * @example
+ * ```ts
+ * import { legacyRestRouter } from '@a2a-js/sdk/compat/v0_3';
+ * app.use('/api', legacyRestRouter({ requestHandler, userBuilder }));
+ * // → POST /api/v1/message:send
+ * // → GET  /api/v1/tasks/:taskId
+ * // …
+ * ```
+ */
+export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHandler {
+  const router = express.Router();
+  const transportHandler = new LegacyRestTransportHandler(options.requestHandler);
+
+  router.use(
+    (_req: Request, res: Response, next: NextFunction) => {
+      res.setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE);
+      next();
+    },
+    express.json({ type: LEGACY_JSON_CONTENT_TYPE }),
+    legacyRestErrorHandler
+  );
+
+  // ==========================================================================
+  // Helper Functions
+  // ==========================================================================
+
+  /**
+   * Builds a {@link ServerCallContext} from the Express request.
+   * - Extracts protocol extensions from the legacy `X-A2A-Extensions`
+   *   header.
+   * - Resolves the authenticated user.
+   * - Defaults the A2A version to {@link A2A_LEGACY_PROTOCOL_VERSION}
+   *   when the `A2A-Version` header is absent or empty (matches the
+   *   v0.3 default specified in §3.6.2).
+   * - Validates the requested version against the agent card's
+   *   `HTTP+JSON` interface list.
+   */
+  const buildContext = async (req: Request): Promise<ServerCallContext> => {
+    const user = await options.userBuilder(req);
+    const requestedVersion = req.header(A2A_VERSION_HEADER) || A2A_LEGACY_PROTOCOL_VERSION;
+    const context = new ServerCallContext({
+      requestedExtensions: Extensions.parseServiceParameter(
+        req.header(LEGACY_HTTP_EXTENSION_HEADER)
+      ),
+      user,
+      requestedVersion,
+    });
+    const agentCard = await transportHandler.getAgentCard();
+    validateVersion(context.requestedVersion, agentCard, 'HTTP+JSON');
+    return context;
+  };
+
+  /**
+   * Sets the legacy activated-extensions response header (if any).
+   */
+  const setExtensionsHeader = (res: Response, context: ServerCallContext): void => {
+    if (context.activatedExtensions) {
+      res.setHeader(LEGACY_HTTP_EXTENSION_HEADER, Array.from(context.activatedExtensions));
+    }
+  };
+
+  /**
+   * Sends a JSON response with the given status code. Bodies are
+   * already v0.3-shaped (no proto serializer roundtrip needed). For
+   * 204 responses the body is omitted.
+   */
+  const sendResponse = <T>(
+    res: Response,
+    statusCode: number,
+    context: ServerCallContext,
+    body?: T
+  ): void => {
+    setExtensionsHeader(res, context);
+    res.status(statusCode);
+    if (statusCode === HTTP_STATUS.NO_CONTENT) {
+      res.end();
+    } else {
+      res.json(body);
+    }
+  };
+
+  /**
+   * Streams v0.3-shaped events back as Server-Sent Events.
+   *
+   * Pulls the first event before flushing headers so an early error
+   * (e.g. `TaskNotFoundError`) is returned as a proper HTTP error code
+   * instead of a 200 followed by an SSE error event.
+   */
+  const sendStreamResponse = async (
+    res: Response,
+    stream: AsyncGenerator<legacy.SendStreamingMessageSuccessResponse['result'], void, undefined>,
+    context: ServerCallContext
+  ): Promise<void> => {
+    const iterator = stream[Symbol.asyncIterator]();
+    let firstResult: IteratorResult<legacy.SendStreamingMessageSuccessResponse['result']>;
+    try {
+      firstResult = await iterator.next();
+    } catch (error) {
+      setExtensionsHeader(res, context);
+      const statusCode = mapErrorToStatus(error);
+      res.status(statusCode).json(toLegacyHTTPError(error));
+      return;
+    }
+
+    Object.entries(SSE_HEADERS).forEach(([key, value]) => {
+      res.setHeader(key, value);
+    });
+    setExtensionsHeader(res, context);
+    res.flushHeaders();
+
+    try {
+      if (!firstResult.done) {
+        res.write(formatSSEEvent(firstResult.value));
+      }
+      for await (const event of { [Symbol.asyncIterator]: () => iterator }) {
+        res.write(formatSSEEvent(event));
+      }
+    } catch (streamError: unknown) {
+      console.error('Legacy SSE streaming error:', streamError);
+      if (!res.writableEnded) {
+        res.write(formatSSEErrorEvent(toLegacyHTTPError(streamError)));
+      }
+    } finally {
+      if (!res.writableEnded) {
+        res.end();
+      }
+    }
+  };
+
+  /**
+   * Centralized error handling for non-streaming route handlers.
+   */
+  const handleError = (res: Response, error: unknown): void => {
+    if (res.headersSent) {
+      if (!res.writableEnded) {
+        res.end();
+      }
+      return;
+    }
+    const statusCode = mapErrorToStatus(error);
+    res.status(statusCode).json(toLegacyHTTPError(error));
+  };
+
+  /**
+   * Wraps an async route handler with centralized error handling.
+   */
+  const asyncHandler = (handler: AsyncRouteHandler): AsyncRouteHandler => {
+    return async (req: Request, res: Response): Promise<void> => {
+      try {
+        await handler(req, res);
+      } catch (error) {
+        handleError(res, error);
+      }
+    };
+  };
+
+  // ==========================================================================
+  // Route Handlers
+  // ==========================================================================
+
+  /**
+   * GET /v1/card
+   *
+   * Retrieves the authenticated extended agent card.
+   */
+  router.get(
+    '/v1/card',
+    asyncHandler(async (req, res) => {
+      const context = await buildContext(req);
+      const result = await transportHandler.getAuthenticatedExtendedAgentCard(context);
+      sendResponse<legacy.AgentCard>(res, HTTP_STATUS.OK, context, result);
+    })
+  );
+
+  /**
+   * POST /v1/message:send
+   *
+   * Sends a message synchronously. Returns either a v0.3 `Task` or `Message`.
+   * The colon is escaped to satisfy Express's path-to-regexp parser.
+   */
+  router.post(
+    '/v1/message\\:send',
+    asyncHandler(async (req, res) => {
+      const context = await buildContext(req);
+      const params = req.body as legacy.MessageSendParams;
+      const result = await transportHandler.sendMessage(params, context);
+      // Match the v0.3 reference status: 201 Created for successful sends.
+      sendResponse(res, HTTP_STATUS.CREATED, context, result);
+    })
+  );
+
+  /**
+   * POST /v1/message:stream
+   *
+   * Sends a message with a streaming SSE response.
+   */
+  router.post(
+    '/v1/message\\:stream',
+    asyncHandler(async (req, res) => {
+      const context = await buildContext(req);
+      const params = req.body as legacy.MessageSendParams;
+      const stream = await transportHandler.sendMessageStream(params, context);
+      await sendStreamResponse(res, stream, context);
+    })
+  );
+
+  /**
+   * GET /v1/tasks/:taskId
+   *
+   * Retrieves a task. Accepts both `?historyLength=` and `?history_length=`
+   * for compatibility with the v0.3 reference (which used snake_case query
+   * parameters in places).
+   */
+  router.get(
+    '/v1/tasks/:taskId',
+    asyncHandler(async (req, res) => {
+      const context = await buildContext(req);
+      const historyLength = req.query.historyLength ?? req.query.history_length;
+      const result = await transportHandler.getTask(req.params.taskId!, context, historyLength);
+      sendResponse<legacy.Task>(res, HTTP_STATUS.OK, context, result);
+    })
+  );
+
+  /**
+   * POST /v1/tasks/:taskId:cancel
+   *
+   * Attempts to cancel a task. Returns 202 Accepted on success.
+   */
+  router.post(
+    '/v1/tasks/:taskId\\:cancel',
+    asyncHandler(async (req, res) => {
+      const context = await buildContext(req);
+      const result = await transportHandler.cancelTask(req.params.taskId!, context);
+      sendResponse<legacy.Task>(res, HTTP_STATUS.ACCEPTED, context, result);
+    })
+  );
+
+  /**
+   * POST /v1/tasks/:taskId:subscribe
+   *
+   * Resubscribes to a task's update stream via SSE.
+   */
+  router.post(
+    '/v1/tasks/:taskId\\:subscribe',
+    asyncHandler(async (req, res) => {
+      const context = await buildContext(req);
+      const stream = await transportHandler.resubscribe(req.params.taskId!, context);
+      await sendStreamResponse(res, stream, context);
+    })
+  );
+
+  /**
+   * POST /v1/tasks/:taskId/pushNotificationConfigs
+   *
+   * Creates a push notification configuration. Returns 201 Created.
+   */
+  router.post(
+    '/v1/tasks/:taskId/pushNotificationConfigs',
+    asyncHandler(async (req, res) => {
+      const context = await buildContext(req);
+      const params = req.body as legacy.TaskPushNotificationConfig;
+      const result = await transportHandler.setTaskPushNotificationConfig(params, context);
+      sendResponse<legacy.TaskPushNotificationConfig>(res, HTTP_STATUS.CREATED, context, result);
+    })
+  );
+
+  /**
+   * GET /v1/tasks/:taskId/pushNotificationConfigs
+   *
+   * Lists all push notification configurations for a task.
+   */
+  router.get(
+    '/v1/tasks/:taskId/pushNotificationConfigs',
+    asyncHandler(async (req, res) => {
+      const context = await buildContext(req);
+      const result = await transportHandler.listTaskPushNotificationConfigs(
+        req.params.taskId!,
+        context
+      );
+      sendResponse<legacy.TaskPushNotificationConfig[]>(res, HTTP_STATUS.OK, context, result);
+    })
+  );
+
+  /**
+   * GET /v1/tasks/:taskId/pushNotificationConfigs/:configId
+   *
+   * Retrieves a specific push notification configuration.
+   */
+  router.get(
+    '/v1/tasks/:taskId/pushNotificationConfigs/:configId',
+    asyncHandler(async (req, res) => {
+      const context = await buildContext(req);
+      const result = await transportHandler.getTaskPushNotificationConfig(
+        req.params.taskId!,
+        req.params.configId!,
+        context
+      );
+      sendResponse<legacy.TaskPushNotificationConfig>(res, HTTP_STATUS.OK, context, result);
+    })
+  );
+
+  /**
+   * DELETE /v1/tasks/:taskId/pushNotificationConfigs/:configId
+   *
+   * Deletes a push notification configuration. Returns 204 No Content.
+   */
+  router.delete(
+    '/v1/tasks/:taskId/pushNotificationConfigs/:configId',
+    asyncHandler(async (req, res) => {
+      const context = await buildContext(req);
+      await transportHandler.deleteTaskPushNotificationConfig(
+        req.params.taskId!,
+        req.params.configId!,
+        context
+      );
+      sendResponse(res, HTTP_STATUS.NO_CONTENT, context);
+    })
+  );
+
+  // Note: `/v1/tasks` (ListTasks) is intentionally NOT registered.
+  // Per `V1_METHODS_WITHOUT_LEGACY_EQUIVALENT` (in `compat/v0_3/constants.ts`),
+  // the v0.3 protocol has no REST endpoint for listing tasks, so an
+  // attempt to GET `/v1/tasks` falls through to Express's default 404.
+
+  return router;
+}

--- a/src/compat/v0_3/server/express/rest_handler.ts
+++ b/src/compat/v0_3/server/express/rest_handler.ts
@@ -81,10 +81,11 @@ type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
 /**
  * Creates an Express router exposing the v0.3 HTTP+JSON/REST endpoints.
  *
- * All endpoints are mounted under the `/v1/...` prefix used by the v0.3
- * reference implementation, so the router can be safely composed with
- * the v1.0 `restHandler` on the same mount point without path
- * collisions.
+ * The routes are mount-relative (no `/v1` prefix on the route literals
+ * themselves). The caller is expected to mount the router under `/v1`,
+ * which is the path prefix used by the v0.3 reference implementation.
+ * The core `restHandler` does this automatically; standalone callers
+ * must do it explicitly.
  *
  * The router:
  *   - Parses `application/json` bodies via {@link LEGACY_JSON_CONTENT_TYPE}.
@@ -99,7 +100,7 @@ type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
  * @example
  * ```ts
  * import { legacyRestRouter } from '@a2a-js/sdk/compat/v0_3';
- * app.use('/api', legacyRestRouter({ requestHandler, userBuilder }));
+ * app.use('/api/v1', legacyRestRouter({ requestHandler, userBuilder }));
  * // → POST /api/v1/message:send
  * // → GET  /api/v1/tasks/:taskId
  * // …
@@ -256,13 +257,19 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   // Route Handlers
   // ==========================================================================
 
+  // The routes below are mount-relative: they assume the router is mounted
+  // by the caller under the v0.3 `/v1` prefix (the core `restHandler` does
+  // this; standalone callers must `app.use('/v1', legacyRestRouter(...))`).
+  // Keeping the routes prefix-free makes the legacy router path-agnostic
+  // and ensures the parent owns the path-prefix dispatch decision.
+
   /**
-   * GET /v1/card
+   * GET /card
    *
    * Retrieves the authenticated extended agent card.
    */
   router.get(
-    '/v1/card',
+    '/card',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await transportHandler.getAuthenticatedExtendedAgentCard(context);
@@ -271,13 +278,13 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * POST /v1/message:send
+   * POST /message:send
    *
    * Sends a message synchronously. Returns either a v0.3 `Task` or `Message`.
    * The colon is escaped to satisfy Express's path-to-regexp parser.
    */
   router.post(
-    '/v1/message\\:send',
+    '/message\\:send',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const params = req.body as legacy.MessageSendParams;
@@ -288,12 +295,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * POST /v1/message:stream
+   * POST /message:stream
    *
    * Sends a message with a streaming SSE response.
    */
   router.post(
-    '/v1/message\\:stream',
+    '/message\\:stream',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const params = req.body as legacy.MessageSendParams;
@@ -303,14 +310,14 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * GET /v1/tasks/:taskId
+   * GET /tasks/:taskId
    *
    * Retrieves a task. Accepts both `?historyLength=` and `?history_length=`
    * for compatibility with the v0.3 reference (which used snake_case query
    * parameters in places).
    */
   router.get(
-    '/v1/tasks/:taskId',
+    '/tasks/:taskId',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const historyLength = req.query.historyLength ?? req.query.history_length;
@@ -320,12 +327,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * POST /v1/tasks/:taskId:cancel
+   * POST /tasks/:taskId:cancel
    *
    * Attempts to cancel a task. Returns 202 Accepted on success.
    */
   router.post(
-    '/v1/tasks/:taskId\\:cancel',
+    '/tasks/:taskId\\:cancel',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await transportHandler.cancelTask(req.params.taskId!, context);
@@ -334,12 +341,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * POST /v1/tasks/:taskId:subscribe
+   * POST /tasks/:taskId:subscribe
    *
    * Resubscribes to a task's update stream via SSE.
    */
   router.post(
-    '/v1/tasks/:taskId\\:subscribe',
+    '/tasks/:taskId\\:subscribe',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const stream = await transportHandler.resubscribe(req.params.taskId!, context);
@@ -348,12 +355,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * POST /v1/tasks/:taskId/pushNotificationConfigs
+   * POST /tasks/:taskId/pushNotificationConfigs
    *
    * Creates a push notification configuration. Returns 201 Created.
    */
   router.post(
-    '/v1/tasks/:taskId/pushNotificationConfigs',
+    '/tasks/:taskId/pushNotificationConfigs',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const params = req.body as legacy.TaskPushNotificationConfig;
@@ -363,12 +370,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * GET /v1/tasks/:taskId/pushNotificationConfigs
+   * GET /tasks/:taskId/pushNotificationConfigs
    *
    * Lists all push notification configurations for a task.
    */
   router.get(
-    '/v1/tasks/:taskId/pushNotificationConfigs',
+    '/tasks/:taskId/pushNotificationConfigs',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await transportHandler.listTaskPushNotificationConfigs(
@@ -380,12 +387,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * GET /v1/tasks/:taskId/pushNotificationConfigs/:configId
+   * GET /tasks/:taskId/pushNotificationConfigs/:configId
    *
    * Retrieves a specific push notification configuration.
    */
   router.get(
-    '/v1/tasks/:taskId/pushNotificationConfigs/:configId',
+    '/tasks/:taskId/pushNotificationConfigs/:configId',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const result = await transportHandler.getTaskPushNotificationConfig(
@@ -398,12 +405,12 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
   );
 
   /**
-   * DELETE /v1/tasks/:taskId/pushNotificationConfigs/:configId
+   * DELETE /tasks/:taskId/pushNotificationConfigs/:configId
    *
    * Deletes a push notification configuration. Returns 204 No Content.
    */
   router.delete(
-    '/v1/tasks/:taskId/pushNotificationConfigs/:configId',
+    '/tasks/:taskId/pushNotificationConfigs/:configId',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       await transportHandler.deleteTaskPushNotificationConfig(
@@ -415,10 +422,11 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
     })
   );
 
-  // Note: `/v1/tasks` (ListTasks) is intentionally NOT registered.
+  // Note: `/tasks` (ListTasks) is intentionally NOT registered.
   // Per `V1_METHODS_WITHOUT_LEGACY_EQUIVALENT` (in `compat/v0_3/constants.ts`),
   // the v0.3 protocol has no REST endpoint for listing tasks, so an
-  // attempt to GET `/v1/tasks` falls through to Express's default 404.
+  // attempt to GET `/tasks` under the legacy mount falls through to the
+  // parent router (or, ultimately, Express's default 404).
 
   return router;
 }

--- a/src/compat/v0_3/server/index.ts
+++ b/src/compat/v0_3/server/index.ts
@@ -4,3 +4,9 @@
 
 export { A2AError as LegacyA2AError } from './error.js';
 export { LegacyJsonRpcTransportHandler } from './transports/jsonrpc/jsonrpc_transport_handler.js';
+export {
+  LegacyRestTransportHandler,
+  toLegacyHTTPError,
+  type LegacyRestErrorBody,
+} from './transports/rest/rest_transport_handler.js';
+export { legacyRestRouter, type LegacyRestHandlerOptions } from './express/rest_handler.js';

--- a/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
@@ -14,7 +14,7 @@
  * versions side-by-side.
  */
 
-import { A2A_ERROR_CODE } from '../../../../../errors.js';
+import { A2A_ERROR_CLASS_TO_CODE, A2A_ERROR_CODE } from '../../../../../errors.js';
 import type { ServerCallContext } from '../../../../../server/context.js';
 import type { A2ARequestHandler } from '../../../../../server/request_handler/a2a_request_handler.js';
 import {
@@ -64,34 +64,17 @@ export interface LegacyRestErrorBody {
 }
 
 /**
- * Maps v1.0 SDK error class names (`error.name`) to v0.3 numeric error
- * codes used in the HTTP error body. Keyed on `error.name` rather than
- * `instanceof` so we don't have to import every v1.0 error class here;
- * the mapping is identical to `A2A_ERROR_CLASS_TO_CODE` from the core
- * `errors.ts`, copied locally to keep the compat layer self-contained.
- */
-const LEGACY_HTTP_ERROR_CODE_BY_NAME: Record<string, number> = {
-  TaskNotFoundError: A2A_ERROR_CODE.TASK_NOT_FOUND,
-  TaskNotCancelableError: A2A_ERROR_CODE.TASK_NOT_CANCELABLE,
-  PushNotificationNotSupportedError: A2A_ERROR_CODE.PUSH_NOTIFICATION_NOT_SUPPORTED,
-  UnsupportedOperationError: A2A_ERROR_CODE.UNSUPPORTED_OPERATION,
-  ContentTypeNotSupportedError: A2A_ERROR_CODE.CONTENT_TYPE_NOT_SUPPORTED,
-  InvalidAgentResponseError: A2A_ERROR_CODE.INVALID_AGENT_RESPONSE,
-  ExtendedAgentCardNotConfiguredError: A2A_ERROR_CODE.EXTENDED_CARD_NOT_CONFIGURED,
-  ExtensionSupportRequiredError: A2A_ERROR_CODE.EXTENSION_SUPPORT_REQUIRED,
-  VersionNotSupportedError: A2A_ERROR_CODE.VERSION_NOT_SUPPORTED,
-  RequestMalformedError: A2A_ERROR_CODE.INVALID_PARAMS,
-  GenericError: A2A_ERROR_CODE.INTERNAL_ERROR,
-};
-
-/**
  * Converts any error to a v0.3-shaped HTTP error body.
  *
  * `LegacyA2AError` instances pass through with their `code`, `message`,
  * and `data` carried over. v1.0 SDK error classes
  * (`TaskNotFoundError`, …) are mapped to their corresponding numeric
- * codes (which are identical between v0.3 and v1.0 for the codes that
- * exist in both). Unknown errors fall through to `INTERNAL_ERROR`.
+ * codes via {@link A2A_ERROR_CLASS_TO_CODE} (these codes are identical
+ * between v0.3 and v1.0 for the codes that exist in both). Unknown
+ * errors fall through to `INTERNAL_ERROR`.
+ *
+ * Mirrors `LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError` in
+ * shape and uses the same centralized lookup table.
  */
 export function toLegacyHTTPError(error: unknown): LegacyRestErrorBody {
   if (error instanceof LegacyA2AError) {
@@ -100,7 +83,7 @@ export function toLegacyHTTPError(error: unknown): LegacyRestErrorBody {
     return body;
   }
   if (error instanceof Error) {
-    const code = LEGACY_HTTP_ERROR_CODE_BY_NAME[error.name];
+    const code = A2A_ERROR_CLASS_TO_CODE[error.name];
     if (code !== undefined) {
       return { code, message: error.message };
     }

--- a/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
@@ -136,7 +136,7 @@ export class LegacyRestTransportHandler {
    */
   async getAuthenticatedExtendedAgentCard(context: ServerCallContext): Promise<legacy.AgentCard> {
     const core = await this.requestHandler.getAuthenticatedExtendedAgentCard(
-      { tenant: '' },
+      { tenant: context.tenant ?? '' },
       context
     );
     return toCompatAgentCard(core);
@@ -163,7 +163,10 @@ export class LegacyRestTransportHandler {
     context: ServerCallContext
   ): Promise<legacy.Task | legacy.Message> {
     this.validateMessageSendParams(params);
-    const coreReq = toCoreSendMessageRequest(buildLegacySendRequest(params, 'message/send'));
+    const coreReq = toCoreSendMessageRequest(
+      buildLegacySendRequest(params, 'message/send'),
+      context.tenant ?? ''
+    );
     const result = await this.requestHandler.sendMessage(coreReq, context);
     return 'messageId' in result
       ? toCompatMessage(result as V1Message)
@@ -186,7 +189,10 @@ export class LegacyRestTransportHandler {
   > {
     await this.requireCapability('streaming');
     this.validateMessageSendParams(params);
-    const coreReq = toCoreSendMessageRequest(buildLegacySendRequest(params, 'message/stream'));
+    const coreReq = toCoreSendMessageRequest(
+      buildLegacySendRequest(params, 'message/stream'),
+      context.tenant ?? ''
+    );
     const stream = this.requestHandler.sendMessageStream(coreReq, context);
     return LegacyRestTransportHandler.translateStream(stream);
   }
@@ -194,6 +200,12 @@ export class LegacyRestTransportHandler {
   /**
    * Fetches a task by id, translated to v0.3 JSON.
    * Accepts optional `historyLength` (parsed/validated locally).
+   *
+   * `historyLength` is deliberately left absent on the params object
+   * when the caller did not supply it: per §3.2.4, `undefined` means
+   * "no client limit, return full history". Coercing the default to
+   * `0` here would silently change the semantics to "return no
+   * history".
    */
   async getTask(
     taskId: string,
@@ -202,8 +214,7 @@ export class LegacyRestTransportHandler {
   ): Promise<legacy.Task> {
     const params: Parameters<A2ARequestHandler['getTask']>[0] = {
       id: taskId,
-      historyLength: 0,
-      tenant: '',
+      tenant: context.tenant ?? '',
     };
     if (historyLength !== undefined) {
       params.historyLength = this.parseHistoryLength(historyLength);
@@ -217,7 +228,7 @@ export class LegacyRestTransportHandler {
    */
   async cancelTask(taskId: string, context: ServerCallContext): Promise<legacy.Task> {
     const core = await this.requestHandler.cancelTask(
-      { id: taskId, tenant: '', metadata: {} },
+      { id: taskId, tenant: context.tenant ?? '', metadata: {} },
       context
     );
     return toCompatTask(core);
@@ -237,7 +248,10 @@ export class LegacyRestTransportHandler {
     AsyncGenerator<legacy.SendStreamingMessageSuccessResponse['result'], void, undefined>
   > {
     await this.requireCapability('streaming');
-    const stream = this.requestHandler.resubscribe({ id: taskId, tenant: '' }, context);
+    const stream = this.requestHandler.resubscribe(
+      { id: taskId, tenant: context.tenant ?? '' },
+      context
+    );
     return LegacyRestTransportHandler.translateStream(stream);
   }
 
@@ -258,7 +272,7 @@ export class LegacyRestTransportHandler {
     if (!config.pushNotificationConfig) {
       throw LegacyA2AError.invalidParams('pushNotificationConfig is required');
     }
-    const core = toCoreTaskPushNotificationConfig(config);
+    const core = toCoreTaskPushNotificationConfig(config, context.tenant ?? '');
     const result = await this.requestHandler.createTaskPushNotificationConfig(core, context);
     return toCompatTaskPushNotificationConfig(result);
   }
@@ -272,7 +286,7 @@ export class LegacyRestTransportHandler {
     context: ServerCallContext
   ): Promise<legacy.TaskPushNotificationConfig[]> {
     const result = await this.requestHandler.listTaskPushNotificationConfigs(
-      { taskId, pageSize: 0, pageToken: '', tenant: '' },
+      { taskId, pageSize: 0, pageToken: '', tenant: context.tenant ?? '' },
       context
     );
     return result.configs.map((cfg) => toCompatTaskPushNotificationConfig(cfg));
@@ -287,7 +301,7 @@ export class LegacyRestTransportHandler {
     context: ServerCallContext
   ): Promise<legacy.TaskPushNotificationConfig> {
     const result = await this.requestHandler.getTaskPushNotificationConfig(
-      { taskId, id: configId, tenant: '' },
+      { taskId, id: configId, tenant: context.tenant ?? '' },
       context
     );
     return toCompatTaskPushNotificationConfig(result);
@@ -302,7 +316,7 @@ export class LegacyRestTransportHandler {
     context: ServerCallContext
   ): Promise<void> {
     await this.requestHandler.deleteTaskPushNotificationConfig(
-      { taskId, id: configId, tenant: '' },
+      { taskId, id: configId, tenant: context.tenant ?? '' },
       context
     );
   }

--- a/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
@@ -382,23 +382,18 @@ export class LegacyRestTransportHandler {
  * Wraps a v0.3 `MessageSendParams` in a minimal v0.3 JSON-RPC request
  * envelope so it can be fed through `toCoreSendMessageRequest` (which
  * was originally written for the JSON-RPC path and expects the
- * `{ params: { … } }` wrapping). The `id` and `method` fields are
- * placeholders; only `params` is consumed by the translator.
+ * `{ params: { … } }` wrapping).
+ *
+ * The `jsonrpc`, `id`, and `method` fields are placeholders: only
+ * `params` is consumed by the translator, but they're required by the
+ * envelope's TypeScript shape. The return type is the union
+ * `SendMessageRequest | SendStreamingMessageRequest` because the
+ * translator accepts either; the caller picks one via the `method`
+ * argument purely to satisfy the discriminated-union envelope.
  */
-function buildLegacySendRequest(
-  params: legacy.MessageSendParams,
-  method: 'message/send'
-): legacy.SendMessageRequest;
-function buildLegacySendRequest(
-  params: legacy.MessageSendParams,
-  method: 'message/stream'
-): legacy.SendStreamingMessageRequest;
 function buildLegacySendRequest(
   params: legacy.MessageSendParams,
   method: 'message/send' | 'message/stream'
 ): legacy.SendMessageRequest | legacy.SendStreamingMessageRequest {
-  if (method === 'message/send') {
-    return { jsonrpc: '2.0', id: 0, method, params };
-  }
   return { jsonrpc: '2.0', id: 0, method, params };
 }

--- a/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
@@ -1,0 +1,421 @@
+/**
+ * v0.3 HTTP+JSON (REST) Transport Handler.
+ *
+ * Mirrors {@link import('../../../../../server/transports/rest/rest_transport_handler.js').RestTransportHandler}
+ * (the v1.0 handler) but accepts v0.3-shaped JSON payloads and returns
+ * v0.3-shaped JSON results. Inbound params are translated to v1.0 proto
+ * values via the `toCore*` helpers in `../../../translate/requests.js`,
+ * dispatched to the v1.0 {@link A2ARequestHandler}, and translated back
+ * to v0.3 JSON via the `toCompat*` helpers before being returned to the
+ * Express layer.
+ *
+ * Designed to share an `A2ARequestHandler` instance with the v1.0
+ * handler so a single agent implementation can serve both protocol
+ * versions side-by-side.
+ */
+
+import { A2A_ERROR_CODE } from '../../../../../errors.js';
+import type { ServerCallContext } from '../../../../../server/context.js';
+import type { A2ARequestHandler } from '../../../../../server/request_handler/a2a_request_handler.js';
+import {
+  HTTP_STATUS,
+  mapErrorToStatus,
+} from '../../../../../server/transports/rest/rest_transport_handler.js';
+import type {
+  AgentCard as V1AgentCard,
+  Message as V1Message,
+  StreamResponse as V1StreamResponse,
+  Task as V1Task,
+} from '../../../../../types/pb/a2a.js';
+import { toCompatAgentCard } from '../../../translate/agent_card.js';
+import { toCompatMessage } from '../../../translate/messages.js';
+import {
+  toCompatTaskPushNotificationConfig,
+  toCoreTaskPushNotificationConfig,
+} from '../../../translate/push_notifications.js';
+import { toCompatStreamResponse, toCoreSendMessageRequest } from '../../../translate/requests.js';
+import { toCompatTask } from '../../../translate/tasks.js';
+import type * as legacy from '../../../types/types.js';
+import { A2AError as LegacyA2AError } from '../../error.js';
+
+// Re-export the shared HTTP status / error mapping helpers from the v1.0
+// transport handler. Numeric A2A error codes and their HTTP semantics
+// are identical between v0.3 and v1.0 for every code that exists in
+// both, so no parallel implementation is needed.
+export { HTTP_STATUS, mapErrorToStatus };
+
+// ============================================================================
+// HTTP Error Conversion (v0.3 wire shape)
+// ============================================================================
+
+/**
+ * v0.3-shaped HTTP error body.
+ *
+ * The v0.3 reference implementation returned errors as a bare
+ * `{ code, message, data? }` object (no `details[]` array, no `status`
+ * field, no outer `{ error: {...} }` wrapper). v1.0 introduced the
+ * structured `google.rpc.Status` JSON envelope, so this shape is kept
+ * separate to preserve wire-compatibility with v0.3 clients.
+ */
+export interface LegacyRestErrorBody {
+  code: number;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Maps v1.0 SDK error class names (`error.name`) to v0.3 numeric error
+ * codes used in the HTTP error body. Keyed on `error.name` rather than
+ * `instanceof` so we don't have to import every v1.0 error class here;
+ * the mapping is identical to `A2A_ERROR_CLASS_TO_CODE` from the core
+ * `errors.ts`, copied locally to keep the compat layer self-contained.
+ */
+const LEGACY_HTTP_ERROR_CODE_BY_NAME: Record<string, number> = {
+  TaskNotFoundError: A2A_ERROR_CODE.TASK_NOT_FOUND,
+  TaskNotCancelableError: A2A_ERROR_CODE.TASK_NOT_CANCELABLE,
+  PushNotificationNotSupportedError: A2A_ERROR_CODE.PUSH_NOTIFICATION_NOT_SUPPORTED,
+  UnsupportedOperationError: A2A_ERROR_CODE.UNSUPPORTED_OPERATION,
+  ContentTypeNotSupportedError: A2A_ERROR_CODE.CONTENT_TYPE_NOT_SUPPORTED,
+  InvalidAgentResponseError: A2A_ERROR_CODE.INVALID_AGENT_RESPONSE,
+  ExtendedAgentCardNotConfiguredError: A2A_ERROR_CODE.EXTENDED_CARD_NOT_CONFIGURED,
+  ExtensionSupportRequiredError: A2A_ERROR_CODE.EXTENSION_SUPPORT_REQUIRED,
+  VersionNotSupportedError: A2A_ERROR_CODE.VERSION_NOT_SUPPORTED,
+  RequestMalformedError: A2A_ERROR_CODE.INVALID_PARAMS,
+  GenericError: A2A_ERROR_CODE.INTERNAL_ERROR,
+};
+
+/**
+ * Converts any error to a v0.3-shaped HTTP error body.
+ *
+ * `LegacyA2AError` instances pass through with their `code`, `message`,
+ * and `data` carried over. v1.0 SDK error classes
+ * (`TaskNotFoundError`, …) are mapped to their corresponding numeric
+ * codes (which are identical between v0.3 and v1.0 for the codes that
+ * exist in both). Unknown errors fall through to `INTERNAL_ERROR`.
+ */
+export function toLegacyHTTPError(error: unknown): LegacyRestErrorBody {
+  if (error instanceof LegacyA2AError) {
+    const body: LegacyRestErrorBody = { code: error.code, message: error.message };
+    if (error.data !== undefined) body.data = error.data;
+    return body;
+  }
+  if (error instanceof Error) {
+    const code = LEGACY_HTTP_ERROR_CODE_BY_NAME[error.name];
+    if (code !== undefined) {
+      return { code, message: error.message };
+    }
+  }
+  const message = (error instanceof Error && error.message) || 'An unexpected error occurred.';
+  return { code: A2A_ERROR_CODE.INTERNAL_ERROR, message };
+}
+
+// ============================================================================
+// REST Transport Handler Class
+// ============================================================================
+
+/**
+ * Handles v0.3 REST transport, routing requests to a v1.0
+ * {@link A2ARequestHandler}.
+ *
+ * Each public method:
+ *   1. Accepts v0.3-shaped JSON params (already parsed from `req.body`,
+ *      `req.params`, or `req.query` by the Express layer).
+ *   2. Translates the params to v1.0 proto via the matching `toCore*`
+ *      helper.
+ *   3. Awaits the v1.0 request handler.
+ *   4. Translates the v1.0 result back to v0.3 JSON via the matching
+ *      `toCompat*` helper.
+ *
+ * Streaming methods return an `AsyncGenerator` of v0.3-shaped
+ * `SendStreamingMessageSuccessResponse.result` payloads
+ * (`Task | Message | TaskStatusUpdateEvent | TaskArtifactUpdateEvent`).
+ */
+export class LegacyRestTransportHandler {
+  private requestHandler: A2ARequestHandler;
+
+  constructor(requestHandler: A2ARequestHandler) {
+    this.requestHandler = requestHandler;
+  }
+
+  // ==========================================================================
+  // Public API Methods
+  // ==========================================================================
+
+  /**
+   * Returns the v1.0 agent card (used for capability checks).
+   */
+  async getAgentCard(): Promise<V1AgentCard> {
+    return this.requestHandler.getAgentCard();
+  }
+
+  /**
+   * Returns the authenticated extended agent card translated to v0.3 JSON.
+   */
+  async getAuthenticatedExtendedAgentCard(context: ServerCallContext): Promise<legacy.AgentCard> {
+    const core = await this.requestHandler.getAuthenticatedExtendedAgentCard(
+      { tenant: '' },
+      context
+    );
+    return toCompatAgentCard(core);
+  }
+
+  /**
+   * Validates that the v0.3 `MessageSendParams` is well-formed.
+   */
+  private validateMessageSendParams(params: legacy.MessageSendParams): void {
+    if (!params.message) {
+      throw LegacyA2AError.invalidParams('message is required');
+    }
+    if (!params.message.messageId) {
+      throw LegacyA2AError.invalidParams('message.messageId is required');
+    }
+  }
+
+  /**
+   * Sends a message to the agent (synchronous).
+   * Returns either a v0.3 `Task` or `Message` envelope.
+   */
+  async sendMessage(
+    params: legacy.MessageSendParams,
+    context: ServerCallContext
+  ): Promise<legacy.Task | legacy.Message> {
+    this.validateMessageSendParams(params);
+    const coreReq = toCoreSendMessageRequest(buildLegacySendRequest(params, 'message/send'));
+    const result = await this.requestHandler.sendMessage(coreReq, context);
+    return 'messageId' in result
+      ? toCompatMessage(result as V1Message)
+      : toCompatTask(result as V1Task);
+  }
+
+  /**
+   * Sends a message to the agent with a streaming response.
+   * Yields v0.3-shaped stream event payloads (the `.result` portion of
+   * the v0.3 `SendStreamingMessageSuccessResponse`).
+   *
+   * @throws {LegacyA2AError} `unsupportedOperation` (-32004) if the
+   *   agent does not advertise streaming.
+   */
+  async sendMessageStream(
+    params: legacy.MessageSendParams,
+    context: ServerCallContext
+  ): Promise<
+    AsyncGenerator<legacy.SendStreamingMessageSuccessResponse['result'], void, undefined>
+  > {
+    await this.requireCapability('streaming');
+    this.validateMessageSendParams(params);
+    const coreReq = toCoreSendMessageRequest(buildLegacySendRequest(params, 'message/stream'));
+    const stream = this.requestHandler.sendMessageStream(coreReq, context);
+    return LegacyRestTransportHandler.translateStream(stream);
+  }
+
+  /**
+   * Fetches a task by id, translated to v0.3 JSON.
+   * Accepts optional `historyLength` (parsed/validated locally).
+   */
+  async getTask(
+    taskId: string,
+    context: ServerCallContext,
+    historyLength?: unknown
+  ): Promise<legacy.Task> {
+    const params: Parameters<A2ARequestHandler['getTask']>[0] = {
+      id: taskId,
+      historyLength: 0,
+      tenant: '',
+    };
+    if (historyLength !== undefined) {
+      params.historyLength = this.parseHistoryLength(historyLength);
+    }
+    const core = await this.requestHandler.getTask(params, context);
+    return toCompatTask(core);
+  }
+
+  /**
+   * Cancels a task, returning the updated v0.3 `Task` envelope.
+   */
+  async cancelTask(taskId: string, context: ServerCallContext): Promise<legacy.Task> {
+    const core = await this.requestHandler.cancelTask(
+      { id: taskId, tenant: '', metadata: {} },
+      context
+    );
+    return toCompatTask(core);
+  }
+
+  /**
+   * Resubscribes to a task's update stream.
+   * Yields v0.3-shaped stream event payloads.
+   *
+   * @throws {LegacyA2AError} `unsupportedOperation` (-32004) if the
+   *   agent does not advertise streaming.
+   */
+  async resubscribe(
+    taskId: string,
+    context: ServerCallContext
+  ): Promise<
+    AsyncGenerator<legacy.SendStreamingMessageSuccessResponse['result'], void, undefined>
+  > {
+    await this.requireCapability('streaming');
+    const stream = this.requestHandler.resubscribe({ id: taskId, tenant: '' }, context);
+    return LegacyRestTransportHandler.translateStream(stream);
+  }
+
+  /**
+   * Creates a push notification configuration (v0.3 calls this "set").
+   *
+   * @throws {LegacyA2AError} `pushNotificationNotSupported` (-32003) if
+   *   the agent does not advertise push notifications.
+   */
+  async setTaskPushNotificationConfig(
+    config: legacy.TaskPushNotificationConfig,
+    context: ServerCallContext
+  ): Promise<legacy.TaskPushNotificationConfig> {
+    await this.requireCapability('pushNotifications');
+    if (!config.taskId) {
+      throw LegacyA2AError.invalidParams('taskId is required');
+    }
+    if (!config.pushNotificationConfig) {
+      throw LegacyA2AError.invalidParams('pushNotificationConfig is required');
+    }
+    const core = toCoreTaskPushNotificationConfig(config);
+    const result = await this.requestHandler.createTaskPushNotificationConfig(core, context);
+    return toCompatTaskPushNotificationConfig(result);
+  }
+
+  /**
+   * Lists all push notification configurations for a task.
+   * Returns a v0.3-shaped array of `TaskPushNotificationConfig`.
+   */
+  async listTaskPushNotificationConfigs(
+    taskId: string,
+    context: ServerCallContext
+  ): Promise<legacy.TaskPushNotificationConfig[]> {
+    const result = await this.requestHandler.listTaskPushNotificationConfigs(
+      { taskId, pageSize: 0, pageToken: '', tenant: '' },
+      context
+    );
+    return result.configs.map((cfg) => toCompatTaskPushNotificationConfig(cfg));
+  }
+
+  /**
+   * Fetches a specific push notification configuration, translated to v0.3 JSON.
+   */
+  async getTaskPushNotificationConfig(
+    taskId: string,
+    configId: string,
+    context: ServerCallContext
+  ): Promise<legacy.TaskPushNotificationConfig> {
+    const result = await this.requestHandler.getTaskPushNotificationConfig(
+      { taskId, id: configId, tenant: '' },
+      context
+    );
+    return toCompatTaskPushNotificationConfig(result);
+  }
+
+  /**
+   * Deletes a push notification configuration.
+   */
+  async deleteTaskPushNotificationConfig(
+    taskId: string,
+    configId: string,
+    context: ServerCallContext
+  ): Promise<void> {
+    await this.requestHandler.deleteTaskPushNotificationConfig(
+      { taskId, id: configId, tenant: '' },
+      context
+    );
+  }
+
+  // ==========================================================================
+  // Helpers
+  // ==========================================================================
+
+  /**
+   * Wraps a v1.0 stream into a v0.3 stream by translating each event via
+   * `toCompatStreamResponse` and unwrapping the JSON-RPC envelope (REST
+   * SSE events carry only the `.result` payload, not the JSON-RPC
+   * wrapper).
+   */
+  private static async *translateStream(
+    stream: AsyncGenerator<V1StreamResponse, void, undefined>
+  ): AsyncGenerator<legacy.SendStreamingMessageSuccessResponse['result'], void, undefined> {
+    for await (const event of stream) {
+      const envelope = toCompatStreamResponse(event, null);
+      yield envelope.result;
+    }
+  }
+
+  /**
+   * Static map of capability to error factory for missing capabilities.
+   */
+  private static readonly CAPABILITY_ERRORS: Record<
+    'streaming' | 'pushNotifications',
+    () => LegacyA2AError
+  > = {
+    streaming: () => LegacyA2AError.unsupportedOperation('Agent does not support streaming'),
+    pushNotifications: () => LegacyA2AError.pushNotificationNotSupported(),
+  };
+
+  /**
+   * Validates that the agent supports a required capability.
+   *
+   * @throws {LegacyA2AError} `unsupportedOperation` for streaming,
+   *   `pushNotificationNotSupported` for push notifications.
+   */
+  private async requireCapability(capability: 'streaming' | 'pushNotifications'): Promise<void> {
+    const agentCard = await this.getAgentCard();
+    if (!agentCard.capabilities?.[capability]) {
+      throw LegacyRestTransportHandler.CAPABILITY_ERRORS[capability]();
+    }
+  }
+
+  /**
+   * Parses and validates the `historyLength` query parameter.
+   */
+  private parseHistoryLength(value: unknown): number {
+    if (value === undefined || value === null) {
+      throw LegacyA2AError.invalidParams('historyLength is required');
+    }
+    const parsed = parseInt(String(value), 10);
+    if (isNaN(parsed)) {
+      throw LegacyA2AError.invalidParams('historyLength must be a valid integer');
+    }
+    if (parsed < 0) {
+      throw LegacyA2AError.invalidParams('historyLength must be non-negative');
+    }
+    return parsed;
+  }
+
+  /**
+   * Converts any error to a v0.3-shaped HTTP error body. Exposed
+   * statically so the Express layer can reuse the same mapping logic
+   * without holding a transport-handler instance. Mirrors
+   * `LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError`.
+   */
+  public static mapToLegacyHTTPError(error: unknown): LegacyRestErrorBody {
+    return toLegacyHTTPError(error);
+  }
+}
+
+/**
+ * Wraps a v0.3 `MessageSendParams` in a minimal v0.3 JSON-RPC request
+ * envelope so it can be fed through `toCoreSendMessageRequest` (which
+ * was originally written for the JSON-RPC path and expects the
+ * `{ params: { … } }` wrapping). The `id` and `method` fields are
+ * placeholders; only `params` is consumed by the translator.
+ */
+function buildLegacySendRequest(
+  params: legacy.MessageSendParams,
+  method: 'message/send'
+): legacy.SendMessageRequest;
+function buildLegacySendRequest(
+  params: legacy.MessageSendParams,
+  method: 'message/stream'
+): legacy.SendStreamingMessageRequest;
+function buildLegacySendRequest(
+  params: legacy.MessageSendParams,
+  method: 'message/send' | 'message/stream'
+): legacy.SendMessageRequest | legacy.SendStreamingMessageRequest {
+  if (method === 'message/send') {
+    return { jsonrpc: '2.0', id: 0, method, params };
+  }
+  return { jsonrpc: '2.0', id: 0, method, params };
+}

--- a/src/compat/v0_3/translate/push_notifications.ts
+++ b/src/compat/v0_3/translate/push_notifications.ts
@@ -70,15 +70,17 @@ export function toCompatAuthenticationInfo(
  * Converts a v0.3 JSON `PushNotificationConfig` (the inner record) into a
  * v1.0 proto `TaskPushNotificationConfig` minus its `taskId` (the caller
  * supplies that when stitching together a full
- * `TaskPushNotificationConfig`). The result has `taskId` and `tenant` set
- * to the proto3 empty-string default — typically overridden by
- * `toCoreTaskPushNotificationConfig`.
+ * `TaskPushNotificationConfig`). `taskId` is set to the proto3
+ * empty-string default; `tenant` defaults to `''` (global tenant) and
+ * may be overridden by the caller — typically by
+ * `toCoreTaskPushNotificationConfig` plumbing the URL tenant.
  */
 export function toCorePushNotificationConfig(
-  compat: legacy.PushNotificationConfig | legacy.PushNotificationConfig1
+  compat: legacy.PushNotificationConfig | legacy.PushNotificationConfig1,
+  tenant: string = ''
 ): V1TaskPushNotificationConfig {
   return {
-    tenant: '',
+    tenant,
     taskId: '',
     id: compat.id ?? '',
     url: compat.url,
@@ -116,12 +118,16 @@ export function toCompatPushNotificationConfig(
  * Converts a v0.3 JSON `TaskPushNotificationConfig` (with the nested
  * `pushNotificationConfig`) into a v1.0 proto flat
  * `TaskPushNotificationConfig`.
+ *
+ * v0.3 has no concept of tenants; the caller may supply the v1.0
+ * `tenant` value out-of-band. Defaults to `''` (global tenant).
  */
 export function toCoreTaskPushNotificationConfig(
-  compat: legacy.TaskPushNotificationConfig
+  compat: legacy.TaskPushNotificationConfig,
+  tenant: string = ''
 ): V1TaskPushNotificationConfig {
   return {
-    tenant: '',
+    tenant,
     taskId: compat.taskId,
     id: compat.pushNotificationConfig.id ?? '',
     url: compat.pushNotificationConfig.url,

--- a/src/compat/v0_3/translate/requests.ts
+++ b/src/compat/v0_3/translate/requests.ts
@@ -98,12 +98,18 @@ export function toCompatSendMessageConfiguration(
 /**
  * v0.3 `SendMessageRequest` (or `SendStreamingMessageRequest`) →
  * v1.0 proto `SendMessageRequest`.
+ *
+ * v0.3 has no concept of tenants, so the caller may supply the v1.0
+ * `tenant` value out-of-band (e.g. from a URL path parameter resolved
+ * by the Express layer). Defaults to `''` for the global tenant when
+ * unspecified, matching the original v0.3 semantics.
  */
 export function toCoreSendMessageRequest(
-  compat: legacy.SendMessageRequest | legacy.SendStreamingMessageRequest
+  compat: legacy.SendMessageRequest | legacy.SendStreamingMessageRequest,
+  tenant: string = ''
 ): V1SendMessageRequest {
   return {
-    tenant: '',
+    tenant,
     message: toCoreMessage(compat.params.message),
     configuration: compat.params.configuration
       ? toCoreSendMessageConfiguration(compat.params.configuration)
@@ -274,10 +280,18 @@ export function toCompatStreamResponse(
 
 /* --------------------------------- GetTask --------------------------------- */
 
-/** v0.3 `GetTaskRequest` → v1.0 proto `GetTaskRequest`. */
-export function toCoreGetTaskRequest(compat: legacy.GetTaskRequest): V1GetTaskRequest {
+/**
+ * v0.3 `GetTaskRequest` → v1.0 proto `GetTaskRequest`.
+ *
+ * v0.3 has no concept of tenants; the caller may supply the v1.0
+ * `tenant` value out-of-band. Defaults to `''` (global tenant).
+ */
+export function toCoreGetTaskRequest(
+  compat: legacy.GetTaskRequest,
+  tenant: string = ''
+): V1GetTaskRequest {
   return {
-    tenant: '',
+    tenant,
     id: compat.params.id,
     historyLength: compat.params.historyLength,
   };
@@ -295,10 +309,18 @@ export function toCompatGetTaskRequest(
 
 /* --------------------------------- CancelTask --------------------------------- */
 
-/** v0.3 `CancelTaskRequest` → v1.0 proto `CancelTaskRequest`. */
-export function toCoreCancelTaskRequest(compat: legacy.CancelTaskRequest): V1CancelTaskRequest {
+/**
+ * v0.3 `CancelTaskRequest` → v1.0 proto `CancelTaskRequest`.
+ *
+ * v0.3 has no concept of tenants; the caller may supply the v1.0
+ * `tenant` value out-of-band. Defaults to `''` (global tenant).
+ */
+export function toCoreCancelTaskRequest(
+  compat: legacy.CancelTaskRequest,
+  tenant: string = ''
+): V1CancelTaskRequest {
   return {
-    tenant: '',
+    tenant,
     id: compat.params.id,
     metadata: deepCloneMetadata(compat.params.metadata),
   };
@@ -317,11 +339,17 @@ export function toCompatCancelTaskRequest(
 
 /* --------------------------------- SubscribeToTask --------------------------------- */
 
-/** v0.3 `TaskResubscriptionRequest` → v1.0 proto `SubscribeToTaskRequest`. */
+/**
+ * v0.3 `TaskResubscriptionRequest` → v1.0 proto `SubscribeToTaskRequest`.
+ *
+ * v0.3 has no concept of tenants; the caller may supply the v1.0
+ * `tenant` value out-of-band. Defaults to `''` (global tenant).
+ */
 export function toCoreSubscribeToTaskRequest(
-  compat: legacy.TaskResubscriptionRequest
+  compat: legacy.TaskResubscriptionRequest,
+  tenant: string = ''
 ): V1SubscribeToTaskRequest {
-  return { tenant: '', id: compat.params.id };
+  return { tenant, id: compat.params.id };
 }
 
 /** v1.0 proto `SubscribeToTaskRequest` → v0.3 `TaskResubscriptionRequest`. */
@@ -343,11 +371,15 @@ export function toCompatTaskResubscriptionRequest(
  * v0.3 `SetTaskPushNotificationConfigRequest` → v1.0 proto
  * `TaskPushNotificationConfig` (used as the request body for
  * `CreateTaskPushNotificationConfig`).
+ *
+ * v0.3 has no concept of tenants; the caller may supply the v1.0
+ * `tenant` value out-of-band. Defaults to `''` (global tenant).
  */
 export function toCoreCreateTaskPushNotificationConfigRequest(
-  compat: legacy.SetTaskPushNotificationConfigRequest
+  compat: legacy.SetTaskPushNotificationConfigRequest,
+  tenant: string = ''
 ): V1TaskPushNotificationConfig {
-  return toCoreTaskPushNotificationConfig(compat.params);
+  return toCoreTaskPushNotificationConfig(compat.params, tenant);
 }
 
 /**
@@ -366,16 +398,22 @@ export function toCompatSetTaskPushNotificationConfigRequest(
   };
 }
 
-/** v0.3 `GetTaskPushNotificationConfigRequest` → v1.0 proto request. */
+/**
+ * v0.3 `GetTaskPushNotificationConfigRequest` → v1.0 proto request.
+ *
+ * v0.3 has no concept of tenants; the caller may supply the v1.0
+ * `tenant` value out-of-band. Defaults to `''` (global tenant).
+ */
 export function toCoreGetTaskPushNotificationConfigRequest(
-  compat: legacy.GetTaskPushNotificationConfigRequest
+  compat: legacy.GetTaskPushNotificationConfigRequest,
+  tenant: string = ''
 ): V1GetTaskPushNotificationConfigRequest {
   const params = compat.params;
   // Both `GetTaskPushNotificationConfigParams` and `TaskIdParams1` carry `id`.
   // The former additionally carries `pushNotificationConfigId`.
   const configId =
     'pushNotificationConfigId' in params ? params.pushNotificationConfigId : undefined;
-  return { tenant: '', taskId: params.id, id: configId ?? '' };
+  return { tenant, taskId: params.id, id: configId ?? '' };
 }
 
 /** v1.0 proto request → v0.3 `GetTaskPushNotificationConfigRequest`. */
@@ -393,12 +431,18 @@ export function toCompatGetTaskPushNotificationConfigRequest(
   };
 }
 
-/** v0.3 `DeleteTaskPushNotificationConfigRequest` → v1.0 proto request. */
+/**
+ * v0.3 `DeleteTaskPushNotificationConfigRequest` → v1.0 proto request.
+ *
+ * v0.3 has no concept of tenants; the caller may supply the v1.0
+ * `tenant` value out-of-band. Defaults to `''` (global tenant).
+ */
 export function toCoreDeleteTaskPushNotificationConfigRequest(
-  compat: legacy.DeleteTaskPushNotificationConfigRequest
+  compat: legacy.DeleteTaskPushNotificationConfigRequest,
+  tenant: string = ''
 ): V1DeleteTaskPushNotificationConfigRequest {
   return {
-    tenant: '',
+    tenant,
     taskId: compat.params.id,
     id: compat.params.pushNotificationConfigId,
   };
@@ -417,11 +461,17 @@ export function toCompatDeleteTaskPushNotificationConfigRequest(
   };
 }
 
-/** v0.3 `ListTaskPushNotificationConfigRequest` → v1.0 proto request. */
+/**
+ * v0.3 `ListTaskPushNotificationConfigRequest` → v1.0 proto request.
+ *
+ * v0.3 has no concept of tenants; the caller may supply the v1.0
+ * `tenant` value out-of-band. Defaults to `''` (global tenant).
+ */
 export function toCoreListTaskPushNotificationConfigsRequest(
-  compat: legacy.ListTaskPushNotificationConfigRequest
+  compat: legacy.ListTaskPushNotificationConfigRequest,
+  tenant: string = ''
 ): V1ListTaskPushNotificationConfigsRequest {
-  return { tenant: '', taskId: compat.params.id, pageSize: 0, pageToken: '' };
+  return { tenant, taskId: compat.params.id, pageSize: 0, pageToken: '' };
 }
 
 /** v1.0 proto request → v0.3 `ListTaskPushNotificationConfigRequest`. */
@@ -463,11 +513,17 @@ export function toCompatListTaskPushNotificationConfigSuccessResponse(
 
 /* --------------------------------- GetExtendedAgentCard --------------------------------- */
 
-/** v0.3 `GetAuthenticatedExtendedCardRequest` → v1.0 proto `GetExtendedAgentCardRequest`. */
+/**
+ * v0.3 `GetAuthenticatedExtendedCardRequest` → v1.0 proto `GetExtendedAgentCardRequest`.
+ *
+ * v0.3 has no concept of tenants; the caller may supply the v1.0
+ * `tenant` value out-of-band. Defaults to `''` (global tenant).
+ */
 export function toCoreGetExtendedAgentCardRequest(
-  _compat: legacy.GetAuthenticatedExtendedCardRequest
+  _compat: legacy.GetAuthenticatedExtendedCardRequest,
+  tenant: string = ''
 ): V1GetExtendedAgentCardRequest {
-  return { tenant: '' };
+  return { tenant };
 }
 
 /** v1.0 proto `GetExtendedAgentCardRequest` → v0.3 `GetAuthenticatedExtendedCardRequest`. */

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -45,6 +45,22 @@ import { RequestMalformedError } from '../../errors.js';
 export interface RestHandlerOptions {
   requestHandler: A2ARequestHandler;
   userBuilder: UserBuilder;
+  /**
+   * Enables the v0.3 protocol compatibility layer.
+   *
+   * When enabled, the handler accepts v0.3-shaped requests
+   * (`A2A-Version: 0.3`, or no header per §3.6.2) on the v0.3
+   * reference URL paths (`/v1/...`) and routes them through the
+   * compat module mounted at the top of the router.
+   *
+   * Default: omitted (treated as disabled). To accept v0.3 clients,
+   * the agent card MUST also declare a v0.3 `HTTP+JSON` interface in
+   * `supportedInterfaces`; see §3.6.2.
+   *
+   * When disabled, the v0.3 compatibility code is not instantiated and
+   * v0.3-shaped requests are rejected by the v1.0 version validator.
+   */
+  legacyCompat?: { enabled: boolean };
 }
 
 /**
@@ -109,14 +125,20 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   const router = express.Router();
   const restTransportHandler = new RestTransportHandler(options.requestHandler);
 
-  // Mount the v0.3 compat router under `/v1`. This is the path-prefix
-  // dispatch point between v0.3 and v1.0: anything under `/v1/*` is
-  // handled by the legacy router with its own middleware (body parser,
-  // content-type setter, error handler); anything else falls through to
-  // the v1.0 middleware and routes below. The two route sets are
-  // disjoint by mount point, so neither version's middleware ever runs
-  // for the other version's requests.
-  router.use('/v1', legacyRestRouter(options));
+  // Opt-in v0.3 compatibility. When enabled, the legacy router is
+  // mounted at the top of the chain (path-less). Dispatch between the
+  // v0.3 and v1.0 layers happens INSIDE the legacy router via a
+  // header-based middleware that parses `A2A-Version` and short-circuits
+  // non-legacy requests via `next('router')`. Path-based dispatch is
+  // intentionally avoided so the v1.0 spec's tenant routes
+  // (`/:tenant/...`) remain free to use `v1` (or any other label) as a
+  // tenant identifier without colliding with the v0.3 reference URLs.
+  // When `legacyCompat` is omitted or disabled, the compat module is
+  // never instantiated and v0.3-shaped requests are rejected by the
+  // v1.0 version validator.
+  if (options.legacyCompat?.enabled) {
+    router.use(legacyRestRouter(options));
+  }
 
   router.use(
     (_req: Request, res: Response, next: NextFunction) => {

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -23,6 +23,7 @@ import {
 import { UserBuilder } from './common.js';
 import { Extensions } from '../../extensions.js';
 import { validateVersion } from '../version.js';
+import { legacyRestRouter } from '../../compat/v0_3/server/express/rest_handler.js';
 
 import {
   AgentCard,
@@ -107,6 +108,13 @@ type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
 export function restHandler(options: RestHandlerOptions): RequestHandler {
   const router = express.Router();
   const restTransportHandler = new RestTransportHandler(options.requestHandler);
+
+  // Mount the v0.3 compat router first. It owns every `/v1/...` path and
+  // brings its own middleware (body parser, content-type setter, error
+  // handler). The two route sets are disjoint by path prefix so the v1.0
+  // middleware below never runs for legacy requests, and `/v1/...`
+  // requests never reach the v1.0 routes.
+  router.use(legacyRestRouter(options));
 
   router.use(
     (_req: Request, res: Response, next: NextFunction) => {

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -109,12 +109,14 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   const router = express.Router();
   const restTransportHandler = new RestTransportHandler(options.requestHandler);
 
-  // Mount the v0.3 compat router first. It owns every `/v1/...` path and
-  // brings its own middleware (body parser, content-type setter, error
-  // handler). The two route sets are disjoint by path prefix so the v1.0
-  // middleware below never runs for legacy requests, and `/v1/...`
-  // requests never reach the v1.0 routes.
-  router.use(legacyRestRouter(options));
+  // Mount the v0.3 compat router under `/v1`. This is the path-prefix
+  // dispatch point between v0.3 and v1.0: anything under `/v1/*` is
+  // handled by the legacy router with its own middleware (body parser,
+  // content-type setter, error handler); anything else falls through to
+  // the v1.0 middleware and routes below. The two route sets are
+  // disjoint by mount point, so neither version's middleware ever runs
+  // for the other version's requests.
+  router.use('/v1', legacyRestRouter(options));
 
   router.use(
     (_req: Request, res: Response, next: NextFunction) => {

--- a/test/compat/v0_3/server/transports/rest/rest_transport_handler.spec.ts
+++ b/test/compat/v0_3/server/transports/rest/rest_transport_handler.spec.ts
@@ -1,0 +1,557 @@
+import { describe, it, beforeEach, afterEach, expect, vi, type Mock } from 'vitest';
+
+import {
+  HTTP_STATUS,
+  LegacyRestTransportHandler,
+  mapErrorToStatus,
+  toLegacyHTTPError,
+} from '../../../../../../src/compat/v0_3/server/transports/rest/rest_transport_handler.js';
+import { A2AError as LegacyA2AError } from '../../../../../../src/compat/v0_3/server/error.js';
+import { A2ARequestHandler } from '../../../../../../src/server/request_handler/a2a_request_handler.js';
+import { ServerCallContext } from '../../../../../../src/server/context.js';
+import {
+  ContentTypeNotSupportedError,
+  ExtendedAgentCardNotConfiguredError,
+  ExtensionSupportRequiredError,
+  GenericError,
+  InvalidAgentResponseError,
+  PushNotificationNotSupportedError,
+  RequestMalformedError,
+  TaskNotCancelableError,
+  TaskNotFoundError,
+  UnsupportedOperationError,
+  VersionNotSupportedError,
+} from '../../../../../../src/errors.js';
+import { Role, TaskState } from '../../../../../../src/types/pb/a2a.js';
+import type {
+  AgentCard as V1AgentCard,
+  Message as V1Message,
+  StreamResponse as V1StreamResponse,
+  Task as V1Task,
+  TaskPushNotificationConfig as V1TaskPushNotificationConfig,
+} from '../../../../../../src/types/pb/a2a.js';
+import type * as legacy from '../../../../../../src/compat/v0_3/types/types.js';
+
+describe('LegacyRestTransportHandler', () => {
+  let mockRequestHandler: A2ARequestHandler;
+  let transportHandler: LegacyRestTransportHandler;
+  let defaultContext: ServerCallContext;
+
+  const streamingAgentCard: V1AgentCard = {
+    name: 'Test',
+    description: '',
+    version: '1.0.0',
+    capabilities: { streaming: true, pushNotifications: true, extensions: [] },
+    defaultInputModes: [],
+    defaultOutputModes: [],
+    skills: [],
+    securityRequirements: [],
+    securitySchemes: {},
+    provider: undefined,
+    signatures: [],
+    supportedInterfaces: [
+      { url: 'http://x', protocolBinding: 'HTTP+JSON', tenant: '', protocolVersion: '0.3' },
+    ],
+    documentationUrl: '',
+    iconUrl: '',
+  };
+
+  const nonStreamingAgentCard: V1AgentCard = {
+    ...streamingAgentCard,
+    capabilities: { ...streamingAgentCard.capabilities, streaming: false },
+  };
+
+  const noPushAgentCard: V1AgentCard = {
+    ...streamingAgentCard,
+    capabilities: { ...streamingAgentCard.capabilities, pushNotifications: false },
+  };
+
+  function sampleV1Message(messageId = 'm-1'): V1Message {
+    return {
+      messageId,
+      contextId: '',
+      taskId: '',
+      role: Role.ROLE_AGENT,
+      parts: [],
+      metadata: undefined,
+      extensions: [],
+      referenceTaskIds: [],
+    };
+  }
+
+  function sampleV1Task(id = 't-1'): V1Task {
+    return {
+      id,
+      contextId: 'ctx',
+      status: {
+        state: TaskState.TASK_STATE_WORKING,
+        message: undefined,
+        timestamp: undefined,
+      },
+      artifacts: [],
+      history: [],
+      metadata: undefined,
+    };
+  }
+
+  function sampleV1TaskPushNotificationConfig(): V1TaskPushNotificationConfig {
+    return {
+      tenant: '',
+      id: 'cfg-1',
+      taskId: 't-1',
+      url: 'https://callback.example.com',
+      token: '',
+      authentication: undefined,
+    };
+  }
+
+  function sampleLegacyMessageSendParams(messageId = 'msg-1'): legacy.MessageSendParams {
+    return {
+      message: {
+        kind: 'message',
+        messageId,
+        role: 'user',
+        parts: [{ kind: 'text', text: 'hello' }],
+      },
+    };
+  }
+
+  function sampleLegacyTaskPushNotificationConfig(): legacy.TaskPushNotificationConfig {
+    return {
+      taskId: 't-1',
+      pushNotificationConfig: {
+        id: 'cfg-1',
+        url: 'https://callback.example.com',
+      },
+    };
+  }
+
+  beforeEach(() => {
+    mockRequestHandler = {
+      getAgentCard: vi.fn().mockResolvedValue(streamingAgentCard),
+      getAuthenticatedExtendedAgentCard: vi.fn(),
+      sendMessage: vi.fn(),
+      sendMessageStream: vi.fn(),
+      getTask: vi.fn(),
+      cancelTask: vi.fn(),
+      createTaskPushNotificationConfig: vi.fn(),
+      getTaskPushNotificationConfig: vi.fn(),
+      listTaskPushNotificationConfigs: vi.fn(),
+      deleteTaskPushNotificationConfig: vi.fn(),
+      resubscribe: vi.fn(),
+      listTasks: vi.fn(),
+    };
+    transportHandler = new LegacyRestTransportHandler(mockRequestHandler);
+    defaultContext = new ServerCallContext();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ==========================================================================
+  // HTTP status mapping
+  // ==========================================================================
+
+  describe('mapErrorToStatus', () => {
+    it('maps TaskNotFoundError to 404', () => {
+      expect(mapErrorToStatus(new TaskNotFoundError('x'))).toBe(HTTP_STATUS.NOT_FOUND);
+    });
+    it('maps RequestMalformedError to 400', () => {
+      expect(mapErrorToStatus(new RequestMalformedError('x'))).toBe(HTTP_STATUS.BAD_REQUEST);
+    });
+    it('maps unknown errors to 500', () => {
+      expect(mapErrorToStatus(new Error('???'))).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR);
+    });
+  });
+
+  // ==========================================================================
+  // Error body shape
+  // ==========================================================================
+
+  describe('toLegacyHTTPError / mapToLegacyHTTPError', () => {
+    it('passes through LegacyA2AError unchanged', () => {
+      const err = LegacyA2AError.taskNotFound('t-1');
+      const body = toLegacyHTTPError(err);
+      expect(body.code).toBe(-32001);
+      expect(body.message).toContain('t-1');
+    });
+
+    it('includes data field when LegacyA2AError carries data', () => {
+      const err = LegacyA2AError.invalidParams('boom', { hint: 'check x' });
+      const body = toLegacyHTTPError(err);
+      expect(body.code).toBe(-32602);
+      expect(body.data).toEqual({ hint: 'check x' });
+    });
+
+    const v1ToLegacyCodeCases: Array<[Error, number]> = [
+      [new TaskNotFoundError('a'), -32001],
+      [new TaskNotCancelableError('a'), -32002],
+      [new PushNotificationNotSupportedError('a'), -32003],
+      [new UnsupportedOperationError('a'), -32004],
+      [new ContentTypeNotSupportedError('a'), -32005],
+      [new InvalidAgentResponseError('a'), -32006],
+      [new ExtendedAgentCardNotConfiguredError('a'), -32007],
+      [new ExtensionSupportRequiredError('a'), -32008],
+      [new VersionNotSupportedError('a'), -32009],
+      [new RequestMalformedError('a'), -32602],
+      [new GenericError('a'), -32603],
+    ];
+
+    v1ToLegacyCodeCases.forEach(([err, expectedCode]) => {
+      it(`maps ${err.name} to code ${expectedCode}`, () => {
+        const body = toLegacyHTTPError(err);
+        expect(body.code).toBe(expectedCode);
+        expect(body.message).toBe('a');
+      });
+    });
+
+    it('omits the data field on v1 SDK errors (v0.3 shape compatibility)', () => {
+      const body = toLegacyHTTPError(new TaskNotFoundError('t'));
+      expect(body).not.toHaveProperty('data');
+    });
+
+    it('produces a bare body without an outer error wrapper or details array', () => {
+      const body = toLegacyHTTPError(new TaskNotFoundError('t'));
+      expect(body).not.toHaveProperty('error');
+      expect(body).not.toHaveProperty('details');
+      expect(body).not.toHaveProperty('status');
+      expect(Object.keys(body).sort()).toEqual(['code', 'message']);
+    });
+
+    it('falls back to INTERNAL_ERROR for unknown errors', () => {
+      const body = toLegacyHTTPError(new Error('unexpected'));
+      expect(body.code).toBe(-32603);
+      expect(body.message).toBe('unexpected');
+    });
+
+    it('exposes the same mapping via the static method', () => {
+      const a = toLegacyHTTPError(new TaskNotFoundError('t'));
+      const b = LegacyRestTransportHandler.mapToLegacyHTTPError(new TaskNotFoundError('t'));
+      expect(a).toEqual(b);
+    });
+  });
+
+  // ==========================================================================
+  // sendMessage
+  // ==========================================================================
+
+  describe('sendMessage', () => {
+    it('translates v0.3 params to a v1 SendMessageRequest', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockResolvedValue(sampleV1Message());
+      await transportHandler.sendMessage(sampleLegacyMessageSendParams(), defaultContext);
+
+      const call = (mockRequestHandler.sendMessage as Mock).mock.calls[0][0];
+      expect(call.tenant).toBe('');
+      expect(call.message.messageId).toBe('msg-1');
+      expect(call.message.role).toBe(Role.ROLE_USER);
+    });
+
+    it('returns a v0.3 Message envelope when sendMessage returns a Message', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockResolvedValue(sampleV1Message('m-out'));
+      const result = (await transportHandler.sendMessage(
+        sampleLegacyMessageSendParams(),
+        defaultContext
+      )) as legacy.Message;
+      expect(result.kind).toBe('message');
+      expect(result.messageId).toBe('m-out');
+    });
+
+    it('returns a v0.3 Task envelope when sendMessage returns a Task', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockResolvedValue(sampleV1Task('t-out'));
+      const result = (await transportHandler.sendMessage(
+        sampleLegacyMessageSendParams(),
+        defaultContext
+      )) as legacy.Task;
+      expect(result.kind).toBe('task');
+      expect(result.id).toBe('t-out');
+    });
+
+    it('rejects when message is missing', async () => {
+      await expect(
+        transportHandler.sendMessage(
+          { message: undefined as unknown as legacy.Message },
+          defaultContext
+        )
+      ).rejects.toBeInstanceOf(LegacyA2AError);
+    });
+
+    it('rejects when message.messageId is missing', async () => {
+      await expect(
+        transportHandler.sendMessage(
+          {
+            message: {
+              kind: 'message',
+              messageId: '',
+              role: 'user',
+              parts: [],
+            },
+          },
+          defaultContext
+        )
+      ).rejects.toMatchObject({ code: -32602 });
+    });
+  });
+
+  // ==========================================================================
+  // sendMessageStream
+  // ==========================================================================
+
+  describe('sendMessageStream', () => {
+    it('rejects when streaming is not supported', async () => {
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(nonStreamingAgentCard);
+      await expect(
+        transportHandler.sendMessageStream(sampleLegacyMessageSendParams(), defaultContext)
+      ).rejects.toMatchObject({ code: -32004 });
+    });
+
+    it('translates each v1 StreamResponse event into a v0.3 result payload', async () => {
+      async function* events(): AsyncGenerator<V1StreamResponse, void, undefined> {
+        yield { payload: { $case: 'task', value: sampleV1Task('t-s') } };
+        yield {
+          payload: {
+            $case: 'statusUpdate',
+            value: {
+              taskId: 't-s',
+              contextId: 'ctx',
+              status: {
+                state: TaskState.TASK_STATE_COMPLETED,
+                message: undefined,
+                timestamp: undefined,
+              },
+              metadata: undefined,
+            },
+          },
+        };
+      }
+      (mockRequestHandler.sendMessageStream as Mock).mockReturnValue(events());
+
+      const generator = await transportHandler.sendMessageStream(
+        sampleLegacyMessageSendParams(),
+        defaultContext
+      );
+      const collected: legacy.SendStreamingMessageSuccessResponse['result'][] = [];
+      for await (const event of generator) {
+        collected.push(event);
+      }
+      expect(collected).toHaveLength(2);
+      expect((collected[0] as legacy.Task).kind).toBe('task');
+      expect((collected[1] as legacy.TaskStatusUpdateEvent).kind).toBe('status-update');
+      expect((collected[1] as legacy.TaskStatusUpdateEvent).final).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // getTask
+  // ==========================================================================
+
+  describe('getTask', () => {
+    it('translates params and returns the v0.3 Task', async () => {
+      (mockRequestHandler.getTask as Mock).mockResolvedValue(sampleV1Task('t-99'));
+      const result = await transportHandler.getTask('t-99', defaultContext, '3');
+      const call = (mockRequestHandler.getTask as Mock).mock.calls[0][0];
+      expect(call.tenant).toBe('');
+      expect(call.id).toBe('t-99');
+      expect(call.historyLength).toBe(3);
+
+      expect(result.kind).toBe('task');
+      expect(result.id).toBe('t-99');
+    });
+
+    it('omits historyLength when not provided', async () => {
+      (mockRequestHandler.getTask as Mock).mockResolvedValue(sampleV1Task('t-2'));
+      await transportHandler.getTask('t-2', defaultContext);
+      const call = (mockRequestHandler.getTask as Mock).mock.calls[0][0];
+      expect(call.historyLength).toBe(0);
+    });
+
+    it('rejects an invalid historyLength (non-numeric)', async () => {
+      await expect(transportHandler.getTask('t-1', defaultContext, 'abc')).rejects.toMatchObject({
+        code: -32602,
+      });
+    });
+
+    it('rejects a negative historyLength', async () => {
+      await expect(transportHandler.getTask('t-1', defaultContext, '-2')).rejects.toMatchObject({
+        code: -32602,
+      });
+    });
+  });
+
+  // ==========================================================================
+  // cancelTask
+  // ==========================================================================
+
+  describe('cancelTask', () => {
+    it('returns the canceled v0.3 Task', async () => {
+      (mockRequestHandler.cancelTask as Mock).mockResolvedValue(sampleV1Task('t-c'));
+      const result = await transportHandler.cancelTask('t-c', defaultContext);
+      expect((mockRequestHandler.cancelTask as Mock).mock.calls[0][0].id).toBe('t-c');
+      expect(result.kind).toBe('task');
+      expect(result.id).toBe('t-c');
+    });
+  });
+
+  // ==========================================================================
+  // resubscribe
+  // ==========================================================================
+
+  describe('resubscribe', () => {
+    it('rejects when streaming is not supported', async () => {
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(nonStreamingAgentCard);
+      await expect(transportHandler.resubscribe('t-1', defaultContext)).rejects.toMatchObject({
+        code: -32004,
+      });
+    });
+
+    it('forwards the task id and translates events', async () => {
+      async function* events(): AsyncGenerator<V1StreamResponse, void, undefined> {
+        yield { payload: { $case: 'task', value: sampleV1Task('t-r') } };
+      }
+      (mockRequestHandler.resubscribe as Mock).mockReturnValue(events());
+
+      const generator = await transportHandler.resubscribe('t-r', defaultContext);
+      const collected: legacy.SendStreamingMessageSuccessResponse['result'][] = [];
+      for await (const event of generator) {
+        collected.push(event);
+      }
+      const call = (mockRequestHandler.resubscribe as Mock).mock.calls[0][0];
+      expect(call.id).toBe('t-r');
+      expect(collected).toHaveLength(1);
+      expect((collected[0] as legacy.Task).kind).toBe('task');
+    });
+  });
+
+  // ==========================================================================
+  // setTaskPushNotificationConfig
+  // ==========================================================================
+
+  describe('setTaskPushNotificationConfig', () => {
+    it('rejects when push notifications are not supported', async () => {
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(noPushAgentCard);
+      await expect(
+        transportHandler.setTaskPushNotificationConfig(
+          sampleLegacyTaskPushNotificationConfig(),
+          defaultContext
+        )
+      ).rejects.toMatchObject({ code: -32003 });
+    });
+
+    it('rejects when taskId is missing', async () => {
+      await expect(
+        transportHandler.setTaskPushNotificationConfig(
+          {
+            taskId: '',
+            pushNotificationConfig: { url: 'http://x' },
+          },
+          defaultContext
+        )
+      ).rejects.toMatchObject({ code: -32602 });
+    });
+
+    it('rejects when pushNotificationConfig is missing', async () => {
+      await expect(
+        transportHandler.setTaskPushNotificationConfig(
+          {
+            taskId: 't-1',
+            pushNotificationConfig: undefined as unknown as legacy.PushNotificationConfig1,
+          },
+          defaultContext
+        )
+      ).rejects.toMatchObject({ code: -32602 });
+    });
+
+    it('translates the v0.3 config and returns a v0.3 config', async () => {
+      (mockRequestHandler.createTaskPushNotificationConfig as Mock).mockResolvedValue(
+        sampleV1TaskPushNotificationConfig()
+      );
+      const result = await transportHandler.setTaskPushNotificationConfig(
+        sampleLegacyTaskPushNotificationConfig(),
+        defaultContext
+      );
+      const call = (mockRequestHandler.createTaskPushNotificationConfig as Mock).mock.calls[0][0];
+      expect(call.taskId).toBe('t-1');
+      expect(call.url).toBe('https://callback.example.com');
+
+      expect(result.taskId).toBe('t-1');
+      expect(result.pushNotificationConfig.url).toBe('https://callback.example.com');
+    });
+  });
+
+  // ==========================================================================
+  // listTaskPushNotificationConfigs
+  // ==========================================================================
+
+  describe('listTaskPushNotificationConfigs', () => {
+    it('returns a v0.3 array of configs', async () => {
+      (mockRequestHandler.listTaskPushNotificationConfigs as Mock).mockResolvedValue({
+        configs: [sampleV1TaskPushNotificationConfig()],
+        nextPageToken: '',
+      });
+      const result = await transportHandler.listTaskPushNotificationConfigs('t-1', defaultContext);
+      const call = (mockRequestHandler.listTaskPushNotificationConfigs as Mock).mock.calls[0][0];
+      expect(call.taskId).toBe('t-1');
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      expect(result[0].taskId).toBe('t-1');
+    });
+  });
+
+  // ==========================================================================
+  // getTaskPushNotificationConfig
+  // ==========================================================================
+
+  describe('getTaskPushNotificationConfig', () => {
+    it('translates params and returns the v0.3 config', async () => {
+      (mockRequestHandler.getTaskPushNotificationConfig as Mock).mockResolvedValue(
+        sampleV1TaskPushNotificationConfig()
+      );
+      const result = await transportHandler.getTaskPushNotificationConfig(
+        't-1',
+        'cfg-1',
+        defaultContext
+      );
+      const call = (mockRequestHandler.getTaskPushNotificationConfig as Mock).mock.calls[0][0];
+      expect(call.taskId).toBe('t-1');
+      expect(call.id).toBe('cfg-1');
+
+      expect(result.taskId).toBe('t-1');
+      expect(result.pushNotificationConfig.id).toBe('cfg-1');
+    });
+  });
+
+  // ==========================================================================
+  // deleteTaskPushNotificationConfig
+  // ==========================================================================
+
+  describe('deleteTaskPushNotificationConfig', () => {
+    it('forwards translated params and returns void', async () => {
+      (mockRequestHandler.deleteTaskPushNotificationConfig as Mock).mockResolvedValue(undefined);
+      const result = await transportHandler.deleteTaskPushNotificationConfig(
+        't-1',
+        'cfg-1',
+        defaultContext
+      );
+      const call = (mockRequestHandler.deleteTaskPushNotificationConfig as Mock).mock.calls[0][0];
+      expect(call.taskId).toBe('t-1');
+      expect(call.id).toBe('cfg-1');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // ==========================================================================
+  // getAuthenticatedExtendedAgentCard
+  // ==========================================================================
+
+  describe('getAuthenticatedExtendedAgentCard', () => {
+    it('returns a v0.3-shaped AgentCard', async () => {
+      (mockRequestHandler.getAuthenticatedExtendedAgentCard as Mock).mockResolvedValue(
+        streamingAgentCard
+      );
+      const result = await transportHandler.getAuthenticatedExtendedAgentCard(defaultContext);
+      expect(result.url).toBe('http://x');
+      expect(result.protocolVersion).toBe('0.3');
+    });
+  });
+});

--- a/test/compat/v0_3/server/transports/rest/rest_transport_handler.spec.ts
+++ b/test/compat/v0_3/server/transports/rest/rest_transport_handler.spec.ts
@@ -358,11 +358,35 @@ describe('LegacyRestTransportHandler', () => {
       expect(result.id).toBe('t-99');
     });
 
-    it('omits historyLength when not provided', async () => {
+    it('leaves historyLength absent when not provided (full-history semantics per §3.2.4)', async () => {
       (mockRequestHandler.getTask as Mock).mockResolvedValue(sampleV1Task('t-2'));
       await transportHandler.getTask('t-2', defaultContext);
       const call = (mockRequestHandler.getTask as Mock).mock.calls[0][0];
+      // undefined means "no client limit, return full history"; coercing
+      // the default to 0 would silently flip semantics to "no history".
+      expect(call.historyLength).toBeUndefined();
+    });
+
+    it('passes historyLength = 0 through when the client explicitly requests no history', async () => {
+      (mockRequestHandler.getTask as Mock).mockResolvedValue(sampleV1Task('t-3'));
+      await transportHandler.getTask('t-3', defaultContext, '0');
+      const call = (mockRequestHandler.getTask as Mock).mock.calls[0][0];
       expect(call.historyLength).toBe(0);
+    });
+
+    it('passes historyLength = N through for N > 0', async () => {
+      (mockRequestHandler.getTask as Mock).mockResolvedValue(sampleV1Task('t-4'));
+      await transportHandler.getTask('t-4', defaultContext, '7');
+      const call = (mockRequestHandler.getTask as Mock).mock.calls[0][0];
+      expect(call.historyLength).toBe(7);
+    });
+
+    it('forwards context.tenant when supplied', async () => {
+      (mockRequestHandler.getTask as Mock).mockResolvedValue(sampleV1Task('t-5'));
+      const tenantContext = new ServerCallContext({ tenant: 'tenant-x' });
+      await transportHandler.getTask('t-5', tenantContext);
+      const call = (mockRequestHandler.getTask as Mock).mock.calls[0][0];
+      expect(call.tenant).toBe('tenant-x');
     });
 
     it('rejects an invalid historyLength (non-numeric)', async () => {

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -1158,5 +1158,40 @@ describe('restHandler', () => {
 
       assert.equal(response.headers['x-a2a-extensions'], 'ext-1');
     });
+
+    it('returns v1.0-shaped error for malformed JSON on v1.0 paths', async () => {
+      // The legacy router is mounted under `/v1`, so its body parser and
+      // error handler do not run for requests that hit v1.0 paths. A
+      // malformed-JSON request to /message:send (no /v1 prefix) must
+      // therefore yield the v1.0 error envelope, not the bare v0.3 shape.
+      const response = await request(dualApp)
+        .post('/message:send')
+        .set('A2A-Version', '1.0')
+        .set('Content-Type', 'application/json')
+        .send('{not valid json')
+        .expect(400);
+
+      // v1.0 envelope shape: { error: { code, status, message, details } }.
+      assert.property(response.body, 'error');
+      assert.equal(response.body.error.code, 400);
+      assert.property(response.body.error, 'details');
+      // v0.3 bare body fields must NOT appear at the top level.
+      assert.notProperty(response.body, 'code');
+      assert.notProperty(response.body, 'message');
+    });
+
+    it('returns v0.3-shaped error for malformed JSON on /v1/... paths', async () => {
+      const response = await request(dualApp)
+        .post('/v1/message:send')
+        .set('Content-Type', 'application/json')
+        .send('{not valid json')
+        .expect(400);
+
+      // v0.3 bare body shape: { code, message }.
+      assert.equal(response.body.code, -32700); // PARSE_ERROR
+      assert.property(response.body, 'message');
+      assert.notProperty(response.body, 'error');
+      assert.notProperty(response.body, 'details');
+    });
   });
 });

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -978,6 +978,7 @@ describe('restHandler', () => {
         restHandler({
           requestHandler: mockRequestHandler,
           userBuilder: UserBuilder.noAuthentication,
+          legacyCompat: { enabled: true },
         })
       );
     });
@@ -1091,22 +1092,20 @@ describe('restHandler', () => {
       assert.notProperty(response.body, 'status');
     });
 
-    it('does not register GET /v1/tasks on the legacy router (ListTasks not in v0.3 REST)', async () => {
-      // ListTasks has no v0.3 equivalent (see V1_METHODS_WITHOUT_LEGACY_EQUIVALENT).
-      // The legacy router intentionally does not register /v1/tasks. To
-      // confirm the legacy transport handler is not invoked for that path
-      // we spy on its (non-existent) list method indirectly via the agent
-      // request handler.
+    it('does not invoke the legacy handler for GET /v1/tasks with A2A-Version: 1.0', async () => {
+      // `/v1/tasks` has no exact match in the legacy router (only
+      // `/v1/tasks/:taskId` is registered). With `A2A-Version: 1.0` the
+      // version-dispatch middleware short-circuits BEFORE any legacy
+      // route can match, falling through to the v1.0 router which then
+      // matches `/:tenant/tasks` with `tenant='v1'` — exercising the
+      // tenant-name reservation fix.
       const legacyListSpy = vi.spyOn(LegacyRestTransportHandler.prototype, 'getTask');
       (mockRequestHandler.listTasks as Mock).mockResolvedValue({ tasks: [], nextPageToken: '' });
 
-      // Request falls through to the v1.0 router. Whether v1.0 matches it
-      // (under `/:tenant/tasks` with tenant='v1') or returns 404 is an
-      // implementation detail of the v1.0 router; what matters here is
-      // that the legacy router did NOT handle it.
       await request(dualApp).get('/v1/tasks').set('A2A-Version', '1.0');
 
       expect(legacyListSpy).not.toHaveBeenCalled();
+      expect(mockRequestHandler.listTasks).toHaveBeenCalled();
     });
 
     it('sets Content-Type application/json on legacy responses', async () => {
@@ -1160,10 +1159,11 @@ describe('restHandler', () => {
     });
 
     it('returns v1.0-shaped error for malformed JSON on v1.0 paths', async () => {
-      // The legacy router is mounted under `/v1`, so its body parser and
-      // error handler do not run for requests that hit v1.0 paths. A
-      // malformed-JSON request to /message:send (no /v1 prefix) must
-      // therefore yield the v1.0 error envelope, not the bare v0.3 shape.
+      // The legacy router's version-dispatch middleware short-circuits
+      // requests with `A2A-Version: 1.0` (via `next('router')`) BEFORE
+      // the legacy body parser runs. A malformed-JSON request to
+      // `/message:send` with v1.0 must therefore yield the v1.0 error
+      // envelope, not the bare v0.3 shape.
       const response = await request(dualApp)
         .post('/message:send')
         .set('A2A-Version', '1.0')
@@ -1192,6 +1192,181 @@ describe('restHandler', () => {
       assert.property(response.body, 'message');
       assert.notProperty(response.body, 'error');
       assert.notProperty(response.body, 'details');
+    });
+
+    // ========================================================================
+    // Opt-in flag matrix
+    // ========================================================================
+
+    it('rejects /v1/message:send when legacyCompat is omitted (flag default)', async () => {
+      // Use a v1.0-only card so the v1.0 version validator cleanly rejects
+      // header-less / 0.3-defaulted requests with a 400.
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(testAgentCard);
+      const optOutApp = express();
+      optOutApp.use(
+        restHandler({
+          requestHandler: mockRequestHandler,
+          userBuilder: UserBuilder.noAuthentication,
+          // legacyCompat omitted => disabled
+        })
+      );
+
+      const response = await request(optOutApp)
+        .post('/v1/message:send')
+        .send(legacyMessageBody)
+        .expect(400);
+
+      // v1.0 envelope: the legacy compat layer is not instantiated, so
+      // the request is rejected by the v1.0 version validator.
+      assert.property(response.body, 'error');
+      // Legacy code path is never invoked.
+      expect(legacySendMessageStub).not.toHaveBeenCalled();
+    });
+
+    it('rejects /v1/message:send when legacyCompat.enabled is false', async () => {
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(testAgentCard);
+      const optOutApp = express();
+      optOutApp.use(
+        restHandler({
+          requestHandler: mockRequestHandler,
+          userBuilder: UserBuilder.noAuthentication,
+          legacyCompat: { enabled: false },
+        })
+      );
+
+      const response = await request(optOutApp)
+        .post('/v1/message:send')
+        .send(legacyMessageBody)
+        .expect(400);
+
+      assert.property(response.body, 'error');
+      expect(legacySendMessageStub).not.toHaveBeenCalled();
+    });
+
+    // ========================================================================
+    // Tenant-collision regression
+    // ========================================================================
+
+    it("POST /v1/message:send with A2A-Version: 1.0 routes to v1.0 with tenant='v1'", async () => {
+      // The headline win of the version-based dispatch: with the
+      // legacy router mounted path-less, `/v1/...` is no longer a
+      // reserved namespace. A v1.0 request to `/v1/message:send` is
+      // matched by the v1.0 router's `/:tenant/message:send` route
+      // with `tenant='v1'` (per v1.0 tenant semantics).
+      (mockRequestHandler.sendMessage as Mock).mockResolvedValue({
+        ...testTask,
+        id: 'v1-task-with-tenant',
+      });
+
+      const message = ProtoMessage.toJSON({
+        ...testMessage,
+        messageId: 'msg-tenant',
+        role: Role.ROLE_USER,
+      });
+
+      await request(dualApp)
+        .post('/v1/message:send')
+        .set('A2A-Version', '1.0')
+        .send({ message, tenant: 'v1' })
+        .expect(200);
+
+      expect(legacySendMessageStub).not.toHaveBeenCalled();
+      expect(mockRequestHandler.sendMessage).toHaveBeenCalledTimes(1);
+      const call = (mockRequestHandler.sendMessage as Mock).mock.calls[0][0];
+      assert.equal(call.tenant, 'v1');
+    });
+
+    // ========================================================================
+    // Version-range dispatch ([0.3, 1.0))
+    // ========================================================================
+
+    it('routes A2A-Version: 0.5 (in legacy range) to the legacy handler', async () => {
+      // Card carries v0.3 but not v0.5; legacy router accepts the
+      // dispatch by range but the version validator then rejects.
+      const response = await request(dualApp)
+        .post('/v1/message:send')
+        .set('A2A-Version', '0.5')
+        .send(legacyMessageBody)
+        .expect(400);
+
+      // v0.3 bare body shape: the legacy router handled it.
+      assert.equal(response.body.code, -32009); // VERSION_NOT_SUPPORTED
+      assert.notProperty(response.body, 'error');
+      expect(legacySendMessageStub).not.toHaveBeenCalled();
+    });
+
+    it('routes A2A-Version: 2.0 (outside legacy range) to the v1.0 handler', async () => {
+      // v1.0 router will reject because the card has no (HTTP+JSON, 2.0).
+      const response = await request(dualApp)
+        .post('/v1/message:send')
+        .set('A2A-Version', '2.0')
+        .send(legacyMessageBody)
+        .expect(400);
+
+      // v1.0 envelope: the v1.0 router handled the rejection.
+      assert.property(response.body, 'error');
+      expect(legacySendMessageStub).not.toHaveBeenCalled();
+    });
+
+    it('routes A2A-Version: foo (unparseable) to the v1.0 handler', async () => {
+      const response = await request(dualApp)
+        .post('/v1/message:send')
+        .set('A2A-Version', 'foo')
+        .send(legacyMessageBody)
+        .expect(400);
+
+      assert.property(response.body, 'error');
+      expect(legacySendMessageStub).not.toHaveBeenCalled();
+    });
+
+    // ========================================================================
+    // Extension-header tolerance on the legacy path
+    // ========================================================================
+
+    it('accepts the v1.0 A2A-Extensions header on the legacy path', async () => {
+      // A v1.0-shaped client hitting a /v1 endpoint with the v1.0
+      // header should still get its requested extension activated.
+      legacySendMessageStub.mockImplementation(async (_params, context) => {
+        context.addActivatedExtension('ext-modern');
+        return {
+          kind: 'task',
+          id: 'legacy-task-modern-hdr',
+          contextId: 'ctx',
+          status: { state: 'working' },
+        };
+      });
+
+      const response = await request(dualApp)
+        .post('/v1/message:send')
+        .set('A2A-Extensions', 'ext-modern')
+        .send(legacyMessageBody)
+        .expect(201);
+
+      // Response always uses the v0.3 spelling on the legacy path.
+      assert.equal(response.headers['x-a2a-extensions'], 'ext-modern');
+    });
+
+    it('prefers X-A2A-Extensions when both spellings are present', async () => {
+      legacySendMessageStub.mockImplementation(async (_params, context) => {
+        for (const ext of context.requestedExtensions ?? []) {
+          context.addActivatedExtension(ext);
+        }
+        return {
+          kind: 'task',
+          id: 'legacy-task-both',
+          contextId: 'ctx',
+          status: { state: 'working' },
+        };
+      });
+
+      const response = await request(dualApp)
+        .post('/v1/message:send')
+        .set('X-A2A-Extensions', 'legacy-ext')
+        .set('A2A-Extensions', 'modern-ext')
+        .send(legacyMessageBody)
+        .expect(201);
+
+      assert.equal(response.headers['x-a2a-extensions'], 'legacy-ext');
     });
   });
 });

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -1,11 +1,22 @@
-import { describe, it, beforeEach, afterEach, assert, expect, vi, Mock } from 'vitest';
+import {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  assert,
+  expect,
+  vi,
+  type Mock,
+  type MockInstance,
+} from 'vitest';
 import express, { Express } from 'express';
 import request from 'supertest';
 
 import { restHandler, UserBuilder } from '../../../src/server/express/index.js';
 import { A2ARequestHandler } from '../../../src/server/request_handler/a2a_request_handler.js';
-import { AgentCard, Task, Message, TaskState } from '../../../src/index.js';
+import { AgentCard, Task, Message, TaskState, Role } from '../../../src/index.js';
 import {
+  GenericError,
   RequestMalformedError,
   TaskNotFoundError,
   TaskNotCancelableError,
@@ -17,6 +28,7 @@ import {
   TaskPushNotificationConfig,
 } from '../../../src/types/pb/a2a.js';
 import { FromProto } from '../../../src/types/converters/from_proto.js';
+import { LegacyRestTransportHandler } from '../../../src/compat/v0_3/server/transports/rest/rest_transport_handler.js';
 
 /**
  * Test suite for restHandler - HTTP+JSON/REST transport implementation
@@ -918,6 +930,233 @@ describe('restHandler', () => {
         .expect(200);
 
       assert.include(response.headers['content-type'], 'text/event-stream');
+    });
+  });
+
+  describe('legacy v0.3 REST dispatch', () => {
+    // Agent card declaring both v1.0 and v0.3 HTTP+JSON interfaces so
+    // version validation accepts requests from either path.
+    const dualVersionAgentCard: AgentCard = {
+      ...testAgentCard,
+      supportedInterfaces: [
+        {
+          url: 'http://localhost:8080/v1',
+          protocolBinding: 'HTTP+JSON',
+          tenant: '',
+          protocolVersion: '1.0',
+        },
+        {
+          url: 'http://localhost:8080/v1',
+          protocolBinding: 'HTTP+JSON',
+          tenant: '',
+          protocolVersion: '0.3',
+        },
+      ],
+    };
+
+    // v0.3 message payload (camelCase JSON, with the `kind` discriminator).
+    const legacyMessageBody = {
+      message: {
+        kind: 'message',
+        messageId: 'msg-legacy-1',
+        role: 'user',
+        parts: [{ kind: 'text', text: 'hello' }],
+      },
+    };
+
+    let legacySendMessageStub: MockInstance;
+    let v1SendMessageStub: MockInstance;
+    let dualApp: Express;
+
+    beforeEach(() => {
+      legacySendMessageStub = vi.spyOn(LegacyRestTransportHandler.prototype, 'sendMessage');
+      v1SendMessageStub = mockRequestHandler.sendMessage as Mock as MockInstance;
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(dualVersionAgentCard);
+
+      dualApp = express();
+      dualApp.use(
+        restHandler({
+          requestHandler: mockRequestHandler,
+          userBuilder: UserBuilder.noAuthentication,
+        })
+      );
+    });
+
+    it('routes POST /v1/message:send to the legacy handler', async () => {
+      legacySendMessageStub.mockResolvedValue({
+        kind: 'task',
+        id: 'legacy-task-1',
+        contextId: 'ctx',
+        status: { state: 'working' },
+      });
+
+      const response = await request(dualApp)
+        .post('/v1/message:send')
+        .set('A2A-Version', '0.3')
+        .send(legacyMessageBody)
+        .expect(201);
+
+      expect(legacySendMessageStub).toHaveBeenCalledTimes(1);
+      expect(v1SendMessageStub).not.toHaveBeenCalled();
+      assert.equal(response.body.kind, 'task');
+      assert.equal(response.body.id, 'legacy-task-1');
+    });
+
+    it('routes POST /message:send to the v1.0 handler', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockResolvedValue({
+        ...testTask,
+        id: 'v1-task-1',
+      });
+
+      const message = ProtoMessage.toJSON({
+        ...testMessage,
+        messageId: 'msg-v1-1',
+        role: Role.ROLE_USER,
+      });
+
+      await request(dualApp)
+        .post('/message:send')
+        .set('A2A-Version', '1.0')
+        .send({ message })
+        .expect(200);
+
+      expect(v1SendMessageStub).toHaveBeenCalledTimes(1);
+      expect(legacySendMessageStub).not.toHaveBeenCalled();
+    });
+
+    it('accepts header-less requests on the legacy path (defaults to 0.3)', async () => {
+      legacySendMessageStub.mockResolvedValue({
+        kind: 'task',
+        id: 'legacy-task-2',
+        contextId: 'ctx',
+        status: { state: 'working' },
+      });
+
+      // No A2A-Version header → defaults to A2A_LEGACY_PROTOCOL_VERSION
+      // ('0.3'). The dual-version card declares v0.3 so validateVersion passes.
+      await request(dualApp).post('/v1/message:send').send(legacyMessageBody).expect(201);
+
+      expect(legacySendMessageStub).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects legacy requests when the card declares no v0.3 interface', async () => {
+      // Restore the v1.0-only card.
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(testAgentCard);
+
+      const response = await request(dualApp)
+        .post('/v1/message:send')
+        .send(legacyMessageBody)
+        .expect(400);
+
+      assert.equal(response.body.code, -32009); // VERSION_NOT_SUPPORTED
+      expect(legacySendMessageStub).not.toHaveBeenCalled();
+    });
+
+    it('streams SSE responses on the legacy path', async () => {
+      const legacyStream = (async function* () {
+        yield {
+          kind: 'task',
+          id: 'legacy-stream-task',
+          contextId: 'ctx',
+          status: { state: 'working' },
+        };
+      })();
+      vi.spyOn(LegacyRestTransportHandler.prototype, 'sendMessageStream').mockResolvedValue(
+        legacyStream as any
+      );
+
+      const response = await request(dualApp)
+        .post('/v1/message:stream')
+        .send(legacyMessageBody)
+        .expect(200);
+
+      assert.include(response.headers['content-type'], 'text/event-stream');
+      assert.include(response.text, '"kind":"task"');
+    });
+
+    it('uses the legacy error mapper (bare body, no details[]) on legacy-path errors', async () => {
+      legacySendMessageStub.mockRejectedValue(new GenericError('legacy boom'));
+
+      const response = await request(dualApp)
+        .post('/v1/message:send')
+        .send(legacyMessageBody)
+        .expect(500);
+
+      assert.equal(response.body.code, -32603); // INTERNAL_ERROR
+      assert.equal(response.body.message, 'legacy boom');
+      // v0.3 body shape: bare {code, message, data?} — no details[], no
+      // outer {error: {...}} wrapper, no status field.
+      assert.notProperty(response.body, 'error');
+      assert.notProperty(response.body, 'details');
+      assert.notProperty(response.body, 'status');
+    });
+
+    it('does not register GET /v1/tasks on the legacy router (ListTasks not in v0.3 REST)', async () => {
+      // ListTasks has no v0.3 equivalent (see V1_METHODS_WITHOUT_LEGACY_EQUIVALENT).
+      // The legacy router intentionally does not register /v1/tasks. To
+      // confirm the legacy transport handler is not invoked for that path
+      // we spy on its (non-existent) list method indirectly via the agent
+      // request handler.
+      const legacyListSpy = vi.spyOn(LegacyRestTransportHandler.prototype, 'getTask');
+      (mockRequestHandler.listTasks as Mock).mockResolvedValue({ tasks: [], nextPageToken: '' });
+
+      // Request falls through to the v1.0 router. Whether v1.0 matches it
+      // (under `/:tenant/tasks` with tenant='v1') or returns 404 is an
+      // implementation detail of the v1.0 router; what matters here is
+      // that the legacy router did NOT handle it.
+      await request(dualApp).get('/v1/tasks').set('A2A-Version', '1.0');
+
+      expect(legacyListSpy).not.toHaveBeenCalled();
+    });
+
+    it('sets Content-Type application/json on legacy responses', async () => {
+      legacySendMessageStub.mockResolvedValue({
+        kind: 'task',
+        id: 'legacy-task-ct',
+        contextId: 'ctx',
+        status: { state: 'working' },
+      });
+
+      const response = await request(dualApp)
+        .post('/v1/message:send')
+        .send(legacyMessageBody)
+        .expect(201);
+
+      assert.include(response.headers['content-type'], 'application/json');
+      assert.notInclude(response.headers['content-type'], 'application/a2a+json');
+    });
+
+    it('keeps Content-Type application/a2a+json on v1.0 responses', async () => {
+      (mockRequestHandler.getTask as Mock).mockResolvedValue(testTask);
+
+      const response = await request(dualApp)
+        .get('/tasks/task-1')
+        .set('A2A-Version', '1.0')
+        .expect(200);
+
+      assert.include(response.headers['content-type'], 'application/a2a+json');
+    });
+
+    it('reads and writes back the legacy X-A2A-Extensions header', async () => {
+      // Spy on sendMessage and have it record the activated extension
+      // via the ServerCallContext, so we can assert the response header.
+      legacySendMessageStub.mockImplementation(async (_params, context) => {
+        context.addActivatedExtension('ext-1');
+        return {
+          kind: 'task',
+          id: 'legacy-task-ext',
+          contextId: 'ctx',
+          status: { state: 'working' },
+        };
+      });
+
+      const response = await request(dualApp)
+        .post('/v1/message:send')
+        .set('X-A2A-Extensions', 'ext-1')
+        .send(legacyMessageBody)
+        .expect(201);
+
+      assert.equal(response.headers['x-a2a-extensions'], 'ext-1');
     });
   });
 });


### PR DESCRIPTION
# Description

This pull request introduces support for legacy v0.3 REST API endpoints alongside the existing v1.0 endpoints in the server, ensuring backward compatibility and proper routing for both protocol versions. The main changes involve updating the server's express handler to mount the legacy router, exposing relevant legacy transport handlers, and adding tests to verify correct dispatching, error handling, and header management for both API versions.

**Legacy REST API support and routing:**

* The `restHandler` in `src/server/express/rest_handler.ts` now mounts the `legacyRestRouter` at the top level, ensuring all `/v1/...` paths are handled by the legacy router when appropriate. The v0.3 and v1.0 route sets are disjoint, so middleware and handlers do not interfere. 
* The legacy REST transport handler, error mapper, and related types are now exported from `src/compat/v0_3/server/index.ts` for use elsewhere in the codebase.

**Testing and validation:**

* The test suite in `test/server/express/rest_handler.spec.ts` adds coverage for legacy v0.3 REST dispatch, including:
  - Correct routing of requests to legacy or v1.0 handlers based on path and protocol version.
  - Defaulting to v0.3 when version headers are absent on legacy paths.
  - Proper error mapping and response body shapes for legacy requests.
  - Ensuring legacy endpoints do not register unsupported routes (e.g., `/v1/tasks`).
  - Validation of content-type headers and extension header propagation for both legacy and v1.0 responses.

Closes #482  🦕
