### PR TITLE
feat: add v0.3 compatibility layer for client and server agent-card handling

### DIFF
--- a/src/client/card-resolver.ts
+++ b/src/client/card-resolver.ts
@@ -1,9 +1,28 @@
 import { AGENT_CARD_PATH } from '../constants.js';
 import { AgentCard } from '../index.js';
+import { isLegacyAgentCard, parseLegacyAgentCard } from '../compat/v0_3/client/index.js';
 
 export interface AgentCardResolverOptions {
   path?: string;
   fetchImpl?: typeof fetch;
+  /**
+   * Enables the v0.3 protocol compatibility layer.
+   *
+   * When enabled, the resolver inspects each fetched agent-card
+   * payload; if its shape matches v0.3 (top-level `url` without
+   * `supportedInterfaces`, `preferredTransport`,
+   * `additionalInterfaces`, `supportsAuthenticatedExtendedCard`, or
+   * a `protocolVersion` in `[0.3, 1.0)`), it is translated to the
+   * v1.0 proto shape via `toCoreAgentCard`. Each synthesized
+   * `AgentInterface` is stamped with `protocolVersion: '0.3'` so
+   * that a {@link JsonRpcTransportFactory} configured with
+   * `legacyCompat: { enabled: true }` selects the compat transport
+   * automatically.
+   *
+   * Default: omitted (treated as disabled). When disabled, the v0.3
+   * compat module is never loaded.
+   */
+  legacyCompat?: { enabled: boolean };
 }
 
 export interface AgentCardResolver {
@@ -51,8 +70,19 @@ export class DefaultAgentCardResolver implements AgentCardResolver {
    * allows us to parse cards served by endpoints returning the Protobuf JSON structure by
    * identifying the lack of the "type" field in security schemes or the presence of the
    * "schemes" wrapper in security entries, and normalizing it before use.
+   *
+   * When `legacyCompat: { enabled: true }`, this method also detects
+   * v0.3-shaped cards and translates them via the lazy-loaded compat
+   * module so the rest of the client stack sees a uniform v1.0
+   * representation with `protocolVersion: '0.3'` stamped on every
+   * synthesized interface.
    */
   private normalizeAgentCard(card: unknown): AgentCard {
+    if (this.options?.legacyCompat?.enabled) {
+      if (isLegacyAgentCard(card)) {
+        return parseLegacyAgentCard(card);
+      }
+    }
     if (this.isProtoAgentCard(card)) {
       const parsedProto = AgentCard.fromJSON(card);
       return parsedProto;

--- a/src/client/card-resolver.ts
+++ b/src/client/card-resolver.ts
@@ -1,6 +1,6 @@
 import { AGENT_CARD_PATH } from '../constants.js';
 import { AgentCard } from '../index.js';
-import { isLegacyAgentCard, parseLegacyAgentCard } from '../compat/v0_3/client/index.js';
+import { isLegacyAgentCard, parseLegacyAgentCard } from '../compat/v0_3/client/card-resolver.js';
 
 export interface AgentCardResolverOptions {
   path?: string;

--- a/src/client/card-resolver.ts
+++ b/src/client/card-resolver.ts
@@ -72,7 +72,7 @@ export class DefaultAgentCardResolver implements AgentCardResolver {
    * "schemes" wrapper in security entries, and normalizing it before use.
    *
    * When `legacyCompat: { enabled: true }`, this method also detects
-   * v0.3-shaped cards and translates them via the lazy-loaded compat
+   * v0.3-shaped cards and translates them via the compat
    * module so the rest of the client stack sees a uniform v1.0
    * representation with `protocolVersion: '0.3'` stamped on every
    * synthesized interface.

--- a/src/compat/v0_3/client/card-resolver.ts
+++ b/src/compat/v0_3/client/card-resolver.ts
@@ -17,7 +17,7 @@
  *
  * Kept in the compat layer (rather than in the core
  * `src/client/card-resolver.ts`) so the v0.3 types and translators are
- * only loaded when an operator has explicitly opted into compat.
+ * only called when an operator has explicitly opted into compat.
  */
 import type { AgentCard as V1AgentCard } from '../../../types/pb/a2a.js';
 import { toCoreAgentCard } from '../translate/agent_card.js';

--- a/src/compat/v0_3/client/card_resolver.ts
+++ b/src/compat/v0_3/client/card_resolver.ts
@@ -1,0 +1,89 @@
+/**
+ * v0.3 compat-layer helpers for the client-side {@link AgentCardResolver}.
+ *
+ * These helpers let a {@link DefaultAgentCardResolver} configured with
+ * `legacyCompat: { enabled: true }` detect a v0.3-shaped agent-card
+ * payload and translate it into a v1.0 proto {@link V1AgentCard} so the
+ * rest of the client stack (transport factories, multitransport client)
+ * sees a uniform v1.0 representation.
+ *
+ * The translator already lives in {@link toCoreAgentCard}
+ * (`../translate/agent_card.ts`) and stamps `protocolVersion: '0.3'` on
+ * every synthesized interface — both the primary (line 200) and every
+ * entry of `additionalInterfaces` (via {@link toCoreAgentInterface}).
+ * A {@link JsonRpcTransportFactory} constructed with
+ * `legacyCompat: { enabled: true }` will then pick the compat transport
+ * automatically when the matched interface declares a legacy version.
+ *
+ * Kept in the compat layer (rather than in the core
+ * `src/client/card-resolver.ts`) so the v0.3 types and translators are
+ * only loaded when an operator has explicitly opted into compat.
+ */
+import type { AgentCard as V1AgentCard } from '../../../types/pb/a2a.js';
+import { toCoreAgentCard } from '../translate/agent_card.js';
+import { isLegacyVersion } from '../translate/versions.js';
+import type * as legacy from '../types/types.js';
+
+/**
+ * Field names that only appear on the v0.3 `AgentCard` shape (not on
+ * the v1.0 proto-JSON shape).
+ *
+ * The presence of ANY of these (or a parseable legacy
+ * `protocolVersion`) is enough to classify the payload as v0.3 without
+ * inspecting every field on the card.
+ */
+const LEGACY_ONLY_TOP_LEVEL_FIELDS = [
+  'preferredTransport',
+  'additionalInterfaces',
+  'supportsAuthenticatedExtendedCard',
+] as const;
+
+/**
+ * Heuristically detects whether a raw agent-card JSON payload is
+ * shaped according to the v0.3 spec.
+ *
+ * Returns `true` when ANY of the following holds:
+ *  - The card has a top-level `url` AND no `supportedInterfaces`.
+ *  - The card has any of {@link LEGACY_ONLY_TOP_LEVEL_FIELDS}.
+ *  - The card has a `protocolVersion` value that falls inside the
+ *    legacy range `[0.3, 1.0)` (per
+ *    {@link isLegacyVersion}).
+ *
+ * Returns `false` for non-objects, null, and anything that lacks the
+ * above indicators (which includes well-formed v1.0 cards).
+ */
+export function isLegacyAgentCard(raw: unknown): boolean {
+  if (!raw || typeof raw !== 'object') return false;
+  const card = raw as Record<string, unknown>;
+
+  if (typeof card.url === 'string' && !('supportedInterfaces' in card)) {
+    return true;
+  }
+
+  for (const field of LEGACY_ONLY_TOP_LEVEL_FIELDS) {
+    if (field in card) return true;
+  }
+
+  if (typeof card.protocolVersion === 'string' && isLegacyVersion(card.protocolVersion)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Translates a v0.3 JSON agent-card payload into a v1.0 proto
+ * {@link V1AgentCard}.
+ *
+ * The returned card has every entry in `supportedInterfaces` stamped
+ * with `protocolVersion: '0.3'` (or whatever value the legacy card
+ * declared at the card level), so downstream factories configured with
+ * `legacyCompat: { enabled: true }` can select the v0.3 transport.
+ *
+ * The input is assumed to have already passed {@link isLegacyAgentCard}.
+ * Callers that pass an obviously-malformed payload will get whatever
+ * runtime error {@link toCoreAgentCard} produces.
+ */
+export function parseLegacyAgentCard(raw: unknown): V1AgentCard {
+  return toCoreAgentCard(raw as legacy.AgentCard);
+}

--- a/src/compat/v0_3/client/index.ts
+++ b/src/compat/v0_3/client/index.ts
@@ -2,7 +2,7 @@
  * Compat-layer client components for v0.3 transports.
  */
 
-export { isLegacyAgentCard, parseLegacyAgentCard } from './card_resolver.js';
+export { isLegacyAgentCard, parseLegacyAgentCard } from './card-resolver.js';
 export {
   LegacyJsonRpcTransport,
   type LegacyJsonRpcTransportOptions,

--- a/src/compat/v0_3/client/index.ts
+++ b/src/compat/v0_3/client/index.ts
@@ -2,6 +2,7 @@
  * Compat-layer client components for v0.3 transports.
  */
 
+export { isLegacyAgentCard, parseLegacyAgentCard } from './card_resolver.js';
 export {
   LegacyJsonRpcTransport,
   type LegacyJsonRpcTransportOptions,

--- a/src/compat/v0_3/server/express/agent_card_handler.ts
+++ b/src/compat/v0_3/server/express/agent_card_handler.ts
@@ -113,10 +113,10 @@ export function legacyAgentCardRouter(options: LegacyAgentCardHandlerOptions): R
         compatCard = toCompatAgentCard(coreCard);
       } catch (error) {
         if (error instanceof VersionNotSupportedError) {
+          res.append('Vary', A2A_VERSION_HEADER);
           res
             .status(HTTP_STATUS.BAD_REQUEST)
             .setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE)
-            .setHeader('Vary', A2A_VERSION_HEADER)
             .json(toLegacyHTTPError(error));
           return;
         }
@@ -130,7 +130,7 @@ export function legacyAgentCardRouter(options: LegacyAgentCardHandlerOptions): R
       // `Vary: A2A-Version` partitions the cache per protocol version
       // so a v1.0 client doesn't get a cached v0.3 body (and vice
       // versa) when sitting behind a shared HTTP cache.
-      res.setHeader('Vary', A2A_VERSION_HEADER);
+      res.append('Vary', A2A_VERSION_HEADER);
       if (maxAge > 0) {
         res.setHeader('Cache-Control', `public, max-age=${maxAge}`);
       } else {

--- a/src/compat/v0_3/server/express/agent_card_handler.ts
+++ b/src/compat/v0_3/server/express/agent_card_handler.ts
@@ -1,0 +1,159 @@
+/**
+ * v0.3 well-known agent-card Express handler.
+ *
+ * Mirrors the v1.0 {@link agentCardHandler} but serves a v0.3-shaped
+ * agent card produced by {@link toCompatAgentCard} for requests whose
+ * `A2A-Version` header falls in the legacy range `[0.3, 1.0)` (or is
+ * absent — per §3.6.2 a missing header defaults to `'0.3'`).
+ *
+ * Designed to be mounted at the top of the v1.0 handler's chain by the
+ * core `agentCardHandler` when `legacyCompat: { enabled: true }`. The
+ * router short-circuits non-legacy requests via `next('router')` so the
+ * v1.0 handler keeps serving the modern card unchanged.
+ */
+
+import crypto from 'crypto';
+import express, {
+  type NextFunction,
+  type Request,
+  type RequestHandler,
+  type Response,
+} from 'express';
+
+import { A2A_VERSION_HEADER } from '../../../../constants.js';
+import { VersionNotSupportedError } from '../../../../errors.js';
+import type {
+  AgentCardCacheOptions,
+  AgentCardProvider,
+} from '../../../../server/express/agent_card_handler.js';
+import { A2A_LEGACY_PROTOCOL_VERSION, LEGACY_JSON_CONTENT_TYPE } from '../../constants.js';
+import { toCompatAgentCard } from '../../translate/agent_card.js';
+import { isLegacyVersion } from '../../translate/versions.js';
+import type * as legacy from '../../types/types.js';
+import { HTTP_STATUS, toLegacyHTTPError } from '../transports/rest/rest_transport_handler.js';
+
+/**
+ * Options for {@link legacyAgentCardRouter}.
+ *
+ * Re-uses the v1.0 {@link AgentCardProvider} and
+ * {@link AgentCardCacheOptions} types so a single options object can be
+ * passed through unchanged from the core `agentCardHandler`.
+ */
+export interface LegacyAgentCardHandlerOptions {
+  agentCardProvider: AgentCardProvider;
+  cache?: AgentCardCacheOptions;
+}
+
+function computeETag(json: string): string {
+  const hash = crypto.createHash('sha256').update(json).digest('hex').slice(0, 16);
+  return `W/"${hash}"`;
+}
+
+/**
+ * Creates an Express router that serves a v0.3-shaped agent card for
+ * legacy-range requests on the well-known agent-card path.
+ *
+ * Dispatch is **header-based**, not path-based: a middleware at the top
+ * of the chain parses `A2A-Version` (defaulting to `'0.3'` per §3.6.2
+ * when absent) and short-circuits any request whose version is not in
+ * `[0.3, 1.0)` by calling `next('router')`, falling through to the
+ * parent's v1.0 handler.
+ *
+ * For legacy requests, the router:
+ *   - Calls the configured `agentCardProvider` to obtain the v1.0
+ *     proto card.
+ *   - Runs the card through {@link toCompatAgentCard}, which filters
+ *     `supportedInterfaces` to legacy entries and rebuilds the v0.3
+ *     card-level `(url, preferredTransport, additionalInterfaces)`
+ *     fields. If no interface qualifies the translator throws
+ *     {@link VersionNotSupportedError}; the router maps that to an
+ *     HTTP 400 with a v0.3-shaped error body.
+ *   - Sets `Content-Type: application/json` (the v0.3 spelling — v1.0
+ *     uses `application/a2a+json`).
+ *   - Computes a per-version `ETag` derived from the v0.3 body and
+ *     emits `Vary: A2A-Version` so caches keep separate entries per
+ *     version.
+ *   - Honors conditional `If-None-Match` requests via `req.fresh`.
+ *
+ * @example
+ * ```ts
+ * import { legacyAgentCardRouter } from '@a2a-js/sdk/compat/v0_3';
+ * app.use(
+ *   '/.well-known/agent-card.json',
+ *   legacyAgentCardRouter({ agentCardProvider: requestHandler })
+ * );
+ * ```
+ */
+export function legacyAgentCardRouter(options: LegacyAgentCardHandlerOptions): RequestHandler {
+  const router = express.Router();
+  const maxAge = options.cache?.maxAge ?? 3600;
+
+  const provider =
+    typeof options.agentCardProvider === 'function'
+      ? options.agentCardProvider
+      : options.agentCardProvider.getAgentCard.bind(options.agentCardProvider);
+
+  // Version-based dispatch: short-circuit anything that isn't in the
+  // legacy range `[0.3, 1.0)`. Header-less requests default to `'0.3'`
+  // per §3.6.2 and stay in this router.
+  router.use((req: Request, _res: Response, next: NextFunction) => {
+    const requestedVersion = req.header(A2A_VERSION_HEADER) || A2A_LEGACY_PROTOCOL_VERSION;
+    if (isLegacyVersion(requestedVersion)) {
+      next();
+    } else {
+      next('router');
+    }
+  });
+
+  router.get('/', async (req: Request, res: Response) => {
+    try {
+      const coreCard = await provider();
+      let compatCard: legacy.AgentCard;
+      try {
+        compatCard = toCompatAgentCard(coreCard);
+      } catch (error) {
+        if (error instanceof VersionNotSupportedError) {
+          res
+            .status(HTTP_STATUS.BAD_REQUEST)
+            .setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE)
+            .setHeader('Vary', A2A_VERSION_HEADER)
+            .json(toLegacyHTTPError(error));
+          return;
+        }
+        throw error;
+      }
+
+      const body = JSON.stringify(compatCard);
+      const etag = computeETag(body);
+
+      res.setHeader('ETag', etag);
+      // `Vary: A2A-Version` partitions the cache per protocol version
+      // so a v1.0 client doesn't get a cached v0.3 body (and vice
+      // versa) when sitting behind a shared HTTP cache.
+      res.setHeader('Vary', A2A_VERSION_HEADER);
+      if (maxAge > 0) {
+        res.setHeader('Cache-Control', `public, max-age=${maxAge}`);
+      } else {
+        res.setHeader('Cache-Control', 'no-cache');
+      }
+
+      // Support conditional requests: if client sends If-None-Match
+      // matching the current ETag, return 304 with no body.
+      if (req.fresh) {
+        res.status(304).end();
+        return;
+      }
+
+      res.setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE);
+      res.status(HTTP_STATUS.OK).send(body);
+    } catch (error) {
+      console.error('Error fetching legacy agent card:', error);
+      res
+        .status(500)
+        .setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE)
+        .json({ error: 'Failed to retrieve agent card' });
+    }
+  });
+
+  return router;
+}

--- a/src/compat/v0_3/server/express/agent_card_handler.ts
+++ b/src/compat/v0_3/server/express/agent_card_handler.ts
@@ -148,6 +148,7 @@ export function legacyAgentCardRouter(options: LegacyAgentCardHandlerOptions): R
       res.status(HTTP_STATUS.OK).send(body);
     } catch (error) {
       console.error('Error fetching legacy agent card:', error);
+      res.append('Vary', A2A_VERSION_HEADER);
       res
         .status(500)
         .setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE)

--- a/src/compat/v0_3/server/index.ts
+++ b/src/compat/v0_3/server/index.ts
@@ -9,4 +9,8 @@ export {
   toLegacyHTTPError,
   type LegacyRestErrorBody,
 } from './transports/rest/rest_transport_handler.js';
+export {
+  legacyAgentCardRouter,
+  type LegacyAgentCardHandlerOptions,
+} from './express/agent_card_handler.js';
 export { legacyRestRouter, type LegacyRestHandlerOptions } from './express/rest_handler.js';

--- a/src/server/express/agent_card_handler.ts
+++ b/src/server/express/agent_card_handler.ts
@@ -102,7 +102,7 @@ export function agentCardHandler(options: AgentCardHandlerOptions): RequestHandl
       // `A2A-Version` so a v1.0 client doesn't receive a cached v0.3
       // body (and vice versa) when sitting behind a shared HTTP cache.
       if (options.legacyCompat?.enabled) {
-        res.setHeader('Vary', A2A_VERSION_HEADER);
+        res.append('Vary', A2A_VERSION_HEADER);
       }
       if (maxAge > 0) {
         res.setHeader('Cache-Control', `public, max-age=${maxAge}`);

--- a/src/server/express/agent_card_handler.ts
+++ b/src/server/express/agent_card_handler.ts
@@ -1,5 +1,7 @@
 import crypto from 'crypto';
 import express, { Request, RequestHandler, Response } from 'express';
+import { A2A_VERSION_HEADER } from '../../constants.js';
+import { legacyAgentCardRouter } from '../../compat/v0_3/server/index.js';
 import { AgentCard } from '../../index.js';
 
 export interface AgentCardCacheOptions {
@@ -9,6 +11,28 @@ export interface AgentCardCacheOptions {
 export interface AgentCardHandlerOptions {
   agentCardProvider: AgentCardProvider;
   cache?: AgentCardCacheOptions;
+  /**
+   * Enables the v0.3 protocol compatibility layer.
+   *
+   * When enabled, the handler inspects the `A2A-Version` header on
+   * each request (defaulting to `'0.3'` per §3.6.2 when absent): for
+   * versions in the legacy range `[0.3, 1.0)` it serves a v0.3-shaped
+   * card produced by `toCompatAgentCard(card)`; for any non-legacy
+   * version it serves the modern v1.0 card unchanged.
+   *
+   * When `toCompatAgentCard` throws `VersionNotSupportedError`
+   * (no v0.3 interface advertised on the agent card), the handler
+   * responds with HTTP 400 and a v0.3-shaped error body.
+   *
+   * Per-version `ETag`s are emitted and `Vary: A2A-Version` is set on
+   * every response so shared HTTP caches keep separate entries per
+   * version.
+   *
+   * Default: omitted (treated as disabled). When disabled, the v0.3
+   * compat module is not instantiated and the well-known endpoint
+   * behaves exactly as it did before this option was introduced.
+   */
+  legacyCompat?: { enabled: boolean };
 }
 
 export type AgentCardProvider = { getAgentCard(): Promise<AgentCard> } | (() => Promise<AgentCard>);
@@ -26,6 +50,12 @@ function computeETag(json: string): string {
  * - Server SHOULD include `ETag`
  * - Client SHOULD honor HTTP caching (conditional requests via `If-None-Match`)
  *
+ * When `legacyCompat: { enabled: true }`, the handler mounts the v0.3
+ * compat router at the top of its chain; that router inspects the
+ * `A2A-Version` header and serves a `toCompatAgentCard()`-translated
+ * card for legacy-range requests. Non-legacy requests fall through to
+ * the v1.0 handler below unchanged.
+ *
  * @example
  * ```ts
  * // With an existing A2ARequestHandler instance:
@@ -34,6 +64,11 @@ function computeETag(json: string): string {
  * app.use('/.well-known/agent-card.json', agentCardHandler({
  *   agentCardProvider: a2aRequestHandler,
  *   cache: { maxAge: 7200 }
+ * }));
+ * // With v0.3 compat negotiation enabled:
+ * app.use('/.well-known/agent-card.json', agentCardHandler({
+ *   agentCardProvider: a2aRequestHandler,
+ *   legacyCompat: { enabled: true },
  * }));
  * ```
  */
@@ -46,6 +81,16 @@ export function agentCardHandler(options: AgentCardHandlerOptions): RequestHandl
       ? options.agentCardProvider
       : options.agentCardProvider.getAgentCard.bind(options.agentCardProvider);
 
+  // Opt-in v0.3 compatibility. When enabled, the legacy router is
+  // mounted at the top of the chain (path-less) and dispatches per
+  // `A2A-Version` header internally: legacy-range requests get served
+  // a v0.3 card; non-legacy requests fall through via `next('router')`
+  // to the v1.0 handler below. When `legacyCompat` is omitted or
+  // disabled, the compat module is never instantiated.
+  if (options.legacyCompat?.enabled) {
+    router.use(legacyAgentCardRouter(options));
+  }
+
   router.get('/', async (req: Request, res: Response) => {
     try {
       const agentCard = await provider();
@@ -53,6 +98,12 @@ export function agentCardHandler(options: AgentCardHandlerOptions): RequestHandl
       const etag = computeETag(body);
 
       res.setHeader('ETag', etag);
+      // When compat negotiation is enabled, the cache key must include
+      // `A2A-Version` so a v1.0 client doesn't receive a cached v0.3
+      // body (and vice versa) when sitting behind a shared HTTP cache.
+      if (options.legacyCompat?.enabled) {
+        res.setHeader('Vary', A2A_VERSION_HEADER);
+      }
       if (maxAge > 0) {
         res.setHeader('Cache-Control', `public, max-age=${maxAge}`);
       } else {

--- a/test/compat/v0_3/client/card_resolver.spec.ts
+++ b/test/compat/v0_3/client/card_resolver.spec.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi, type Mock } from 'vitest';
+import { DefaultAgentCardResolver } from '../../../../src/client/card-resolver.js';
+import {
+  isLegacyAgentCard,
+  parseLegacyAgentCard,
+} from '../../../../src/compat/v0_3/client/card_resolver.js';
+import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
+
+function minimalLegacyCard(): legacy.AgentCard {
+  return {
+    name: 'Agent',
+    description: 'desc',
+    version: '1.2.3',
+    url: 'https://api.example/a2a',
+    preferredTransport: 'JSONRPC',
+    protocolVersion: '0.3',
+    capabilities: { streaming: true },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [{ id: 's1', name: 'Skill', description: 'desc', tags: [] }],
+  };
+}
+
+function modernCardJson(): Record<string, unknown> {
+  // A v1.0 proto-shaped agent card JSON payload, the same shape used by
+  // the existing `DefaultAgentCardResolver.isProtoAgentCard` heuristic
+  // for non-legacy payloads.
+  return {
+    name: 'Modern',
+    description: 'desc',
+    version: '1.0.0',
+    supportedInterfaces: [
+      {
+        url: 'https://api.example/v1',
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+    ],
+    capabilities: {
+      streaming: true,
+      pushNotifications: false,
+      extensions: [],
+    },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    securityRequirements: [],
+    securitySchemes: {},
+    signatures: [],
+    provider: { url: '', organization: '' },
+  };
+}
+
+describe('isLegacyAgentCard', () => {
+  it('returns true for a minimal v0.3 card with `url` and no `supportedInterfaces`', () => {
+    expect(isLegacyAgentCard(minimalLegacyCard())).toBe(true);
+  });
+
+  it('returns true for a card with `preferredTransport`', () => {
+    expect(isLegacyAgentCard({ preferredTransport: 'JSONRPC' })).toBe(true);
+  });
+
+  it('returns true for a card with `additionalInterfaces`', () => {
+    expect(
+      isLegacyAgentCard({
+        additionalInterfaces: [{ url: 'https://x', transport: 'GRPC' }],
+      })
+    ).toBe(true);
+  });
+
+  it('returns true for a card with `supportsAuthenticatedExtendedCard`', () => {
+    expect(isLegacyAgentCard({ supportsAuthenticatedExtendedCard: true })).toBe(true);
+  });
+
+  it('returns true for a card with a legacy-range `protocolVersion`', () => {
+    expect(isLegacyAgentCard({ protocolVersion: '0.3' })).toBe(true);
+    expect(isLegacyAgentCard({ protocolVersion: '0.3.5' })).toBe(true);
+    expect(isLegacyAgentCard({ protocolVersion: '0.9' })).toBe(true);
+  });
+
+  it('returns false for a modern v1.0 proto-shaped card', () => {
+    expect(isLegacyAgentCard(modernCardJson())).toBe(false);
+  });
+
+  it('returns false for non-objects', () => {
+    expect(isLegacyAgentCard(null)).toBe(false);
+    expect(isLegacyAgentCard(undefined)).toBe(false);
+    expect(isLegacyAgentCard('string')).toBe(false);
+    expect(isLegacyAgentCard(42)).toBe(false);
+    expect(isLegacyAgentCard([])).toBe(false);
+  });
+
+  it('returns false for a `protocolVersion: "1.0"` (non-legacy)', () => {
+    expect(isLegacyAgentCard({ protocolVersion: '1.0' })).toBe(false);
+  });
+
+  it('returns false for a card that has both `url` and `supportedInterfaces`', () => {
+    // A bare `url` alone isn't enough to classify as legacy when the
+    // modern `supportedInterfaces` array is also present.
+    expect(
+      isLegacyAgentCard({
+        url: 'https://api.example/a2a',
+        supportedInterfaces: [
+          {
+            url: 'https://api.example/v1',
+            protocolBinding: 'JSONRPC',
+            tenant: '',
+            protocolVersion: '1.0',
+          },
+        ],
+      })
+    ).toBe(false);
+  });
+});
+
+describe('parseLegacyAgentCard', () => {
+  it('translates a v0.3 card to a v1.0 proto card', () => {
+    const v1 = parseLegacyAgentCard(minimalLegacyCard());
+    expect(v1.supportedInterfaces).toHaveLength(1);
+    expect(v1.supportedInterfaces[0]!.url).toBe('https://api.example/a2a');
+    expect(v1.supportedInterfaces[0]!.protocolBinding).toBe('JSONRPC');
+    expect(v1.supportedInterfaces[0]!.protocolVersion).toBe('0.3');
+  });
+
+  it('stamps `protocolVersion: "0.3"` on every synthesized interface (primary + additional)', () => {
+    const compatCard: legacy.AgentCard = {
+      ...minimalLegacyCard(),
+      additionalInterfaces: [
+        { url: 'https://api.example/grpc', transport: 'GRPC' },
+        { url: 'https://api.example/rest', transport: 'HTTP+JSON' },
+      ],
+    };
+    const v1 = parseLegacyAgentCard(compatCard);
+    expect(v1.supportedInterfaces).toHaveLength(3);
+    for (const intf of v1.supportedInterfaces) {
+      expect(intf.protocolVersion).toBe('0.3');
+    }
+    expect(v1.supportedInterfaces.map((i) => i.protocolBinding)).toEqual([
+      'JSONRPC',
+      'GRPC',
+      'HTTP+JSON',
+    ]);
+  });
+});
+
+describe('DefaultAgentCardResolver with legacyCompat', () => {
+  function makeMockFetch(responseBody: unknown): Mock<typeof fetch> {
+    const fn = vi.fn();
+    fn.mockResolvedValue(
+      new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+    return fn as unknown as Mock<typeof fetch>;
+  }
+
+  it('translates a v0.3 card to v1.0 shape when legacyCompat is enabled', async () => {
+    const mockFetch = makeMockFetch(minimalLegacyCard());
+    const resolver = new DefaultAgentCardResolver({
+      fetchImpl: mockFetch,
+      legacyCompat: { enabled: true },
+    });
+
+    const card = await resolver.resolve('https://example.com');
+
+    expect(card.supportedInterfaces).toHaveLength(1);
+    expect(card.supportedInterfaces[0]!.protocolVersion).toBe('0.3');
+    expect(card.supportedInterfaces[0]!.protocolBinding).toBe('JSONRPC');
+    expect(card.supportedInterfaces[0]!.url).toBe('https://api.example/a2a');
+  });
+
+  it('translates a v0.3 card with additional interfaces and stamps every interface', async () => {
+    const mockFetch = makeMockFetch({
+      ...minimalLegacyCard(),
+      additionalInterfaces: [{ url: 'https://api.example/grpc', transport: 'GRPC' }],
+    });
+    const resolver = new DefaultAgentCardResolver({
+      fetchImpl: mockFetch,
+      legacyCompat: { enabled: true },
+    });
+
+    const card = await resolver.resolve('https://example.com');
+
+    expect(card.supportedInterfaces).toHaveLength(2);
+    expect(card.supportedInterfaces.every((i) => i.protocolVersion === '0.3')).toBe(true);
+  });
+
+  it('leaves a modern v1.0 card unchanged when legacyCompat is enabled', async () => {
+    const mockFetch = makeMockFetch(modernCardJson());
+    const resolver = new DefaultAgentCardResolver({
+      fetchImpl: mockFetch,
+      legacyCompat: { enabled: true },
+    });
+
+    const card = await resolver.resolve('https://example.com');
+
+    expect(card.supportedInterfaces).toHaveLength(1);
+    expect(card.supportedInterfaces[0]!.protocolVersion).toBe('1.0');
+    expect(card.supportedInterfaces[0]!.protocolBinding).toBe('JSONRPC');
+  });
+
+  it('does NOT translate a v0.3 card when legacyCompat is omitted', async () => {
+    const mockFetch = makeMockFetch(minimalLegacyCard());
+    const resolver = new DefaultAgentCardResolver({ fetchImpl: mockFetch });
+
+    const card = await resolver.resolve('https://example.com');
+
+    // The existing normalization path doesn't run the v0.3 translator,
+    // so `supportedInterfaces` is NOT synthesized.
+    expect(card.supportedInterfaces).toBeUndefined();
+  });
+
+  it('does NOT translate a v0.3 card when legacyCompat.enabled is false', async () => {
+    const mockFetch = makeMockFetch(minimalLegacyCard());
+    const resolver = new DefaultAgentCardResolver({
+      fetchImpl: mockFetch,
+      legacyCompat: { enabled: false },
+    });
+
+    const card = await resolver.resolve('https://example.com');
+
+    expect(card.supportedInterfaces).toBeUndefined();
+  });
+});

--- a/test/compat/v0_3/client/card_resolver.spec.ts
+++ b/test/compat/v0_3/client/card_resolver.spec.ts
@@ -3,7 +3,7 @@ import { DefaultAgentCardResolver } from '../../../../src/client/card-resolver.j
 import {
   isLegacyAgentCard,
   parseLegacyAgentCard,
-} from '../../../../src/compat/v0_3/client/card_resolver.js';
+} from '../../../../src/compat/v0_3/client/card-resolver.js';
 import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
 
 function minimalLegacyCard(): legacy.AgentCard {

--- a/test/compat/v0_3/server/express/agent_card_handler.spec.ts
+++ b/test/compat/v0_3/server/express/agent_card_handler.spec.ts
@@ -267,6 +267,34 @@ describe('agentCardHandler with legacyCompat', () => {
       assert.equal(response.headers['vary'], 'Accept-Encoding, A2A-Version');
     });
 
+    it('preserves an upstream Vary value on the generic 500 error path', async () => {
+      // Provider throws a plain Error (not VersionNotSupportedError) so the
+      // outer catch in the legacy router is exercised. The Vary header must
+      // still be appended so shared HTTP caches don't serve this 500 to a
+      // v1.0 client that should have hit the v1.0 handler instead.
+      const app = express();
+      app.use((_req: Request, res: Response, next: NextFunction) => {
+        res.setHeader('Vary', 'Accept-Encoding');
+        next();
+      });
+      app.use(
+        '/.well-known/agent-card.json',
+        agentCardHandler({
+          agentCardProvider: async () => {
+            throw new Error('boom');
+          },
+          legacyCompat: { enabled: true },
+        })
+      );
+
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .expect(500);
+
+      assert.equal(response.headers['vary'], 'Accept-Encoding, A2A-Version');
+    });
+
     it('emits different ETags for the v0.3 and v1.0 bodies', async () => {
       const app = createApp(dualVersionCard(), { enabled: true });
       const compat = await request(app)

--- a/test/compat/v0_3/server/express/agent_card_handler.spec.ts
+++ b/test/compat/v0_3/server/express/agent_card_handler.spec.ts
@@ -1,0 +1,321 @@
+import express from 'express';
+import request from 'supertest';
+import { assert, describe, it } from 'vitest';
+
+import { agentCardHandler } from '../../../../../src/server/express/agent_card_handler.js';
+import { legacyAgentCardRouter } from '../../../../../src/compat/v0_3/server/express/agent_card_handler.js';
+import type { AgentCard } from '../../../../../src/index.js';
+
+/**
+ * Agent card with a single v0.3 JSONRPC interface so
+ * `toCompatAgentCard` produces a valid legacy card.
+ */
+function legacyOnlyCard(): AgentCard {
+  return {
+    name: 'Test Agent',
+    description: 'A test agent',
+    version: '1.0.0',
+    provider: { url: 'https://example.com', organization: 'Test Org' },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    securitySchemes: {},
+    securityRequirements: [],
+    signatures: [],
+    supportedInterfaces: [
+      {
+        url: 'https://api.example/a2a',
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: '0.3',
+      },
+    ],
+    capabilities: {
+      extensions: [],
+      streaming: true,
+      pushNotifications: false,
+    },
+  };
+}
+
+/**
+ * Agent card with both a v0.3 and a v1.0 interface so the same card
+ * can be served at both protocol versions.
+ */
+function dualVersionCard(): AgentCard {
+  return {
+    name: 'Test Agent',
+    description: 'A test agent',
+    version: '1.0.0',
+    provider: { url: 'https://example.com', organization: 'Test Org' },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    securitySchemes: {},
+    securityRequirements: [],
+    signatures: [],
+    supportedInterfaces: [
+      {
+        url: 'https://api.example/v1',
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+      {
+        url: 'https://api.example/legacy',
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: '0.3',
+      },
+    ],
+    capabilities: {
+      extensions: [],
+      streaming: true,
+      pushNotifications: false,
+    },
+  };
+}
+
+/**
+ * Agent card with NO v0.3 interface — `toCompatAgentCard` must throw
+ * `VersionNotSupportedError`, which the handler converts to HTTP 400.
+ */
+function modernOnlyCard(): AgentCard {
+  return {
+    name: 'Test Agent',
+    description: 'A test agent',
+    version: '1.0.0',
+    provider: { url: 'https://example.com', organization: 'Test Org' },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    securitySchemes: {},
+    securityRequirements: [],
+    signatures: [],
+    supportedInterfaces: [
+      {
+        url: 'https://api.example/v1',
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+    ],
+    capabilities: {
+      extensions: [],
+      streaming: true,
+      pushNotifications: false,
+    },
+  };
+}
+
+function createApp(card: AgentCard, legacyCompat?: { enabled: boolean }) {
+  const app = express();
+  app.use(
+    '/.well-known/agent-card.json',
+    agentCardHandler({
+      agentCardProvider: async () => card,
+      legacyCompat,
+    })
+  );
+  return app;
+}
+
+function createLegacyOnlyApp(card: AgentCard) {
+  // Mount only the legacy router for tests that need to exercise the
+  // legacy code path in isolation.
+  const app = express();
+  app.use(
+    '/.well-known/agent-card.json',
+    legacyAgentCardRouter({ agentCardProvider: async () => card })
+  );
+  return app;
+}
+
+describe('agentCardHandler with legacyCompat', () => {
+  describe('header-based dispatch', () => {
+    it('serves a v0.3 card when no A2A-Version header is sent (defaults to 0.3)', async () => {
+      const app = createApp(dualVersionCard(), { enabled: true });
+      const response = await request(app).get('/.well-known/agent-card.json').expect(200);
+
+      // v0.3 cards have a top-level `url`/`preferredTransport` shape and
+      // no `supportedInterfaces` array.
+      assert.equal(response.body.name, 'Test Agent');
+      assert.equal(response.body.url, 'https://api.example/legacy');
+      assert.equal(response.body.preferredTransport, 'JSONRPC');
+      assert.equal(response.body.protocolVersion, '0.3');
+      assert.isUndefined(response.body.supportedInterfaces);
+    });
+
+    it('serves a v0.3 card on explicit A2A-Version: 0.3', async () => {
+      const app = createApp(dualVersionCard(), { enabled: true });
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .expect(200);
+
+      assert.equal(response.body.url, 'https://api.example/legacy');
+      assert.equal(response.body.protocolVersion, '0.3');
+    });
+
+    it('serves the modern v1.0 card on explicit A2A-Version: 1.0', async () => {
+      const app = createApp(dualVersionCard(), { enabled: true });
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '1.0')
+        .expect(200);
+
+      // v1.0 card preserves the `supportedInterfaces` array and no
+      // top-level `url`/`preferredTransport`.
+      assert.isArray(response.body.supportedInterfaces);
+      assert.equal(response.body.supportedInterfaces.length, 2);
+      assert.isUndefined(response.body.url);
+      assert.isUndefined(response.body.preferredTransport);
+    });
+
+    it('serves the modern v1.0 card on a non-legacy version > 1.0', async () => {
+      const app = createApp(dualVersionCard(), { enabled: true });
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '2.0')
+        .expect(200);
+
+      // Anything outside `[0.3, 1.0)` falls through to v1.0.
+      assert.isArray(response.body.supportedInterfaces);
+    });
+  });
+
+  describe('caching headers', () => {
+    it('sets Vary: A2A-Version on the compat path', async () => {
+      const app = createApp(dualVersionCard(), { enabled: true });
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .expect(200);
+
+      assert.equal(response.headers['vary'], 'A2A-Version');
+    });
+
+    it('sets Vary: A2A-Version on the v1.0 path when compat is enabled', async () => {
+      const app = createApp(dualVersionCard(), { enabled: true });
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '1.0')
+        .expect(200);
+
+      assert.equal(response.headers['vary'], 'A2A-Version');
+    });
+
+    it('does NOT set Vary when compat is disabled', async () => {
+      const app = createApp(modernOnlyCard());
+      const response = await request(app).get('/.well-known/agent-card.json').expect(200);
+
+      assert.isUndefined(response.headers['vary']);
+    });
+
+    it('emits different ETags for the v0.3 and v1.0 bodies', async () => {
+      const app = createApp(dualVersionCard(), { enabled: true });
+      const compat = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .expect(200);
+      const modern = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '1.0')
+        .expect(200);
+
+      assert.isDefined(compat.headers['etag']);
+      assert.isDefined(modern.headers['etag']);
+      assert.notEqual(compat.headers['etag'], modern.headers['etag']);
+    });
+
+    it('returns 304 when If-None-Match matches the per-version ETag', async () => {
+      const app = createApp(dualVersionCard(), { enabled: true });
+      const first = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .expect(200);
+      const etag = first.headers['etag'];
+
+      await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .set('If-None-Match', etag)
+        .expect(304);
+    });
+
+    it('emits Cache-Control with default max-age on the compat path', async () => {
+      const app = createApp(dualVersionCard(), { enabled: true });
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .expect(200);
+
+      assert.equal(response.headers['cache-control'], 'public, max-age=3600');
+    });
+  });
+
+  describe('error handling', () => {
+    it('returns 400 with a v0.3-shaped error when no legacy interface is advertised', async () => {
+      const app = createApp(modernOnlyCard(), { enabled: true });
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .expect(400);
+
+      // v0.3 error body: bare `{ code, message, data? }`.
+      assert.isNumber(response.body.code);
+      assert.isString(response.body.message);
+      assert.match(response.body.message, /interface/i);
+    });
+
+    it('falls through to the v1.0 handler for non-legacy requests against a modern-only card', async () => {
+      const app = createApp(modernOnlyCard(), { enabled: true });
+      // v1.0 request should NOT get the 400 — the legacy router
+      // short-circuits via `next('router')`.
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '1.0')
+        .expect(200);
+
+      assert.isArray(response.body.supportedInterfaces);
+    });
+  });
+
+  describe('back-compat (legacyCompat omitted)', () => {
+    it('serves the v1.0 card regardless of A2A-Version header', async () => {
+      const app = createApp(legacyOnlyCard());
+
+      // Even with header set, behavior is unchanged from today.
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .expect(200);
+
+      assert.isArray(response.body.supportedInterfaces);
+    });
+  });
+});
+
+describe('legacyAgentCardRouter (standalone)', () => {
+  it('serves the v0.3 card when mounted directly', async () => {
+    const app = createLegacyOnlyApp(legacyOnlyCard());
+    const response = await request(app).get('/.well-known/agent-card.json').expect(200);
+
+    assert.equal(response.body.url, 'https://api.example/a2a');
+    assert.equal(response.body.preferredTransport, 'JSONRPC');
+    assert.equal(response.body.protocolVersion, '0.3');
+  });
+
+  it('falls through (404) for a v1.0 request when nothing else is mounted', async () => {
+    const app = createLegacyOnlyApp(legacyOnlyCard());
+    // Without a v1.0 handler mounted after the legacy router,
+    // `next('router')` causes Express to return 404.
+    await request(app).get('/.well-known/agent-card.json').set('A2A-Version', '1.0').expect(404);
+  });
+
+  it('uses application/json content type (not application/a2a+json)', async () => {
+    const app = createLegacyOnlyApp(legacyOnlyCard());
+    const response = await request(app).get('/.well-known/agent-card.json').expect(200);
+    assert.match(response.headers['content-type'], /^application\/json/);
+  });
+});

--- a/test/compat/v0_3/server/express/agent_card_handler.spec.ts
+++ b/test/compat/v0_3/server/express/agent_card_handler.spec.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { type NextFunction, type Request, type Response } from 'express';
 import request from 'supertest';
 import { assert, describe, it } from 'vitest';
 
@@ -120,6 +120,28 @@ function createApp(card: AgentCard, legacyCompat?: { enabled: boolean }) {
   return app;
 }
 
+/**
+ * Mounts a tiny pre-middleware that stamps `Vary: Accept-Encoding` so
+ * tests can assert that the handlers' `Vary` write merges into (rather
+ * than overwrites) upstream values — emulating what compression/CORS
+ * middleware would do in a real deployment.
+ */
+function createAppWithUpstreamVary(card: AgentCard, legacyCompat?: { enabled: boolean }) {
+  const app = express();
+  app.use((_req: Request, res: Response, next: NextFunction) => {
+    res.setHeader('Vary', 'Accept-Encoding');
+    next();
+  });
+  app.use(
+    '/.well-known/agent-card.json',
+    agentCardHandler({
+      agentCardProvider: async () => card,
+      legacyCompat,
+    })
+  );
+  return app;
+}
+
 function createLegacyOnlyApp(card: AgentCard) {
   // Mount only the legacy router for tests that need to exercise the
   // legacy code path in isolation.
@@ -210,6 +232,39 @@ describe('agentCardHandler with legacyCompat', () => {
       const response = await request(app).get('/.well-known/agent-card.json').expect(200);
 
       assert.isUndefined(response.headers['vary']);
+    });
+
+    it('preserves an upstream Vary value on the compat (v0.3) success path', async () => {
+      const app = createAppWithUpstreamVary(dualVersionCard(), { enabled: true });
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .expect(200);
+
+      // `res.append` merges into the existing comma-separated value
+      // instead of overwriting `Accept-Encoding` set by upstream
+      // (e.g. compression) middleware.
+      assert.equal(response.headers['vary'], 'Accept-Encoding, A2A-Version');
+    });
+
+    it('preserves an upstream Vary value on the v1.0 success path', async () => {
+      const app = createAppWithUpstreamVary(dualVersionCard(), { enabled: true });
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '1.0')
+        .expect(200);
+
+      assert.equal(response.headers['vary'], 'Accept-Encoding, A2A-Version');
+    });
+
+    it('preserves an upstream Vary value on the VersionNotSupportedError (400) path', async () => {
+      const app = createAppWithUpstreamVary(modernOnlyCard(), { enabled: true });
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .expect(400);
+
+      assert.equal(response.headers['vary'], 'Accept-Encoding, A2A-Version');
     });
 
     it('emits different ETags for the v0.3 and v1.0 bodies', async () => {

--- a/vitest.edge.config.ts
+++ b/vitest.edge.config.ts
@@ -8,6 +8,7 @@ export default defineWorkersConfig(
       exclude: [
         // Express tests require Node.js-specific APIs (http, Express framework)
         'test/server/express/**',
+        'test/compat/v0_3/server/express/**',
         // gRpc test require Node.js-specific gRPC module
         'test/server/grpc/*.spec.ts',
         'test/client/transports/grpc_transport.spec.ts',


### PR DESCRIPTION
# Description

This pull request introduces a v0.3 protocol compatibility layer for both client and server handling of agent cards. The main goal is to allow negotiation and translation between legacy (v0.3) and modern (v1.0) agent card shapes, ensuring backward compatibility for clients and servers opting into this feature. The changes are opt-in and only affect behavior when the new `legacyCompat: { enabled: true }` option is set.

Closes #485  🦕
