### PR TITLE
feat: implement v0.3 protocol compatibility for RestTransportFactory

### DIFF
--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -12,7 +12,6 @@ import { parseSseStream } from '../../sse_utils.js';
 import { isLegacyVersion } from '../../version_utils.js';
 import { Transport, TransportFactory } from './transport.js';
 import {
-  AgentInterface,
   CancelTaskRequest,
   DeleteTaskPushNotificationConfigRequest,
   GetExtendedAgentCardRequest,
@@ -30,6 +29,7 @@ import {
 } from '../../types/pb/a2a.js';
 import { JSON_CONTENT_TYPE } from '../../constants.js';
 import { LegacyJsonRpcTransport } from '../../compat/v0_3/client/index.js';
+import { pickMatchingInterface } from './pick_interface.js';
 
 const PROTOCOL_NAME: TransportProtocolName = 'JSONRPC';
 
@@ -395,33 +395,6 @@ export class JsonRpcTransportFactoryOptions {
    * agents are not contacted via the compat transport.
    */
   legacyCompat?: { enabled: boolean };
-}
-
-/**
- * Picks the `AgentInterface` for the given protocol binding that best
- * matches the endpoint URL.
- *
- * Mirrors Python's `_find_best_interface(..., url=...)`: filters by
- * `protocolBinding` (case-insensitive), narrows to entries whose `url`
- * matches if any such entry exists, then prefers `protocolVersion === '1.0'`
- * among the survivors. Returns `undefined` when nothing matches so the
- * caller can fall back to a default policy (today: assume v1.0).
- */
-function pickMatchingInterface(
-  agentCard: AgentCard,
-  protocolBinding: string,
-  url: string
-): AgentInterface | undefined {
-  const target = protocolBinding.toUpperCase();
-  const candidates = (agentCard.supportedInterfaces ?? []).filter(
-    (i) => i.protocolBinding?.toUpperCase() === target
-  );
-  if (candidates.length === 0) return undefined;
-
-  const byUrl = candidates.filter((i) => i.url === url);
-  const pool = byUrl.length > 0 ? byUrl : candidates;
-
-  return pool.find((i) => i.protocolVersion === '1.0') ?? pool[0];
 }
 
 /**

--- a/src/client/transports/pick_interface.ts
+++ b/src/client/transports/pick_interface.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared helper for picking the best-matching `AgentInterface` for a
+ * given protocol binding from an agent card's `supportedInterfaces`.
+ *
+ * Lives in its own module so protocol-specific factories can
+ * share the same dispatch policy when deciding whether to dispatch to a
+ * v0.3 compat transport.
+ */
+
+import type { AgentCard, AgentInterface } from '../../types/pb/a2a.js';
+
+/**
+ * Picks the `AgentInterface` for the given protocol binding that best
+ * matches the endpoint URL.
+ *
+ * Mirrors Python's `_find_best_interface(..., url=...)`: filters by
+ * `protocolBinding` (case-insensitive), narrows to entries whose `url`
+ * matches if any such entry exists, then prefers `protocolVersion === '1.0'`
+ * among the survivors. Returns `undefined` when nothing matches so the
+ * caller can fall back to a default policy (today: assume v1.0).
+ */
+export function pickMatchingInterface(
+  agentCard: AgentCard,
+  protocolBinding: string,
+  url: string
+): AgentInterface | undefined {
+  const target = protocolBinding.toUpperCase();
+  const candidates = (agentCard.supportedInterfaces ?? []).filter(
+    (i) => i.protocolBinding?.toUpperCase() === target
+  );
+  if (candidates.length === 0) return undefined;
+
+  const byUrl = candidates.filter((i) => i.url === url);
+  const pool = byUrl.length > 0 ? byUrl : candidates;
+
+  return pool.find((i) => i.protocolVersion === '1.0') ?? pool[0];
+}

--- a/src/client/transports/rest_transport.ts
+++ b/src/client/transports/rest_transport.ts
@@ -425,7 +425,7 @@ export class RestTransportFactoryOptions {
    * agents, the agent card MUST declare a v0.3 `HTTP+JSON` interface
    * in `supportedInterfaces`; see §3.6.2.
    *
-   * When disabled, the v0.3 compat module is never loaded and v0.3
+   * When disabled, the v0.3 compat module is never called and v0.3
    * agents are not contacted via the compat transport.
    */
   legacyCompat?: { enabled: boolean };
@@ -444,14 +444,10 @@ export class RestTransportFactoryOptions {
  * otherwise (1.0 / empty / missing), the v1.0 transport is used.
  *
  * When `legacyCompat` is omitted or `{ enabled: false }`, the factory
- * always produces the v1.0 `RestTransport` and never loads the compat
+ * always produces the v1.0 `RestTransport` and never calls the compat
  * module. This mirrors the server-side opt-in convention shared with the
  * Express JSON-RPC and REST handlers and the symmetric
  * `JsonRpcTransportFactory.legacyCompat` flag.
- *
- * The v0.3 transport module is loaded lazily on demand, so callers that
- * only ever talk to v1.0 agents never pull compat code into their
- * runtime graph.
  */
 export class RestTransportFactory implements TransportFactory {
   constructor(private readonly options?: RestTransportFactoryOptions) {}

--- a/src/client/transports/rest_transport.ts
+++ b/src/client/transports/rest_transport.ts
@@ -5,6 +5,8 @@ import { SendMessageResult, A2A_PROTOCOL_VERSION, A2A_CONTENT_TYPE } from '../..
 import { RequestOptions } from '../multitransport-client.js';
 import { parseSseStream } from '../../sse_utils.js';
 import { Transport, TransportFactory } from './transport.js';
+import { isLegacyVersion } from '../../version_utils.js';
+import { pickMatchingInterface } from './pick_interface.js';
 import { FromProto } from '../../types/converters/from_proto.js';
 import {
   AgentCard,
@@ -27,6 +29,7 @@ import {
   TaskState,
   taskStateToJSON,
 } from '../../types/pb/a2a.js';
+import { LegacyRestTransport } from '../../compat/v0_3/client/index.js';
 
 const PROTOCOL_NAME: TransportProtocolName = 'HTTP+JSON';
 
@@ -408,10 +411,48 @@ export class RestTransport implements Transport {
   }
 }
 
-export interface RestTransportFactoryOptions {
+export class RestTransportFactoryOptions {
   fetchImpl?: typeof fetch;
+  /**
+   * Enables the v0.3 protocol compatibility layer.
+   *
+   * When enabled, the factory inspects the matched
+   * `AgentInterface.protocolVersion` on every `create()` call; if it
+   * falls in `[0.3, 1.0)`, the v0.3 `LegacyRestTransport` is
+   * instantiated instead of the v1.0 `RestTransport`.
+   *
+   * Default: omitted (treated as disabled). To talk to v0.3 REST
+   * agents, the agent card MUST declare a v0.3 `HTTP+JSON` interface
+   * in `supportedInterfaces`; see §3.6.2.
+   *
+   * When disabled, the v0.3 compat module is never loaded and v0.3
+   * agents are not contacted via the compat transport.
+   */
+  legacyCompat?: { enabled: boolean };
 }
 
+/**
+ * Factory that produces an HTTP+JSON `Transport` for the matched agent
+ * interface.
+ *
+ * When the factory is constructed with `legacyCompat: { enabled: true }`,
+ * it transparently dispatches between the v1.0 transport
+ * (`RestTransport`) and the v0.3 compat transport
+ * (`LegacyRestTransport`) based on the matched
+ * `AgentInterface.protocolVersion`: when the matched interface declares
+ * `protocolVersion` in `[0.3, 1.0)`, the v0.3 transport is used;
+ * otherwise (1.0 / empty / missing), the v1.0 transport is used.
+ *
+ * When `legacyCompat` is omitted or `{ enabled: false }`, the factory
+ * always produces the v1.0 `RestTransport` and never loads the compat
+ * module. This mirrors the server-side opt-in convention shared with the
+ * Express JSON-RPC and REST handlers and the symmetric
+ * `JsonRpcTransportFactory.legacyCompat` flag.
+ *
+ * The v0.3 transport module is loaded lazily on demand, so callers that
+ * only ever talk to v1.0 agents never pull compat code into their
+ * runtime graph.
+ */
 export class RestTransportFactory implements TransportFactory {
   constructor(private readonly options?: RestTransportFactoryOptions) {}
 
@@ -419,7 +460,16 @@ export class RestTransportFactory implements TransportFactory {
     return PROTOCOL_NAME;
   }
 
-  async create(url: string, _agentCard: AgentCard): Promise<Transport> {
+  async create(url: string, agentCard: AgentCard): Promise<Transport> {
+    if (this.options?.legacyCompat?.enabled) {
+      const iface = pickMatchingInterface(agentCard, PROTOCOL_NAME, url);
+      if (iface && isLegacyVersion(iface.protocolVersion)) {
+        return new LegacyRestTransport({
+          endpoint: url,
+          fetchImpl: this.options?.fetchImpl,
+        });
+      }
+    }
     return new RestTransport({
       endpoint: url,
       fetchImpl: this.options?.fetchImpl,

--- a/src/compat/v0_3/client/index.ts
+++ b/src/compat/v0_3/client/index.ts
@@ -6,3 +6,8 @@ export {
   LegacyJsonRpcTransport,
   type LegacyJsonRpcTransportOptions,
 } from './transports/json_rpc_transport.js';
+
+export {
+  LegacyRestTransport,
+  type LegacyRestTransportOptions,
+} from './transports/rest_transport.js';

--- a/src/compat/v0_3/client/transports/rest_transport.ts
+++ b/src/compat/v0_3/client/transports/rest_transport.ts
@@ -34,14 +34,8 @@
  */
 
 import {
-  A2A_ERROR_CODE,
-  ContentTypeNotSupportedError,
-  ExtendedAgentCardNotConfiguredError,
   InvalidAgentResponseError,
-  PushNotificationNotSupportedError,
-  RequestMalformedError,
-  TaskNotCancelableError,
-  TaskNotFoundError,
+  mapA2aErrorToSdkError,
   UnsupportedOperationError,
 } from '../../../../errors.js';
 import type { TransportProtocolName } from '../../../../core.js';
@@ -315,8 +309,8 @@ export class LegacyRestTransport implements Transport {
    *   caller's translator). Skipped for `GET`/`DELETE`.
    * - 204 No Content (e.g. `DELETE`) resolves to `undefined`.
    * - Non-2xx responses with a parseable v0.3 error body are mapped to a
-   *   typed SDK error via {@link mapToError}; everything else falls
-   *   through to a generic `Error`.
+   *   typed SDK error via {@link mapA2aErrorToSdkError}; everything else
+   *   falls through to a generic `Error`.
    */
   private async _sendRequest<TResponse>(
     method: 'GET' | 'POST' | 'DELETE',
@@ -423,7 +417,10 @@ export class LegacyRestTransport implements Transport {
     try {
       const parsed = JSON.parse(jsonData) as unknown;
       if (LegacyRestTransport._isLegacyRestErrorBody(parsed)) {
-        return LegacyRestTransport.mapToError(parsed);
+        return mapA2aErrorToSdkError(parsed, () => {
+          const dataSuffix = parsed.data ? ` Data: ${JSON.stringify(parsed.data)}` : '';
+          return new Error(`REST error: ${parsed.message} (Code: ${parsed.code})${dataSuffix}`);
+        });
       }
       return new Error(`SSE error event: ${jsonData}`);
     } catch {
@@ -435,7 +432,7 @@ export class LegacyRestTransport implements Transport {
    * Reads an error response body and throws a typed SDK error.
    *
    * v0.3 wire shape is a bare `{ code, message, data? }` JSON object. If
-   * the body parses to that shape, we map via {@link mapToError};
+   * the body parses to that shape, we map via {@link mapA2aErrorToSdkError};
    * otherwise we throw a generic `Error` with the HTTP status and the
    * raw body text for debuggability. Mirrors `RestTransport`'s v1.0
    * equivalent but uses the bare body shape rather than
@@ -458,7 +455,11 @@ export class LegacyRestTransport implements Transport {
     }
 
     if (errorBody) {
-      throw LegacyRestTransport.mapToError(errorBody);
+      const body = errorBody;
+      throw mapA2aErrorToSdkError(body, () => {
+        const dataSuffix = body.data ? ` Data: ${JSON.stringify(body.data)}` : '';
+        return new Error(`REST error: ${body.message} (Code: ${body.code})${dataSuffix}`);
+      });
     }
 
     throw new Error(
@@ -495,44 +496,5 @@ export class LegacyRestTransport implements Transport {
     throw new InvalidAgentResponseError(
       `Unexpected v0.3 message:send result kind: ${String((result as { kind?: string }).kind)}`
     );
-  }
-
-  /**
-   * Maps a v0.3 REST error body into an SDK error class.
-   *
-   * Numeric A2A error codes are identical between v0.3 and v1.0 for
-   * every code that exists in both. Mirrors
-   * `LegacyJsonRpcTransport.mapToError` so users can catch the same
-   * typed errors regardless of which compat transport produced them.
-   * Unknown codes fall through to a generic `Error`.
-   */
-  private static mapToError(body: LegacyRestErrorBody): Error {
-    const message = body.message;
-    switch (body.code) {
-      case A2A_ERROR_CODE.PARSE_ERROR:
-      case A2A_ERROR_CODE.INVALID_REQUEST:
-      case A2A_ERROR_CODE.METHOD_NOT_FOUND:
-      case A2A_ERROR_CODE.INVALID_PARAMS:
-      case A2A_ERROR_CODE.INTERNAL_ERROR:
-        return new RequestMalformedError(message);
-      case A2A_ERROR_CODE.TASK_NOT_FOUND:
-        return new TaskNotFoundError(message);
-      case A2A_ERROR_CODE.TASK_NOT_CANCELABLE:
-        return new TaskNotCancelableError(message);
-      case A2A_ERROR_CODE.PUSH_NOTIFICATION_NOT_SUPPORTED:
-        return new PushNotificationNotSupportedError(message);
-      case A2A_ERROR_CODE.UNSUPPORTED_OPERATION:
-        return new UnsupportedOperationError(message);
-      case A2A_ERROR_CODE.CONTENT_TYPE_NOT_SUPPORTED:
-        return new ContentTypeNotSupportedError(message);
-      case A2A_ERROR_CODE.INVALID_AGENT_RESPONSE:
-        return new InvalidAgentResponseError(message);
-      case A2A_ERROR_CODE.EXTENDED_CARD_NOT_CONFIGURED:
-        return new ExtendedAgentCardNotConfiguredError(message);
-      default: {
-        const dataSuffix = body.data ? ` Data: ${JSON.stringify(body.data)}` : '';
-        return new Error(`REST error: ${message} (Code: ${body.code})${dataSuffix}`);
-      }
-    }
   }
 }

--- a/src/compat/v0_3/client/transports/rest_transport.ts
+++ b/src/compat/v0_3/client/transports/rest_transport.ts
@@ -203,7 +203,7 @@ export class LegacyRestTransport implements Transport {
     return toCoreListTaskPushNotificationConfigsResponse({
       id: this._nextResponseId(),
       jsonrpc: '2.0',
-      result,
+      result: result ?? [],
     });
   }
 
@@ -345,7 +345,8 @@ export class LegacyRestTransport implements Transport {
       return undefined as TResponse;
     }
 
-    return (await response.json()) as TResponse;
+    const text = await response.text();
+    return (text ? JSON.parse(text) : undefined) as TResponse;
   }
 
   private async *_sendStreamingRequest(

--- a/src/compat/v0_3/client/transports/rest_transport.ts
+++ b/src/compat/v0_3/client/transports/rest_transport.ts
@@ -1,0 +1,537 @@
+/**
+ * v0.3 HTTP+JSON (REST) client transport (compat layer).
+ *
+ * Implements the v1.0 {@link Transport} interface but speaks the v0.3 REST
+ * wire format. Each method translates the v1.0 proto request to v0.3 JSON
+ * via the `toCompat*` helpers in `../../translate/requests.js`, issues an
+ * HTTP request against the canonical v0.3 reference URLs
+ * (`/v1/message:send`, `/v1/tasks/:taskId`, …), then translates the v0.3
+ * response back to v1.0 proto via the corresponding `toCore*` helpers.
+ *
+ * Shares `protocolName === 'HTTP+JSON'` with the v1.0 transport. The
+ * core-side {@link RestTransportFactory} inspects the matched
+ * `AgentInterface.protocolVersion` and lazy-loads this class when it falls
+ * in `[0.3, 1.0)`, so installing the default `RestTransportFactory` with
+ * `legacyCompat: { enabled: true }` transparently covers both protocol
+ * versions.
+ *
+ * v0.3 wire-format differences from v1.0:
+ *   - Content-Type / Accept are `application/json` (v0.3 did not introduce
+ *     the `application/a2a+json` media type).
+ *   - All paths live under `/v1/...` (the canonical v0.3 reference URLs).
+ *   - Error bodies are bare `{ code, message, data? }` objects with no
+ *     outer `{ error: {...} }` wrapper, no `status` field, and no
+ *     `details[]` array — `google.rpc.Status` was a v1.0 addition.
+ *   - REST SSE events carry only the bare v0.3 stream-result payload
+ *     (`Task | Message | TaskStatusUpdateEvent | TaskArtifactUpdateEvent`)
+ *     with no JSON-RPC envelope.
+ *
+ * `listTasks` has no equivalent in v0.3 HTTP+JSON (per
+ * {@link V1_METHODS_WITHOUT_LEGACY_EQUIVALENT}: the v0.3 REST surface
+ * never exposed `tasks/list`). Calling it throws
+ * {@link UnsupportedOperationError} synchronously, without issuing any
+ * HTTP request.
+ */
+
+import {
+  A2A_ERROR_CODE,
+  ContentTypeNotSupportedError,
+  ExtendedAgentCardNotConfiguredError,
+  InvalidAgentResponseError,
+  PushNotificationNotSupportedError,
+  RequestMalformedError,
+  TaskNotCancelableError,
+  TaskNotFoundError,
+  UnsupportedOperationError,
+} from '../../../../errors.js';
+import type { TransportProtocolName } from '../../../../core.js';
+import type { SendMessageResult } from '../../../../index.js';
+import type { RequestOptions } from '../../../../client/multitransport-client.js';
+import { Transport } from '../../../../client/transports/transport.js';
+import { parseSseStream } from '../../../../sse_utils.js';
+import type {
+  AgentCard as V1AgentCard,
+  CancelTaskRequest as V1CancelTaskRequest,
+  DeleteTaskPushNotificationConfigRequest as V1DeleteTaskPushNotificationConfigRequest,
+  GetExtendedAgentCardRequest as V1GetExtendedAgentCardRequest,
+  GetTaskPushNotificationConfigRequest as V1GetTaskPushNotificationConfigRequest,
+  GetTaskRequest as V1GetTaskRequest,
+  ListTaskPushNotificationConfigsRequest as V1ListTaskPushNotificationConfigsRequest,
+  ListTaskPushNotificationConfigsResponse as V1ListTaskPushNotificationConfigsResponse,
+  ListTasksRequest as V1ListTasksRequest,
+  ListTasksResponse as V1ListTasksResponse,
+  SendMessageRequest as V1SendMessageRequest,
+  StreamResponse as V1StreamResponse,
+  SubscribeToTaskRequest as V1SubscribeToTaskRequest,
+  Task as V1Task,
+  TaskPushNotificationConfig as V1TaskPushNotificationConfig,
+} from '../../../../types/pb/a2a.js';
+import { A2A_LEGACY_PROTOCOL_VERSION, LEGACY_JSON_CONTENT_TYPE } from '../../constants.js';
+import { toCoreAgentCard } from '../../translate/agent_card.js';
+import { toCoreMessage } from '../../translate/messages.js';
+import {
+  toCompatTaskPushNotificationConfig,
+  toCoreTaskPushNotificationConfig,
+} from '../../translate/push_notifications.js';
+import {
+  toCompatSendMessageRequest,
+  toCoreListTaskPushNotificationConfigsResponse,
+  toCoreStreamResponse,
+} from '../../translate/requests.js';
+import { toCoreTask } from '../../translate/tasks.js';
+import type * as legacy from '../../types/types.js';
+
+const PROTOCOL_NAME: TransportProtocolName = 'HTTP+JSON';
+
+export interface LegacyRestTransportOptions {
+  endpoint: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * v0.3-shaped HTTP error body.
+ *
+ * Mirrors `LegacyRestErrorBody` on the server side: v0.3 returned errors
+ * as bare `{ code, message, data? }` objects (no `details[]` array, no
+ * `status` field, no outer `{ error: {...} }` wrapper).
+ */
+interface LegacyRestErrorBody {
+  code: number;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * v0.3 REST client transport. See the file-level comment for the overall
+ * design.
+ */
+export class LegacyRestTransport implements Transport {
+  private readonly customFetchImpl?: typeof fetch;
+  private readonly endpoint: string;
+  private requestIdCounter: number = 1;
+
+  constructor(options: LegacyRestTransportOptions) {
+    // Match v1.0 RestTransport: strip trailing slashes so callers can pass
+    // either `https://host/api` or `https://host/api/` and get identical
+    // paths.
+    this.endpoint = options.endpoint.replace(/\/+$/, '');
+    this.customFetchImpl = options.fetchImpl;
+  }
+
+  get protocolName(): string {
+    return PROTOCOL_NAME;
+  }
+
+  get protocolVersion(): string {
+    return A2A_LEGACY_PROTOCOL_VERSION;
+  }
+
+  async getExtendedAgentCard(
+    _params: V1GetExtendedAgentCardRequest,
+    options?: RequestOptions
+  ): Promise<V1AgentCard> {
+    const card = await this._sendRequest<legacy.AgentCard>('GET', '/v1/card', undefined, options);
+    return toCoreAgentCard(card);
+  }
+
+  async sendMessage(
+    params: V1SendMessageRequest,
+    options?: RequestOptions
+  ): Promise<SendMessageResult> {
+    const body = this._buildSendMessageParams(params);
+    const result = await this._sendRequest<legacy.Task | legacy.Message>(
+      'POST',
+      '/v1/message:send',
+      body,
+      options
+    );
+    return LegacyRestTransport._parseSendMessageResult(result);
+  }
+
+  async *sendMessageStream(
+    params: V1SendMessageRequest,
+    options?: RequestOptions
+  ): AsyncGenerator<V1StreamResponse, void, undefined> {
+    const body = this._buildSendMessageParams(params);
+    yield* this._sendStreamingRequest('/v1/message:stream', body, options);
+  }
+
+  async createTaskPushNotificationConfig(
+    params: V1TaskPushNotificationConfig,
+    options?: RequestOptions
+  ): Promise<V1TaskPushNotificationConfig> {
+    const body = toCompatTaskPushNotificationConfig(params);
+    const path = `/v1/tasks/${encodeURIComponent(params.taskId)}/pushNotificationConfigs`;
+    const result = await this._sendRequest<legacy.TaskPushNotificationConfig>(
+      'POST',
+      path,
+      body,
+      options
+    );
+    return toCoreTaskPushNotificationConfig(result);
+  }
+
+  async getTaskPushNotificationConfig(
+    params: V1GetTaskPushNotificationConfigRequest,
+    options?: RequestOptions
+  ): Promise<V1TaskPushNotificationConfig> {
+    const path =
+      `/v1/tasks/${encodeURIComponent(params.taskId)}/pushNotificationConfigs/` +
+      encodeURIComponent(params.id);
+    const result = await this._sendRequest<legacy.TaskPushNotificationConfig>(
+      'GET',
+      path,
+      undefined,
+      options
+    );
+    return toCoreTaskPushNotificationConfig(result);
+  }
+
+  async listTaskPushNotificationConfig(
+    params: V1ListTaskPushNotificationConfigsRequest,
+    options?: RequestOptions
+  ): Promise<V1ListTaskPushNotificationConfigsResponse> {
+    const path = `/v1/tasks/${encodeURIComponent(params.taskId)}/pushNotificationConfigs`;
+    const result = await this._sendRequest<legacy.TaskPushNotificationConfig[]>(
+      'GET',
+      path,
+      undefined,
+      options
+    );
+    // Wrap the bare list response into the v0.3 success-response shape
+    // that `toCoreListTaskPushNotificationConfigsResponse` expects.
+    return toCoreListTaskPushNotificationConfigsResponse({
+      id: this._nextResponseId(),
+      jsonrpc: '2.0',
+      result,
+    });
+  }
+
+  async deleteTaskPushNotificationConfig(
+    params: V1DeleteTaskPushNotificationConfigRequest,
+    options?: RequestOptions
+  ): Promise<void> {
+    const path =
+      `/v1/tasks/${encodeURIComponent(params.taskId)}/pushNotificationConfigs/` +
+      encodeURIComponent(params.id);
+    await this._sendRequest<void>('DELETE', path, undefined, options);
+  }
+
+  async getTask(params: V1GetTaskRequest, options?: RequestOptions): Promise<V1Task> {
+    const queryParams = new URLSearchParams();
+    if (params.historyLength !== undefined) {
+      queryParams.set('historyLength', String(params.historyLength));
+    }
+    const queryString = queryParams.toString();
+    const path = `/v1/tasks/${encodeURIComponent(params.id)}${queryString ? `?${queryString}` : ''}`;
+    const result = await this._sendRequest<legacy.Task>('GET', path, undefined, options);
+    return toCoreTask(result);
+  }
+
+  async cancelTask(params: V1CancelTaskRequest, options?: RequestOptions): Promise<V1Task> {
+    const path = `/v1/tasks/${encodeURIComponent(params.id)}:cancel`;
+    const result = await this._sendRequest<legacy.Task>('POST', path, undefined, options);
+    return toCoreTask(result);
+  }
+
+  /**
+   * `tasks/list` has no REST binding in v0.3 (per
+   * {@link V1_METHODS_WITHOUT_LEGACY_EQUIVALENT}). Throws synchronously
+   * without issuing an HTTP request.
+   */
+  async listTasks(
+    _params: V1ListTasksRequest,
+    _options?: RequestOptions
+  ): Promise<V1ListTasksResponse> {
+    throw new UnsupportedOperationError('tasks/list has no equivalent in v0.3 HTTP+JSON');
+  }
+
+  async *resubscribeTask(
+    params: V1SubscribeToTaskRequest,
+    options?: RequestOptions
+  ): AsyncGenerator<V1StreamResponse, void, undefined> {
+    const path = `/v1/tasks/${encodeURIComponent(params.id)}:subscribe`;
+    yield* this._sendStreamingRequest(path, undefined, options);
+  }
+
+  // ==========================================================================
+  // Internals
+  // ==========================================================================
+
+  /**
+   * Translates v1.0 `SendMessageRequest` into v0.3 `MessageSendParams` by
+   * leaning on `toCompatSendMessageRequest` (which builds the full v0.3
+   * JSON-RPC envelope) and extracting its `.params` field. REST does not
+   * carry the JSON-RPC envelope — only the params payload is sent as the
+   * HTTP body.
+   *
+   * The `requestId` passed to `toCompatSendMessageRequest` is irrelevant
+   * since we only consume `.params`; we use the same counter as JSON-RPC
+   * for symmetry but never see the value on the wire.
+   */
+  private _buildSendMessageParams(core: V1SendMessageRequest): legacy.MessageSendParams {
+    const envelope = toCompatSendMessageRequest(core, this.requestIdCounter++);
+    return envelope.params;
+  }
+
+  /**
+   * Allocates a response ID for envelopes that need one for translator
+   * purposes (e.g. wrapping a bare list response so
+   * `toCoreListTaskPushNotificationConfigsResponse` can consume it). The
+   * value never appears on the v0.3 REST wire.
+   */
+  private _nextResponseId(): number {
+    return this.requestIdCounter++;
+  }
+
+  private _fetch(...args: Parameters<typeof fetch>): ReturnType<typeof fetch> {
+    if (this.customFetchImpl) {
+      return this.customFetchImpl(...args);
+    }
+    if (typeof fetch === 'function') {
+      return fetch(...args);
+    }
+    throw new Error(
+      'A `fetch` implementation was not provided and is not available in the global scope. ' +
+        'Please provide a `fetchImpl` in the LegacyRestTransportOptions.'
+    );
+  }
+
+  private _buildHeaders(
+    options: RequestOptions | undefined,
+    acceptHeader: string = LEGACY_JSON_CONTENT_TYPE
+  ): HeadersInit {
+    return {
+      ...options?.serviceParameters,
+      'Content-Type': LEGACY_JSON_CONTENT_TYPE,
+      Accept: acceptHeader,
+    };
+  }
+
+  /**
+   * Issues a non-streaming HTTP request against the v0.3 REST surface.
+   *
+   * - `body` is JSON-serialized as-is (already in v0.3 shape from the
+   *   caller's translator). Skipped for `GET`/`DELETE`.
+   * - 204 No Content (e.g. `DELETE`) resolves to `undefined`.
+   * - Non-2xx responses with a parseable v0.3 error body are mapped to a
+   *   typed SDK error via {@link mapToError}; everything else falls
+   *   through to a generic `Error`.
+   */
+  private async _sendRequest<TResponse>(
+    method: 'GET' | 'POST' | 'DELETE',
+    path: string,
+    body: unknown | undefined,
+    options: RequestOptions | undefined
+  ): Promise<TResponse> {
+    const url = `${this.endpoint}${path}`;
+    const requestInit: RequestInit = {
+      method,
+      headers: this._buildHeaders(options),
+      signal: options?.signal,
+    };
+
+    if (body !== undefined && method !== 'GET' && method !== 'DELETE') {
+      requestInit.body = JSON.stringify(body);
+    }
+
+    const response = await this._fetch(url, requestInit);
+
+    if (!response.ok) {
+      await LegacyRestTransport._handleErrorResponse(response, path);
+    }
+
+    if (response.status === 204) {
+      return undefined as TResponse;
+    }
+
+    return (await response.json()) as TResponse;
+  }
+
+  private async *_sendStreamingRequest(
+    path: string,
+    body: unknown | undefined,
+    options?: RequestOptions
+  ): AsyncGenerator<V1StreamResponse, void, undefined> {
+    const url = `${this.endpoint}${path}`;
+    const requestInit: RequestInit = {
+      method: 'POST',
+      headers: this._buildHeaders(options, 'text/event-stream'),
+      signal: options?.signal,
+    };
+
+    if (body !== undefined) {
+      requestInit.body = JSON.stringify(body);
+    }
+
+    const response = await this._fetch(url, requestInit);
+
+    if (!response.ok) {
+      await LegacyRestTransport._handleErrorResponse(response, path);
+    }
+
+    const contentType = response.headers.get('Content-Type');
+    if (!contentType?.startsWith('text/event-stream')) {
+      throw new Error(
+        `Invalid response Content-Type for SSE stream. Expected 'text/event-stream', got '${contentType}'.`
+      );
+    }
+
+    for await (const event of parseSseStream(response)) {
+      if (event.type === 'error') {
+        throw LegacyRestTransport._parseSseErrorEvent(event.data);
+      }
+      yield LegacyRestTransport._processSseEventData(event.data);
+    }
+  }
+
+  /**
+   * Translates a bare v0.3 SSE event payload into a v1.0 `StreamResponse`.
+   *
+   * REST SSE in v0.3 does not wrap events in a JSON-RPC envelope — the
+   * `data:` field is the bare stream-result payload. We re-wrap it into a
+   * minimal v0.3 success-response envelope so we can reuse
+   * `toCoreStreamResponse` (which expects the envelope shape).
+   */
+  private static _processSseEventData(jsonData: string): V1StreamResponse {
+    if (!jsonData.trim()) {
+      throw new Error('Attempted to process empty SSE event data.');
+    }
+
+    type LegacyStreamResult = legacy.SendStreamingMessageSuccessResponse['result'];
+    let result: LegacyStreamResult;
+    try {
+      result = JSON.parse(jsonData) as LegacyStreamResult;
+    } catch (e) {
+      throw new Error(
+        `Failed to parse SSE event data: "${jsonData.substring(0, 100)}...". Original error: ${(e instanceof Error && e.message) || 'Unknown error'}`,
+        { cause: e }
+      );
+    }
+
+    return toCoreStreamResponse({ id: null, jsonrpc: '2.0', result });
+  }
+
+  /**
+   * Maps an SSE `error`-typed event payload to a typed SDK error. The
+   * payload should be a bare v0.3 error body
+   * (`{ code, message, data? }`); falls back to a generic `Error` on
+   * shape mismatch.
+   */
+  private static _parseSseErrorEvent(jsonData: string): Error {
+    try {
+      const parsed = JSON.parse(jsonData) as unknown;
+      if (LegacyRestTransport._isLegacyRestErrorBody(parsed)) {
+        return LegacyRestTransport.mapToError(parsed);
+      }
+      return new Error(`SSE error event: ${jsonData}`);
+    } catch {
+      return new Error(`SSE error event (unparseable): ${jsonData}`);
+    }
+  }
+
+  /**
+   * Reads an error response body and throws a typed SDK error.
+   *
+   * v0.3 wire shape is a bare `{ code, message, data? }` JSON object. If
+   * the body parses to that shape, we map via {@link mapToError};
+   * otherwise we throw a generic `Error` with the HTTP status and the
+   * raw body text for debuggability. Mirrors `RestTransport`'s v1.0
+   * equivalent but uses the bare body shape rather than
+   * `{ error: { code, status, message, details } }`.
+   */
+  private static async _handleErrorResponse(response: Response, path: string): Promise<never> {
+    let errorBodyText = '(empty or non-JSON response)';
+    let errorBody: LegacyRestErrorBody | undefined;
+
+    try {
+      errorBodyText = await response.text();
+      if (errorBodyText) {
+        const parsed = JSON.parse(errorBodyText) as unknown;
+        if (LegacyRestTransport._isLegacyRestErrorBody(parsed)) {
+          errorBody = parsed;
+        }
+      }
+    } catch {
+      // JSON parse failed — fall through to generic error
+    }
+
+    if (errorBody) {
+      throw LegacyRestTransport.mapToError(errorBody);
+    }
+
+    throw new Error(
+      `HTTP error for ${path}! Status: ${response.status} ${response.statusText}. Response: ${errorBodyText}`
+    );
+  }
+
+  private static _isLegacyRestErrorBody(value: unknown): value is LegacyRestErrorBody {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as { code?: unknown }).code === 'number' &&
+      typeof (value as { message?: unknown }).message === 'string'
+    );
+  }
+
+  /**
+   * Parses the v0.3 `message/send` result into a v1.0
+   * {@link SendMessageResult}. v0.3 used a discriminated union with a
+   * `kind: 'task' | 'message'` field; we use that to pick the right
+   * translator. Mirrors
+   * {@link LegacyJsonRpcTransport._parseSendMessageResult}.
+   */
+  private static _parseSendMessageResult(result: legacy.Task | legacy.Message): SendMessageResult {
+    if (!result) {
+      throw new InvalidAgentResponseError('Invalid response: v0.3 message:send result is missing.');
+    }
+    if (result.kind === 'task') {
+      return toCoreTask(result);
+    }
+    if (result.kind === 'message') {
+      return toCoreMessage(result);
+    }
+    throw new InvalidAgentResponseError(
+      `Unexpected v0.3 message:send result kind: ${String((result as { kind?: string }).kind)}`
+    );
+  }
+
+  /**
+   * Maps a v0.3 REST error body into an SDK error class.
+   *
+   * Numeric A2A error codes are identical between v0.3 and v1.0 for
+   * every code that exists in both. Mirrors
+   * `LegacyJsonRpcTransport.mapToError` so users can catch the same
+   * typed errors regardless of which compat transport produced them.
+   * Unknown codes fall through to a generic `Error`.
+   */
+  private static mapToError(body: LegacyRestErrorBody): Error {
+    const message = body.message;
+    switch (body.code) {
+      case A2A_ERROR_CODE.PARSE_ERROR:
+      case A2A_ERROR_CODE.INVALID_REQUEST:
+      case A2A_ERROR_CODE.METHOD_NOT_FOUND:
+      case A2A_ERROR_CODE.INVALID_PARAMS:
+      case A2A_ERROR_CODE.INTERNAL_ERROR:
+        return new RequestMalformedError(message);
+      case A2A_ERROR_CODE.TASK_NOT_FOUND:
+        return new TaskNotFoundError(message);
+      case A2A_ERROR_CODE.TASK_NOT_CANCELABLE:
+        return new TaskNotCancelableError(message);
+      case A2A_ERROR_CODE.PUSH_NOTIFICATION_NOT_SUPPORTED:
+        return new PushNotificationNotSupportedError(message);
+      case A2A_ERROR_CODE.UNSUPPORTED_OPERATION:
+        return new UnsupportedOperationError(message);
+      case A2A_ERROR_CODE.CONTENT_TYPE_NOT_SUPPORTED:
+        return new ContentTypeNotSupportedError(message);
+      case A2A_ERROR_CODE.INVALID_AGENT_RESPONSE:
+        return new InvalidAgentResponseError(message);
+      case A2A_ERROR_CODE.EXTENDED_CARD_NOT_CONFIGURED:
+        return new ExtendedAgentCardNotConfiguredError(message);
+      default: {
+        const dataSuffix = body.data ? ` Data: ${JSON.stringify(body.data)}` : '';
+        return new Error(`REST error: ${message} (Code: ${body.code})${dataSuffix}`);
+      }
+    }
+  }
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -309,16 +309,24 @@ export class JSONRPCTransportError extends Error {
 }
 
 /**
- * Maps a JSON-RPC error envelope to a typed SDK error instance.
+ * Maps an A2A numeric error code + message to a typed SDK error class.
  *
- * Shared by both the v1.0 `JsonRpcTransport` and the v0.3 compat
- * `LegacyJsonRpcTransport`. v0.3 servers will never emit the
- * `EXTENSION_SUPPORT_REQUIRED` / `VERSION_NOT_SUPPORTED` codes in practice,
- * so handling them here is a no-op for the legacy transport.
+ * Envelope-agnostic core of the A2A code → SDK error switch. Used by both
+ * JSON-RPC transports (via {@link mapJsonRpcErrorToSdkError}) and the v0.3
+ * REST compat transport, which carry the same numeric `A2A_ERROR_CODE`
+ * values in different wire envelopes (JSON-RPC envelope vs. bare v0.3
+ * REST error body).
+ *
+ * Unknown codes return `fallback()`, allowing each transport to surface a
+ * shape-appropriate generic error (e.g. `JSONRPCTransportError` carrying
+ * the full envelope, or a plain `Error` with the REST body fields).
  */
-export function mapJsonRpcErrorToSdkError(response: JSONRPCErrorResponse): Error {
-  const errorMessage = response.error.message;
-  switch (response.error.code) {
+export function mapA2aErrorToSdkError(
+  err: { code: number; message: string },
+  fallback: () => Error
+): Error {
+  const errorMessage = err.message;
+  switch (err.code) {
     case A2A_ERROR_CODE.PARSE_ERROR:
     case A2A_ERROR_CODE.INVALID_REQUEST:
     case A2A_ERROR_CODE.METHOD_NOT_FOUND:
@@ -344,6 +352,22 @@ export function mapJsonRpcErrorToSdkError(response: JSONRPCErrorResponse): Error
     case A2A_ERROR_CODE.VERSION_NOT_SUPPORTED:
       return new VersionNotSupportedError(errorMessage);
     default:
-      return new JSONRPCTransportError(response);
+      return fallback();
   }
+}
+
+/**
+ * Maps a JSON-RPC error envelope to a typed SDK error instance.
+ *
+ * Shared by both the v1.0 `JsonRpcTransport` and the v0.3 compat
+ * `LegacyJsonRpcTransport`. v0.3 servers will never emit the
+ * `EXTENSION_SUPPORT_REQUIRED` / `VERSION_NOT_SUPPORTED` codes in practice,
+ * so handling them here is a no-op for the legacy transport.
+ *
+ * Thin wrapper over {@link mapA2aErrorToSdkError} that supplies a
+ * JSON-RPC-appropriate fallback ({@link JSONRPCTransportError}) carrying
+ * the full envelope for debuggability.
+ */
+export function mapJsonRpcErrorToSdkError(response: JSONRPCErrorResponse): Error {
+  return mapA2aErrorToSdkError(response.error, () => new JSONRPCTransportError(response));
 }

--- a/test/client/transports/json_rpc_transport.spec.ts
+++ b/test/client/transports/json_rpc_transport.spec.ts
@@ -262,6 +262,8 @@ describe('JsonRpcTransportFactory', () => {
       expect(transport).not.toBeInstanceOf(LegacyJsonRpcTransport);
     });
 
+    // TODO: It should default to v0.3 when protocolVersion is missing and legacyCompat is enabled
+    // after https://github.com/a2aproject/a2a-js/issues/474
     it('produces JsonRpcTransport when matched interface has empty protocolVersion', async () => {
       const card = baseAgentCard();
       card.supportedInterfaces = [

--- a/test/client/transports/rest_transport.spec.ts
+++ b/test/client/transports/rest_transport.spec.ts
@@ -546,6 +546,8 @@ describe('legacyCompat enabled', () => {
     expect(transport).not.toBeInstanceOf(LegacyRestTransport);
   });
 
+  // TODO: It should default to v0.3 when protocolVersion is missing and legacyCompat is enabled
+  // after https://github.com/a2aproject/a2a-js/issues/474
   it('produces RestTransport when matched interface has empty protocolVersion', async () => {
     const card = createMockAgentCard({
       supportedInterfaces: [

--- a/test/client/transports/rest_transport.spec.ts
+++ b/test/client/transports/rest_transport.spec.ts
@@ -4,6 +4,7 @@ import {
 } from '../../../src/client/transports/rest_transport.js';
 import { describe, it, beforeEach, afterEach, expect, vi, type Mock } from 'vitest';
 import { RequestOptions } from '../../../src/client/multitransport-client.js';
+import { LegacyRestTransport } from '../../../src/compat/v0_3/client/transports/rest_transport.js';
 import { HTTP_EXTENSION_HEADER } from '../../../src/constants.js';
 import { ServiceParameters, withA2AExtensions } from '../../../src/client/service-parameters.js';
 import {
@@ -508,5 +509,137 @@ describe('RestTransportFactory', () => {
     });
     const transport = await factory.create('https://example.com/api', agentCard);
     expect(transport).to.be.instanceOf(RestTransport);
+  });
+});
+
+describe('legacyCompat enabled', () => {
+  it('produces LegacyRestTransport when matched interface has protocolVersion 0.3', async () => {
+    const card = createMockAgentCard({
+      supportedInterfaces: [
+        {
+          url: 'https://a.example/rest',
+          protocolBinding: 'HTTP+JSON',
+          tenant: '',
+          protocolVersion: '0.3',
+        },
+      ],
+    });
+    const factory = new RestTransportFactory({ legacyCompat: { enabled: true } });
+    const transport = await factory.create('https://a.example/rest', card);
+    expect(transport).toBeInstanceOf(LegacyRestTransport);
+  });
+
+  it('produces RestTransport when matched interface has protocolVersion 1.0', async () => {
+    const card = createMockAgentCard({
+      supportedInterfaces: [
+        {
+          url: 'https://a.example/rest',
+          protocolBinding: 'HTTP+JSON',
+          tenant: '',
+          protocolVersion: '1.0',
+        },
+      ],
+    });
+    const factory = new RestTransportFactory({ legacyCompat: { enabled: true } });
+    const transport = await factory.create('https://a.example/rest', card);
+    expect(transport).toBeInstanceOf(RestTransport);
+    expect(transport).not.toBeInstanceOf(LegacyRestTransport);
+  });
+
+  it('produces RestTransport when matched interface has empty protocolVersion', async () => {
+    const card = createMockAgentCard({
+      supportedInterfaces: [
+        {
+          url: 'https://a.example/rest',
+          protocolBinding: 'HTTP+JSON',
+          tenant: '',
+          protocolVersion: '',
+        },
+      ],
+    });
+    const factory = new RestTransportFactory({ legacyCompat: { enabled: true } });
+    const transport = await factory.create('https://a.example/rest', card);
+    expect(transport).toBeInstanceOf(RestTransport);
+    expect(transport).not.toBeInstanceOf(LegacyRestTransport);
+  });
+
+  it('disambiguates by URL when multiple HTTP+JSON interfaces are present', async () => {
+    const card = createMockAgentCard({
+      supportedInterfaces: [
+        {
+          url: 'https://v1.example/rest',
+          protocolBinding: 'HTTP+JSON',
+          tenant: '',
+          protocolVersion: '1.0',
+        },
+        {
+          url: 'https://v03.example/rest',
+          protocolBinding: 'HTTP+JSON',
+          tenant: '',
+          protocolVersion: '0.3',
+        },
+      ],
+    });
+    const factory = new RestTransportFactory({ legacyCompat: { enabled: true } });
+
+    const v03 = await factory.create('https://v03.example/rest', card);
+    expect(v03).toBeInstanceOf(LegacyRestTransport);
+
+    const v1 = await factory.create('https://v1.example/rest', card);
+    expect(v1).toBeInstanceOf(RestTransport);
+    expect(v1).not.toBeInstanceOf(LegacyRestTransport);
+  });
+
+  it('falls back to v1.0 RestTransport when no HTTP+JSON interface is found', async () => {
+    const card = createMockAgentCard({
+      supportedInterfaces: [
+        {
+          url: 'https://a.example/rpc',
+          protocolBinding: 'JSONRPC',
+          tenant: '',
+          protocolVersion: '0.3',
+        },
+      ],
+    });
+    const factory = new RestTransportFactory({ legacyCompat: { enabled: true } });
+    const transport = await factory.create('https://a.example/rest', card);
+    expect(transport).toBeInstanceOf(RestTransport);
+    expect(transport).not.toBeInstanceOf(LegacyRestTransport);
+  });
+});
+
+describe('legacyCompat disabled (default)', () => {
+  it('produces RestTransport for v0.3 interface when legacyCompat option is omitted', async () => {
+    const card = createMockAgentCard({
+      supportedInterfaces: [
+        {
+          url: 'https://a.example/rest',
+          protocolBinding: 'HTTP+JSON',
+          tenant: '',
+          protocolVersion: '0.3',
+        },
+      ],
+    });
+    const factory = new RestTransportFactory();
+    const transport = await factory.create('https://a.example/rest', card);
+    expect(transport).toBeInstanceOf(RestTransport);
+    expect(transport).not.toBeInstanceOf(LegacyRestTransport);
+  });
+
+  it('produces RestTransport for v0.3 interface when legacyCompat.enabled is false', async () => {
+    const card = createMockAgentCard({
+      supportedInterfaces: [
+        {
+          url: 'https://a.example/rest',
+          protocolBinding: 'HTTP+JSON',
+          tenant: '',
+          protocolVersion: '0.3',
+        },
+      ],
+    });
+    const factory = new RestTransportFactory({ legacyCompat: { enabled: false } });
+    const transport = await factory.create('https://a.example/rest', card);
+    expect(transport).toBeInstanceOf(RestTransport);
+    expect(transport).not.toBeInstanceOf(LegacyRestTransport);
   });
 });

--- a/test/compat/v0_3/client/transports/rest_transport.spec.ts
+++ b/test/compat/v0_3/client/transports/rest_transport.spec.ts
@@ -1,0 +1,640 @@
+import { describe, it, beforeEach, expect, vi, type Mock } from 'vitest';
+
+import { LegacyRestTransport } from '../../../../../src/compat/v0_3/client/transports/rest_transport.js';
+import {
+  A2A_ERROR_CODE,
+  PushNotificationNotSupportedError,
+  TaskNotCancelableError,
+  TaskNotFoundError,
+  UnsupportedOperationError,
+} from '../../../../../src/errors.js';
+import { formatSSEEvent, formatSSEErrorEvent } from '../../../../../src/sse_utils.js';
+import {
+  Role,
+  TaskState,
+  type CancelTaskRequest as V1CancelTaskRequest,
+  type DeleteTaskPushNotificationConfigRequest as V1DeleteTaskPushNotificationConfigRequest,
+  type GetTaskPushNotificationConfigRequest as V1GetTaskPushNotificationConfigRequest,
+  type GetTaskRequest as V1GetTaskRequest,
+  type ListTaskPushNotificationConfigsRequest as V1ListTaskPushNotificationConfigsRequest,
+  type SendMessageRequest as V1SendMessageRequest,
+  type SubscribeToTaskRequest as V1SubscribeToTaskRequest,
+  type TaskPushNotificationConfig as V1TaskPushNotificationConfig,
+} from '../../../../../src/types/pb/a2a.js';
+
+const ENDPOINT = 'https://test.example/api';
+
+function makeJsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeNoContentResponse(): Response {
+  return new Response(null, { status: 204 });
+}
+
+function makeSseResponse(events: object[]): Response {
+  const body = events.map((event) => formatSSEEvent(event)).join('');
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+function makeSseErrorResponse(errorBodies: object[]): Response {
+  const body = errorBodies.map((err) => formatSSEErrorEvent(err)).join('');
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+function sendMessageRequest(): V1SendMessageRequest {
+  return {
+    tenant: '',
+    message: {
+      messageId: 'msg-1',
+      contextId: '',
+      taskId: '',
+      role: Role.ROLE_USER,
+      parts: [
+        {
+          content: { $case: 'text', value: 'hi' },
+          filename: '',
+          mediaType: '',
+          metadata: undefined,
+        },
+      ],
+      extensions: [],
+      metadata: undefined,
+      referenceTaskIds: [],
+    },
+    configuration: undefined,
+    metadata: {},
+  };
+}
+
+describe('LegacyRestTransport', () => {
+  let transport: LegacyRestTransport;
+  let mockFetch: Mock<typeof fetch>;
+
+  beforeEach(() => {
+    mockFetch = vi.fn();
+    transport = new LegacyRestTransport({
+      endpoint: ENDPOINT,
+      fetchImpl: mockFetch,
+    });
+  });
+
+  describe('metadata', () => {
+    it("protocolName is 'HTTP+JSON'", () => {
+      expect(transport.protocolName).toBe('HTTP+JSON');
+    });
+
+    it("protocolVersion is '0.3'", () => {
+      expect(transport.protocolVersion).toBe('0.3');
+    });
+  });
+
+  describe('constructor', () => {
+    it('trims a trailing slash from endpoint', async () => {
+      const t = new LegacyRestTransport({
+        endpoint: 'https://test.example/api/',
+        fetchImpl: mockFetch,
+      });
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({
+          kind: 'task',
+          id: 't-1',
+          contextId: 'ctx-1',
+          status: { state: 'working' },
+        })
+      );
+
+      await t.sendMessage(sendMessageRequest());
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://test.example/api/v1/message:send');
+    });
+
+    it('trims multiple trailing slashes from endpoint', async () => {
+      const t = new LegacyRestTransport({
+        endpoint: 'https://test.example/api///',
+        fetchImpl: mockFetch,
+      });
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({
+          kind: 'task',
+          id: 't-1',
+          contextId: 'ctx-1',
+          status: { state: 'working' },
+        })
+      );
+
+      await t.sendMessage(sendMessageRequest());
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe('https://test.example/api/v1/message:send');
+    });
+  });
+
+  describe('getExtendedAgentCard', () => {
+    it('emits GET /v1/card and translates the v0.3 AgentCard to v1 proto', async () => {
+      const legacyCard: Record<string, unknown> = {
+        name: 'My Agent',
+        description: 'desc',
+        version: '1.2.3',
+        url: 'https://agent.example/rest',
+        preferredTransport: 'HTTP+JSON',
+        protocolVersion: '0.3',
+        capabilities: {},
+        defaultInputModes: ['text/plain'],
+        defaultOutputModes: ['text/plain'],
+        skills: [],
+      };
+      mockFetch.mockResolvedValue(makeJsonResponse(legacyCard));
+
+      const card = await transport.getExtendedAgentCard({ tenant: '' });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/card`);
+      const init2 = init as RequestInit;
+      expect(init2.method).toBe('GET');
+      const headers = init2.headers as Record<string, string>;
+      expect(headers['Content-Type']).toBe('application/json');
+      expect(headers['Accept']).toBe('application/json');
+
+      expect(card.name).toBe('My Agent');
+      // Primary interface lifted from card-level (url, preferredTransport,
+      // protocolVersion) per the v0.3 → v1.0 translator.
+      expect(card.supportedInterfaces[0]!.url).toBe('https://agent.example/rest');
+      expect(card.supportedInterfaces[0]!.protocolBinding).toBe('HTTP+JSON');
+      expect(card.supportedInterfaces[0]!.protocolVersion).toBe('0.3');
+    });
+  });
+
+  describe('sendMessage', () => {
+    it('emits POST /v1/message:send with v0.3 MessageSendParams body', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({
+          kind: 'task',
+          id: 't-1',
+          contextId: 'ctx-1',
+          status: { state: 'working' },
+        })
+      );
+
+      const result = await transport.sendMessage(sendMessageRequest());
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/message:send`);
+      const init2 = init as RequestInit;
+      expect(init2.method).toBe('POST');
+      const headers = init2.headers as Record<string, string>;
+      // v0.3 uses bare application/json, not application/a2a+json.
+      expect(headers['Content-Type']).toBe('application/json');
+      expect(headers['Accept']).toBe('application/json');
+
+      const body = JSON.parse(init2.body as string);
+      // REST body is bare params (no JSON-RPC envelope).
+      expect(body.jsonrpc).toBeUndefined();
+      expect(body.method).toBeUndefined();
+      expect(body.message.kind).toBe('message');
+      expect(body.message.role).toBe('user');
+
+      // task result has no messageId; should be translated to v1 Task.
+      expect('messageId' in result).toBe(false);
+      expect('id' in result && (result as { id: string }).id).toBe('t-1');
+    });
+
+    it('translates a v0.3 message-shaped result into a v1 Message', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({
+          kind: 'message',
+          messageId: 'msg-resp',
+          role: 'agent',
+          parts: [],
+        })
+      );
+
+      const result = await transport.sendMessage(sendMessageRequest());
+      expect('messageId' in result && (result as { messageId: string }).messageId).toBe('msg-resp');
+    });
+  });
+
+  describe('getTask', () => {
+    it('emits GET /v1/tasks/:id and translates the v0.3 Task to v1 proto', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({
+          kind: 'task',
+          id: 't-1',
+          contextId: 'ctx-1',
+          status: { state: 'completed' },
+        })
+      );
+
+      const req: V1GetTaskRequest = { tenant: '', id: 't-1', historyLength: 5 };
+      const task = await transport.getTask(req);
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/tasks/t-1?historyLength=5`);
+      expect((init as RequestInit).method).toBe('GET');
+      expect(task.id).toBe('t-1');
+      expect(task.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+    });
+
+    it('omits the historyLength query parameter when undefined', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({
+          kind: 'task',
+          id: 't-1',
+          contextId: 'ctx-1',
+          status: { state: 'working' },
+        })
+      );
+
+      const req: V1GetTaskRequest = { tenant: '', id: 't-1', historyLength: undefined };
+      await transport.getTask(req);
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/tasks/t-1`);
+    });
+
+    it('percent-encodes the task id in the URL', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({
+          kind: 'task',
+          id: 'a b/c',
+          contextId: 'ctx-1',
+          status: { state: 'working' },
+        })
+      );
+
+      await transport.getTask({ tenant: '', id: 'a b/c', historyLength: 0 });
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/tasks/${encodeURIComponent('a b/c')}?historyLength=0`);
+    });
+  });
+
+  describe('cancelTask', () => {
+    it('emits POST /v1/tasks/:id:cancel with no body and translates the v0.3 Task', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({
+          kind: 'task',
+          id: 't-1',
+          contextId: 'ctx-1',
+          status: { state: 'canceled' },
+        })
+      );
+
+      const req: V1CancelTaskRequest = { tenant: '', id: 't-1', metadata: undefined };
+      const task = await transport.cancelTask(req);
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/tasks/t-1:cancel`);
+      const init2 = init as RequestInit;
+      expect(init2.method).toBe('POST');
+      expect(init2.body).toBeUndefined();
+      expect(task.id).toBe('t-1');
+      expect(task.status?.state).toBe(TaskState.TASK_STATE_CANCELED);
+    });
+
+    it('maps -32002 TASK_NOT_CANCELABLE to TaskNotCancelableError', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse(
+          { code: A2A_ERROR_CODE.TASK_NOT_CANCELABLE, message: 'cannot cancel' },
+          409
+        )
+      );
+
+      await expect(
+        transport.cancelTask({ tenant: '', id: 't-1', metadata: undefined })
+      ).rejects.toBeInstanceOf(TaskNotCancelableError);
+    });
+  });
+
+  describe('listTasks', () => {
+    it('throws UnsupportedOperationError synchronously without calling fetch', async () => {
+      await expect(
+        transport.listTasks({
+          tenant: '',
+          contextId: '',
+          status: TaskState.TASK_STATE_UNSPECIFIED,
+          pageSize: 0,
+          pageToken: '',
+          historyLength: 0,
+          statusTimestampAfter: '',
+          includeArtifacts: false,
+        })
+      ).rejects.toBeInstanceOf(UnsupportedOperationError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('error message references the missing v0.3 capability', async () => {
+      await expect(
+        transport.listTasks({
+          tenant: '',
+          contextId: '',
+          status: TaskState.TASK_STATE_UNSPECIFIED,
+          pageSize: 0,
+          pageToken: '',
+          historyLength: 0,
+          statusTimestampAfter: '',
+          includeArtifacts: false,
+        })
+      ).rejects.toSatisfy((err: unknown) => {
+        expect(err).toBeInstanceOf(UnsupportedOperationError);
+        expect((err as Error).message).toContain('tasks/list');
+        expect((err as Error).message).toContain('v0.3');
+        return true;
+      });
+    });
+  });
+
+  describe('push notification configs', () => {
+    function v1PushConfig(): V1TaskPushNotificationConfig {
+      return {
+        tenant: '',
+        id: 'cfg-1',
+        taskId: 'task-1',
+        url: 'https://webhook.example/notify',
+        token: 'tok',
+        authentication: undefined,
+      };
+    }
+
+    it('createTaskPushNotificationConfig POSTs to the v0.3 path with a v0.3 body', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'cfg-1',
+            url: 'https://webhook.example/notify',
+            token: 'tok',
+          },
+        })
+      );
+
+      const result = await transport.createTaskPushNotificationConfig(v1PushConfig());
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/tasks/task-1/pushNotificationConfigs`);
+      const init2 = init as RequestInit;
+      expect(init2.method).toBe('POST');
+      const body = JSON.parse(init2.body as string);
+      expect(body).toEqual({
+        taskId: 'task-1',
+        pushNotificationConfig: {
+          id: 'cfg-1',
+          url: 'https://webhook.example/notify',
+          token: 'tok',
+        },
+      });
+      expect(result.id).toBe('cfg-1');
+      expect(result.taskId).toBe('task-1');
+    });
+
+    it('createTaskPushNotificationConfig maps -32003 to PushNotificationNotSupportedError', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse(
+          { code: A2A_ERROR_CODE.PUSH_NOTIFICATION_NOT_SUPPORTED, message: 'no push' },
+          400
+        )
+      );
+
+      await expect(
+        transport.createTaskPushNotificationConfig(v1PushConfig())
+      ).rejects.toBeInstanceOf(PushNotificationNotSupportedError);
+    });
+
+    it('getTaskPushNotificationConfig GETs the v0.3 nested path', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({
+          taskId: 'task-1',
+          pushNotificationConfig: {
+            id: 'cfg-1',
+            url: 'https://webhook.example/notify',
+            token: 'tok',
+          },
+        })
+      );
+
+      const req: V1GetTaskPushNotificationConfigRequest = {
+        tenant: '',
+        taskId: 'task-1',
+        id: 'cfg-1',
+      };
+      const result = await transport.getTaskPushNotificationConfig(req);
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/tasks/task-1/pushNotificationConfigs/cfg-1`);
+      expect((init as RequestInit).method).toBe('GET');
+      expect(result.id).toBe('cfg-1');
+    });
+
+    it('listTaskPushNotificationConfig GETs the collection and wraps the array response', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse([
+          {
+            taskId: 'task-1',
+            pushNotificationConfig: {
+              id: 'cfg-1',
+              url: 'https://webhook.example/notify',
+              token: 'tok',
+            },
+          },
+        ])
+      );
+
+      const req: V1ListTaskPushNotificationConfigsRequest = {
+        tenant: '',
+        taskId: 'task-1',
+        pageSize: 0,
+        pageToken: '',
+      };
+      const result = await transport.listTaskPushNotificationConfig(req);
+
+      const [url] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/tasks/task-1/pushNotificationConfigs`);
+      expect(result.configs).toHaveLength(1);
+      expect(result.configs[0]!.id).toBe('cfg-1');
+    });
+
+    it('deleteTaskPushNotificationConfig DELETEs the nested path and accepts 204', async () => {
+      mockFetch.mockResolvedValue(makeNoContentResponse());
+
+      const req: V1DeleteTaskPushNotificationConfigRequest = {
+        tenant: '',
+        taskId: 'task-1',
+        id: 'cfg-1',
+      };
+      await transport.deleteTaskPushNotificationConfig(req);
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/tasks/task-1/pushNotificationConfigs/cfg-1`);
+      const init2 = init as RequestInit;
+      expect(init2.method).toBe('DELETE');
+      // DELETE never carries a body.
+      expect(init2.body).toBeUndefined();
+    });
+  });
+
+  describe('error envelope mapping', () => {
+    it('maps -32001 TASK_NOT_FOUND from a bare v0.3 error body to TaskNotFoundError', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({ code: A2A_ERROR_CODE.TASK_NOT_FOUND, message: 'no such task' }, 404)
+      );
+
+      await expect(
+        transport.getTask({ tenant: '', id: 't-x', historyLength: 0 })
+      ).rejects.toBeInstanceOf(TaskNotFoundError);
+    });
+
+    it('falls back to a generic Error for unknown codes', async () => {
+      mockFetch.mockResolvedValue(makeJsonResponse({ code: -42000, message: 'mystery' }, 400));
+
+      await expect(
+        transport.getTask({ tenant: '', id: 't-x', historyLength: 0 })
+      ).rejects.toSatisfy((err: unknown) => {
+        expect(err).toBeInstanceOf(Error);
+        expect(err).not.toBeInstanceOf(TaskNotFoundError);
+        expect((err as Error).message).toContain('mystery');
+        expect((err as Error).message).toContain('-42000');
+        return true;
+      });
+    });
+
+    it('falls back to a generic Error for non-JSON HTTP error bodies', async () => {
+      mockFetch.mockResolvedValue(
+        new Response('upstream went boom', {
+          status: 500,
+          statusText: 'Internal Server Error',
+          headers: { 'Content-Type': 'text/plain' },
+        })
+      );
+
+      await expect(
+        transport.getTask({ tenant: '', id: 't-x', historyLength: 0 })
+      ).rejects.toSatisfy((err: unknown) => {
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toContain('500');
+        expect((err as Error).message).toContain('upstream went boom');
+        return true;
+      });
+    });
+  });
+
+  describe('streaming', () => {
+    it('sendMessageStream POSTs to /v1/message:stream and translates bare v0.3 SSE events', async () => {
+      const events: Record<string, unknown>[] = [
+        {
+          kind: 'task',
+          id: 't-1',
+          contextId: 'ctx-1',
+          status: { state: 'submitted' },
+        },
+        {
+          kind: 'status-update',
+          taskId: 't-1',
+          contextId: 'ctx-1',
+          final: false,
+          status: { state: 'working' },
+        },
+        {
+          kind: 'artifact-update',
+          taskId: 't-1',
+          contextId: 'ctx-1',
+          artifact: { artifactId: 'a-1', parts: [] },
+        },
+        {
+          kind: 'message',
+          messageId: 'm-1',
+          role: 'agent',
+          parts: [],
+        },
+      ];
+      mockFetch.mockResolvedValue(makeSseResponse(events));
+
+      const received = [];
+      for await (const value of transport.sendMessageStream(sendMessageRequest())) {
+        received.push(value);
+      }
+
+      expect(received).toHaveLength(4);
+      expect(received[0]!.payload?.$case).toBe('task');
+      expect(received[1]!.payload?.$case).toBe('statusUpdate');
+      expect(received[2]!.payload?.$case).toBe('artifactUpdate');
+      expect(received[3]!.payload?.$case).toBe('message');
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/message:stream`);
+      const init2 = init as RequestInit;
+      const headers = init2.headers as Record<string, string>;
+      expect(headers['Accept']).toBe('text/event-stream');
+
+      // Body shape: bare v0.3 params (no JSON-RPC envelope).
+      const body = JSON.parse(init2.body as string);
+      expect(body.jsonrpc).toBeUndefined();
+      expect(body.message.kind).toBe('message');
+    });
+
+    it('resubscribeTask POSTs to /v1/tasks/:id:subscribe with no body', async () => {
+      mockFetch.mockResolvedValue(makeSseResponse([]));
+
+      const req: V1SubscribeToTaskRequest = { tenant: '', id: 't-1' };
+      const events = [];
+      for await (const event of transport.resubscribeTask(req)) {
+        events.push(event);
+      }
+      expect(events).toHaveLength(0);
+
+      const [url, init] = mockFetch.mock.calls[0]!;
+      expect(url).toBe(`${ENDPOINT}/v1/tasks/t-1:subscribe`);
+      const init2 = init as RequestInit;
+      expect(init2.method).toBe('POST');
+      expect(init2.body).toBeUndefined();
+    });
+
+    it('maps SSE error events with a v0.3 body to typed SDK errors', async () => {
+      mockFetch.mockResolvedValue(
+        makeSseErrorResponse([
+          { code: A2A_ERROR_CODE.TASK_NOT_FOUND, message: 'task gone mid-stream' },
+        ])
+      );
+
+      const iterator = transport.sendMessageStream(sendMessageRequest());
+      await expect(iterator.next()).rejects.toBeInstanceOf(TaskNotFoundError);
+    });
+  });
+
+  describe('service parameters / headers', () => {
+    it('forwards serviceParameters headers to fetch', async () => {
+      mockFetch.mockResolvedValue(
+        makeJsonResponse({
+          kind: 'task',
+          id: 't-1',
+          contextId: 'ctx-1',
+          status: { state: 'working' },
+        })
+      );
+
+      await transport.getTask(
+        { tenant: '', id: 't-1', historyLength: 0 },
+        { serviceParameters: { 'A2A-Version': '0.3', 'X-Custom': 'yes' } }
+      );
+
+      const [, init] = mockFetch.mock.calls[0]!;
+      const headers = (init as RequestInit).headers as Record<string, string>;
+      expect(headers['A2A-Version']).toBe('0.3');
+      expect(headers['X-Custom']).toBe('yes');
+      // Content-Type / Accept are appended after the service parameter spread
+      // and should win.
+      expect(headers['Content-Type']).toBe('application/json');
+    });
+  });
+});

--- a/test/errors.spec.ts
+++ b/test/errors.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import type { JSONRPCErrorResponse } from '../src/core.js';
 import {
   A2A_ERROR_CODE,
@@ -13,6 +13,7 @@ import {
   TaskNotFoundError,
   UnsupportedOperationError,
   VersionNotSupportedError,
+  mapA2aErrorToSdkError,
   mapJsonRpcErrorToSdkError,
 } from '../src/errors.js';
 
@@ -68,5 +69,37 @@ describe('mapJsonRpcErrorToSdkError', () => {
     const result = mapJsonRpcErrorToSdkError(envelope);
     expect(result).toBeInstanceOf(TaskNotFoundError);
     expect(result.message).toBe('task xyz missing');
+  });
+});
+
+describe('mapA2aErrorToSdkError', () => {
+  it('maps a known code to the matching typed SDK error', () => {
+    const fallback = vi.fn(() => new Error('should not be called'));
+    const result = mapA2aErrorToSdkError(
+      { code: A2A_ERROR_CODE.TASK_NOT_FOUND, message: 'task xyz missing' },
+      fallback
+    );
+    expect(result).toBeInstanceOf(TaskNotFoundError);
+    expect(result.message).toBe('task xyz missing');
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it('propagates the message for the catch-all malformed-request bucket', () => {
+    const fallback = vi.fn(() => new Error('should not be called'));
+    const result = mapA2aErrorToSdkError(
+      { code: A2A_ERROR_CODE.INVALID_PARAMS, message: 'bad params' },
+      fallback
+    );
+    expect(result).toBeInstanceOf(RequestMalformedError);
+    expect(result.message).toBe('bad params');
+    expect(fallback).not.toHaveBeenCalled();
+  });
+
+  it('invokes the fallback for unknown codes and returns its result', () => {
+    const fallbackError = new Error('fallback chosen');
+    const fallback = vi.fn(() => fallbackError);
+    const result = mapA2aErrorToSdkError({ code: -99999, message: 'mystery' }, fallback);
+    expect(fallback).toHaveBeenCalledTimes(1);
+    expect(result).toBe(fallbackError);
   });
 });


### PR DESCRIPTION
# Description

This pull request introduces a compatibility layer for REST transports, allowing the client to transparently support both v1.0 and legacy v0.3 protocol versions based on the agent card's interface. It does this by adding a new dispatch policy that selects the appropriate transport implementation at runtime, and includes comprehensive tests for the new behavior. The main logic for matching the correct agent interface is now shared between protocol-specific factories.

Key changes include:

### Legacy protocol (v0.3) compatibility for REST transport

* Added a `legacyCompat` option to `RestTransportFactoryOptions`, enabling the factory to dynamically choose between `RestTransport` (v1.0) and `LegacyRestTransport` (v0.3) based on the matched interface's `protocolVersion`. When enabled, v0.3 agents are contacted using the compat transport; otherwise, only v1.0 is used.
* Updated the `RestTransportFactory.create()` method to use the new dispatch policy, loading the v0.3 transport module only when necessary.

### Interface selection logic refactor

* Moved the `pickMatchingInterface` helper into its own module (`pick_interface.ts`) so both JSON-RPC and REST factories share the same logic for matching agent interfaces by protocol binding, URL, and version.

Closes #484  🦕
