### PR TITLE
feat: add opt-in legacy v0.3 compatibility to JSON-RPC handler and improve extension header support

### DIFF
--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -110,10 +110,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
       // header-less legacy client will only succeed if the card declares
       // a v0.3 JSONRPC interface.
       validateVersion(context.requestedVersion, agentCard, 'JSONRPC');
-      const transportHandler =
-        useLegacy && legacyJsonRpcTransportHandler !== undefined
-          ? legacyJsonRpcTransportHandler
-          : jsonRpcTransportHandler;
+      const transportHandler = useLegacy ? legacyJsonRpcTransportHandler : jsonRpcTransportHandler;
       const rpcResponseOrStream = await transportHandler.handle(req.body, context);
 
       if (context.activatedExtensions) {

--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -17,10 +17,29 @@ import { Extensions } from '../../extensions.js';
 import { RequestMalformedError } from '../../errors.js';
 import { validateVersion } from '../version.js';
 import { LegacyJsonRpcTransportHandler, isLegacyJsonRpcMethod } from '../../compat/v0_3/index.js';
+import { LEGACY_HTTP_EXTENSION_HEADER } from '../../compat/v0_3/constants.js';
 
 export interface JsonRpcHandlerOptions {
   requestHandler: A2ARequestHandler;
   userBuilder: UserBuilder;
+  /**
+   * Enables the v0.3 protocol compatibility layer.
+   *
+   * When enabled, the handler inspects each incoming JSON-RPC request
+   * body's `method` field; if it matches a known v0.3 method name
+   * (e.g. `message/send`, `tasks/get`), the request is routed through
+   * the v0.3 compat module instead of the v1.0 dispatcher.
+   *
+   * Default: omitted (treated as disabled). To accept v0.3 JSON-RPC
+   * clients, the agent card MUST also declare a v0.3 `JSONRPC`
+   * interface in `supportedInterfaces`; see §3.6.2.
+   *
+   * When disabled, the v0.3 compat code is not instantiated, the
+   * method-name inspection is skipped, and v0.3-shaped requests are
+   * surfaced as JSON-RPC `method not found` errors (-32601) by the
+   * v1.0 dispatcher.
+   */
+  legacyCompat?: { enabled: boolean };
 }
 
 /**
@@ -50,22 +69,37 @@ function isLegacyRequest(body: unknown): boolean {
  */
 export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
   const jsonRpcTransportHandler = new JsonRpcTransportHandler(options.requestHandler);
-  const legacyJsonRpcTransportHandler = new LegacyJsonRpcTransportHandler(options.requestHandler);
+  // Only instantiate the v0.3 compat handler when the operator has
+  // explicitly opted in. When omitted, v0.3-shaped requests fall
+  // through to the v1.0 dispatcher which rejects them as
+  // `method not found` (-32601).
+  const legacyJsonRpcTransportHandler = options.legacyCompat?.enabled
+    ? new LegacyJsonRpcTransportHandler(options.requestHandler)
+    : undefined;
 
   const router = express.Router();
 
   router.use(express.json(), jsonErrorHandler);
 
   router.post('/', async (req: Request, res: Response) => {
-    const useLegacy = isLegacyRequest(req.body);
+    const useLegacy = legacyJsonRpcTransportHandler !== undefined && isLegacyRequest(req.body);
     const mapToError = useLegacy
       ? LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError
       : JsonRpcTransportHandler.mapToJSONRPCError;
     try {
       const user = await options.userBuilder(req);
       const requestedVersion = req.header(A2A_VERSION_HEADER) || undefined;
+      // On the legacy path, accept both the v0.3 `X-A2A-Extensions`
+      // header (preferred — the v0.3 spec spelling) and the v1.0
+      // `A2A-Extensions` header (fallback for tolerance with
+      // v1.0-shaped clients hitting the compat layer). On the v1.0
+      // path, stay strict on the v1.0 spelling — matches the REST
+      // handler's behaviour.
+      const requestedExtensionsHeader = useLegacy
+        ? (req.header(LEGACY_HTTP_EXTENSION_HEADER) ?? req.header(HTTP_EXTENSION_HEADER))
+        : req.header(HTTP_EXTENSION_HEADER);
       const context = new ServerCallContext({
-        requestedExtensions: Extensions.parseServiceParameter(req.header(HTTP_EXTENSION_HEADER)),
+        requestedExtensions: Extensions.parseServiceParameter(requestedExtensionsHeader),
         user,
         requestedVersion,
       });
@@ -76,11 +110,20 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
       // header-less legacy client will only succeed if the card declares
       // a v0.3 JSONRPC interface.
       validateVersion(context.requestedVersion, agentCard, 'JSONRPC');
-      const transportHandler = useLegacy ? legacyJsonRpcTransportHandler : jsonRpcTransportHandler;
+      const transportHandler =
+        useLegacy && legacyJsonRpcTransportHandler !== undefined
+          ? legacyJsonRpcTransportHandler
+          : jsonRpcTransportHandler;
       const rpcResponseOrStream = await transportHandler.handle(req.body, context);
 
       if (context.activatedExtensions) {
-        res.setHeader(HTTP_EXTENSION_HEADER, Array.from(context.activatedExtensions));
+        // Legacy path responds with the v0.3 `X-A2A-Extensions`
+        // spelling; v1.0 path responds with `A2A-Extensions`. Matches
+        // the REST handler's per-path response convention.
+        res.setHeader(
+          useLegacy ? LEGACY_HTTP_EXTENSION_HEADER : HTTP_EXTENSION_HEADER,
+          Array.from(context.activatedExtensions)
+        );
       }
       // Check if it's an AsyncGenerator (stream)
       if (typeof (rpcResponseOrStream as AsyncGenerator)?.[Symbol.asyncIterator] === 'function') {

--- a/test/server/express/express_app.spec.ts
+++ b/test/server/express/express_app.spec.ts
@@ -19,7 +19,11 @@ import express, {
 } from 'express';
 import request from 'supertest';
 
-import { jsonErrorHandler, jsonRpcHandler } from '../../../src/server/express/json_rpc_handler.js';
+import {
+  jsonErrorHandler,
+  jsonRpcHandler,
+  type JsonRpcHandlerOptions,
+} from '../../../src/server/express/json_rpc_handler.js';
 import { agentCardHandler } from '../../../src/server/express/agent_card_handler.js';
 import { UserBuilder } from '../../../src/server/express/common.js';
 import { A2ARequestHandler } from '../../../src/server/request_handler/a2a_request_handler.js';
@@ -43,18 +47,32 @@ describe('A2AExpressApp', () => {
     userBuilder: UserBuilder = UserBuilder.noAuthentication,
     baseUrl: string = '',
     middlewares: Array<RequestHandler | ErrorRequestHandler> = [],
-    agentCardPath: string = AGENT_CARD_PATH
+    agentCardPath: string = AGENT_CARD_PATH,
+    jsonRpcOptions: Partial<Omit<JsonRpcHandlerOptions, 'requestHandler' | 'userBuilder'>> = {}
   ): Express => {
     const router = express.Router();
     router.use(express.json(), jsonErrorHandler);
     if (middlewares.length > 0) {
       router.use(middlewares);
     }
-    router.use(jsonRpcHandler({ requestHandler, userBuilder }));
+    router.use(jsonRpcHandler({ requestHandler, userBuilder, ...jsonRpcOptions }));
     router.use(`/${agentCardPath}`, agentCardHandler({ agentCardProvider: requestHandler }));
     expressApp.use(baseUrl, router);
     return expressApp;
   };
+
+  /**
+   * Convenience wrapper around {@link setupA2ARoutes} that enables the
+   * v0.3 compatibility layer. Used by the `legacy v0.3 JSON-RPC
+   * dispatch` test block to opt the handler into v0.3 method routing.
+   */
+  const setupA2ARoutesWithLegacyCompat = (
+    expressApp: Express,
+    requestHandler: A2ARequestHandler
+  ): Express =>
+    setupA2ARoutes(expressApp, requestHandler, undefined, undefined, undefined, undefined, {
+      legacyCompat: { enabled: true },
+    });
 
   // Helper function to create JSON-RPC request bodies
   const createRpcRequest = (id: string | null, method = 'SendMessage', params: object = {}) => ({
@@ -696,7 +714,7 @@ describe('A2AExpressApp', () => {
     beforeEach(() => {
       legacyHandleStub = vi.spyOn(LegacyJsonRpcTransportHandler.prototype, 'handle');
       (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(dualVersionAgentCard);
-      setupA2ARoutes(expressApp, mockRequestHandler);
+      setupA2ARoutesWithLegacyCompat(expressApp, mockRequestHandler);
     });
 
     it('routes a v0.3 method to the legacy handler', async () => {
@@ -800,6 +818,140 @@ describe('A2AExpressApp', () => {
       // v0.3 JSONRPCError.data is `Record<string,unknown>` not the v1.0
       // ErrorDetail[] array. The legacy mapper omits the field entirely.
       expect(response.body.error).to.not.have.property('data');
+    });
+
+    it('returns method-not-found for v0.3 methods when legacyCompat is omitted', async () => {
+      // Build a fresh app WITHOUT the compat opt-in. The v0.3 method
+      // name is unknown to the v1.0 dispatcher, which returns -32601.
+      const optOutApp = express();
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(dualVersionAgentCard);
+      setupA2ARoutes(optOutApp, mockRequestHandler);
+
+      const response = await request(optOutApp)
+        .post('/')
+        .set('A2A-Version', '0.3')
+        .send(createRpcRequest('req-no-compat', 'message/send'))
+        .expect(200);
+
+      // JSON-RPC convention: HTTP 200 carries the JSON-RPC error body.
+      expect(response.body.error.code).to.equal(A2A_ERROR_CODE.METHOD_NOT_FOUND);
+      // Legacy code path is never instantiated nor invoked.
+      expect(legacyHandleStub).not.toHaveBeenCalled();
+    });
+
+    it('returns method-not-found for v0.3 methods when legacyCompat.enabled is false', async () => {
+      const optOutApp = express();
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(dualVersionAgentCard);
+      setupA2ARoutes(optOutApp, mockRequestHandler, undefined, undefined, undefined, undefined, {
+        legacyCompat: { enabled: false },
+      });
+
+      const response = await request(optOutApp)
+        .post('/')
+        .set('A2A-Version', '0.3')
+        .send(createRpcRequest('req-disabled', 'message/send'))
+        .expect(200);
+
+      expect(response.body.error.code).to.equal(A2A_ERROR_CODE.METHOD_NOT_FOUND);
+      expect(legacyHandleStub).not.toHaveBeenCalled();
+    });
+
+    // ========================================================================
+    // Extension-header tolerance on the legacy JSON-RPC path
+    // ========================================================================
+
+    it('accepts X-A2A-Extensions on the legacy JSON-RPC path', async () => {
+      legacyHandleStub.mockImplementation(async (_body, context) => {
+        context.addActivatedExtension('ext-legacy');
+        return { jsonrpc: '2.0', id: 'ext-1', result: { kind: 'task' } };
+      });
+
+      const response = await request(expressApp)
+        .post('/')
+        .set('A2A-Version', '0.3')
+        .set('X-A2A-Extensions', 'ext-legacy')
+        .send(createRpcRequest('ext-1', 'message/send'))
+        .expect(200);
+
+      // Legacy response carries the v0.3 spelling.
+      assert.equal(response.headers['x-a2a-extensions'], 'ext-legacy');
+      assert.notProperty(response.headers, 'a2a-extensions');
+    });
+
+    it('accepts A2A-Extensions as fallback on the legacy JSON-RPC path', async () => {
+      legacyHandleStub.mockImplementation(async (_body, context) => {
+        context.addActivatedExtension('ext-modern');
+        return { jsonrpc: '2.0', id: 'ext-2', result: { kind: 'task' } };
+      });
+
+      const response = await request(expressApp)
+        .post('/')
+        .set('A2A-Version', '0.3')
+        .set('A2A-Extensions', 'ext-modern')
+        .send(createRpcRequest('ext-2', 'message/send'))
+        .expect(200);
+
+      // Legacy response always uses the X- spelling regardless of input.
+      assert.equal(response.headers['x-a2a-extensions'], 'ext-modern');
+    });
+
+    it('prefers X-A2A-Extensions when both spellings are present on the legacy path', async () => {
+      legacyHandleStub.mockImplementation(async (_body, context) => {
+        for (const ext of context.requestedExtensions ?? []) {
+          context.addActivatedExtension(ext);
+        }
+        return { jsonrpc: '2.0', id: 'ext-3', result: { kind: 'task' } };
+      });
+
+      const response = await request(expressApp)
+        .post('/')
+        .set('A2A-Version', '0.3')
+        .set('X-A2A-Extensions', 'legacy-ext')
+        .set('A2A-Extensions', 'modern-ext')
+        .send(createRpcRequest('ext-3', 'message/send'))
+        .expect(200);
+
+      // Legacy spelling wins on input; legacy spelling on output.
+      assert.equal(response.headers['x-a2a-extensions'], 'legacy-ext');
+    });
+
+    it('v1.0 JSON-RPC path writes A2A-Extensions (not X-) on responses', async () => {
+      handleStub.mockImplementation(async (_body, context) => {
+        context.addActivatedExtension('ext-v1');
+        return { jsonrpc: '2.0', id: 'ext-4', result: { task: { id: 't' } } };
+      });
+
+      const response = await request(expressApp)
+        .post('/')
+        .set('A2A-Version', '1.0')
+        .set('A2A-Extensions', 'ext-v1')
+        .send(createRpcRequest('ext-4', 'SendMessage'))
+        .expect(200);
+
+      assert.equal(response.headers['a2a-extensions'], 'ext-v1');
+      assert.notProperty(response.headers, 'x-a2a-extensions');
+    });
+
+    it('v1.0 JSON-RPC path does NOT read X-A2A-Extensions (stays strict)', async () => {
+      // Non-regression: matches the REST handler's behaviour where the
+      // v1.0 layer ignores the legacy header spelling.
+      handleStub.mockImplementation(async (_body, context) => {
+        for (const ext of context.requestedExtensions ?? []) {
+          context.addActivatedExtension(ext);
+        }
+        return { jsonrpc: '2.0', id: 'ext-5', result: { task: { id: 't' } } };
+      });
+
+      const response = await request(expressApp)
+        .post('/')
+        .set('A2A-Version', '1.0')
+        .set('X-A2A-Extensions', 'ignored-by-v1')
+        .send(createRpcRequest('ext-5', 'SendMessage'))
+        .expect(200);
+
+      // No extensions activated; no header in response.
+      assert.notProperty(response.headers, 'a2a-extensions');
+      assert.notProperty(response.headers, 'x-a2a-extensions');
     });
   });
 });


### PR DESCRIPTION
# Description

This pull request enhances the JSON-RPC handler to make support for the legacy v0.3 protocol compatibility layer explicitly opt-in, and improves extension header handling for both v0.3 and v1.0 code paths.

**Opt-in legacy v0.3 protocol support:**

* Adds a `legacyCompat` option to `JsonRpcHandlerOptions`, allowing operators to explicitly enable or disable the v0.3 compatibility layer. When omitted or set to false, v0.3-shaped requests are rejected with `method not found` errors, and the legacy handler is not instantiated.

**Extension header handling improvements:**

* On the legacy JSON-RPC path, accepts both the legacy `X-A2A-Extensions` and the modern `A2A-Extensions` headers for incoming requests, preferring the legacy spelling when both are present. Response headers match the path: legacy responses use `X-A2A-Extensions`, v1.0 responses use `A2A-Extensions`.

Closes #500 🦕
