### PR TITLE
feat: implement versioned push notification serializers with legacy v0.3 compatibility support

### DIFF
--- a/src/compat/v0_3/README.md
+++ b/src/compat/v0_3/README.md
@@ -52,9 +52,9 @@ Webhooks registered over v0.3 transports must receive the v0.3-shaped HTTP body,
 
 This is implemented by two pieces working together:
 
-1. **`PushNotificationStore` captures the wire version.** The `InMemoryPushNotificationStore` (and any conforming implementation) reads `context.requestedVersion` on `save()` and persists it alongside the config as a `StoredPushNotificationConfig { config, wireVersion }`. When the same task later emits events, `load()` returns the wire version next to each config.
+1. **`PushNotificationStore` captures the wire version.** The `InMemoryPushNotificationStore` (and any conforming implementation) reads `context.requestedVersion` on `save()` and persists it alongside the config as a `StoredPushNotificationConfig { config, wireVersion }`. The wire version is surfaced via the optional `loadWithMetadata` read method.
 
-2. **`DefaultPushNotificationSender` routes per wire version.** The sender resolves a `PushNotificationSerializer` per stored entry using the persisted wire version. It always registers `V1PushNotificationSerializer` under `'1.0'` and falls back to it (with a one-time warning per unknown version) when no serializer is registered for the entry's version.
+2. **`DefaultPushNotificationSender` routes per wire version.** The sender prefers `loadWithMetadata` when the store implements it, otherwise falls back to `load` and defaults every entry to wire version `'0.3'` per spec §3.6.2's absent-header rule. It always registers `V1PushNotificationSerializer` under `'1.0'` and falls back to it (with a one-time warning per unknown version) when no serializer is registered for the entry's version.
 
 ### Enabling v0.3 push delivery
 
@@ -71,3 +71,13 @@ const sender = createLegacyAwarePushNotificationSender(store);
 ```
 
 v1.0-registered webhooks continue to receive the canonical `StreamResponse` body with `application/a2a+json`; v0.3-registered webhooks receive the bare-event JSON with `application/json`. Custom serializers (or overrides for the built-in `'0.3'` / `'1.0'` entries) can be supplied via the `serializers` option; user-supplied entries take precedence.
+
+### Caveat for custom `PushNotificationStore` implementations
+
+The `PushNotificationStore.loadWithMetadata` method is optional. The SDK's `InMemoryPushNotificationStore` implements it; **custom store implementations that omit it cause the sender to default every stored config to wire version `'0.3'`** (per spec §3.6.2). The implications:
+
+- **v0.3-only deployments**: no concern — the default matches your transports.
+- **v1.0-only deployments**: also no concern unless you also opt into this compat layer (which you have no reason to do).
+- **Mixed v0.3 + v1.0 deployments backed by a custom store + the compat layer**: v1.0-registered webhooks will silently receive v0.3 bodies. Implement `loadWithMetadata` on your custom store (mirror `InMemoryPushNotificationStore`'s 3-line implementation) to preserve the originating wire version per config.
+
+This compat layer (and therefore the caveat above) is opt-in and will be retired once the ecosystem has migrated to v1.0.

--- a/src/compat/v0_3/README.md
+++ b/src/compat/v0_3/README.md
@@ -74,10 +74,12 @@ v1.0-registered webhooks continue to receive the canonical `StreamResponse` body
 
 ### Caveat for custom `PushNotificationStore` implementations
 
-The `PushNotificationStore.loadWithMetadata` method is optional. The SDK's `InMemoryPushNotificationStore` implements it; **custom store implementations that omit it cause the sender to default every stored config to wire version `'0.3'`** (per spec §3.6.2). The implications:
+The `PushNotificationStore.loadWithMetadata` method is optional. The SDK's `InMemoryPushNotificationStore` implements it. **Custom store implementations that omit it cause the sender to default each dispatch to the wire version of the request that _triggered_ the dispatch (`context.requestedVersion`),** falling back to `'0.3'` per spec §3.6.2 only when the triggering context carries no version.
 
-- **v0.3-only deployments**: no concern — the default matches your transports.
-- **v1.0-only deployments**: also no concern unless you also opt into this compat layer (which you have no reason to do).
-- **Mixed v0.3 + v1.0 deployments backed by a custom store + the compat layer**: v1.0-registered webhooks will silently receive v0.3 bodies. Implement `loadWithMetadata` on your custom store (mirror `InMemoryPushNotificationStore`'s 3-line implementation) to preserve the originating wire version per config.
+What this means for the two deployment shapes a v1.0 server can take:
 
-This compat layer (and therefore the caveat above) is opt-in and will be retired once the ecosystem has migrated to v1.0.
+- **Pure v1.0 deployment** (no compat layer opted in): no concern. Every triggering context carries `'1.0'`, the built-in V1 serializer handles every dispatch, and no warnings are emitted — even with a custom store implementation.
+
+- **v1.0 deployment with v0.3 compat opted in** (`createLegacyAwarePushNotificationSender`): each webhook receives the body shape of whichever client _triggered_ the dispatch, not necessarily of the client that originally registered the webhook. If a v1.0 client triggers an event for a task with a webhook registered by a legacy v0.3 client, that v0.3 webhook will receive a v1.0 body (and vice versa). Implement `loadWithMetadata` on your custom store (mirror `InMemoryPushNotificationStore`'s 3-line implementation) to preserve the originating wire version per config.
+
+The compat layer (and therefore the caveat above) is opt-in and will be retired once the legacy v0.3 client base has migrated to v1.0.

--- a/src/compat/v0_3/README.md
+++ b/src/compat/v0_3/README.md
@@ -45,3 +45,29 @@ Notable policy decisions:
 - `TaskStatusUpdateEvent.final` is computed from the status state going v1.0 → v0.3 (`true` for `completed`, `canceled`, `failed`, `rejected`).
 - `SendMessageConfiguration.returnImmediately` ↔ `MessageSendConfiguration.blocking` with inverted polarity.
 - `toCompatAgentCard` filters `supportedInterfaces` to those whose `protocolVersion` is empty or in `[0.3, 1.0)` and throws `VersionNotSupportedError` if none qualify.
+
+## Push Notifications
+
+Webhooks registered over v0.3 transports must receive the v0.3-shaped HTTP body, not the v1.0 `StreamResponse` wrapper. Per the v0.3 spec example (§9.5), the body is the **bare event object** (a v0.3 JSON `Task`, `TaskStatusUpdateEvent`, or `TaskArtifactUpdateEvent` discriminated by its `kind` field) with `Content-Type: application/json` — no `StreamResponse` discriminator and no JSON-RPC envelope.
+
+This is implemented by two pieces working together:
+
+1. **`PushNotificationStore` captures the wire version.** The `InMemoryPushNotificationStore` (and any conforming implementation) reads `context.requestedVersion` on `save()` and persists it alongside the config as a `StoredPushNotificationConfig { config, wireVersion }`. When the same task later emits events, `load()` returns the wire version next to each config.
+
+2. **`DefaultPushNotificationSender` routes per wire version.** The sender resolves a `PushNotificationSerializer` per stored entry using the persisted wire version. It always registers `V1PushNotificationSerializer` under `'1.0'` and falls back to it (with a one-time warning per unknown version) when no serializer is registered for the entry's version.
+
+### Enabling v0.3 push delivery
+
+Use `createLegacyAwarePushNotificationSender` from `src/compat/v0_3/server/index.ts` (re-exported as `createLegacyAwarePushNotificationSender` from `@a2a-js/sdk/server`'s compat barrel) instead of constructing the sender directly. It pre-registers `V03PushNotificationSerializer` under the `'0.3'` key:
+
+```ts
+import { InMemoryPushNotificationStore } from '@a2a-js/sdk/server';
+import { createLegacyAwarePushNotificationSender } from '@a2a-js/sdk/compat/v0_3/server';
+
+const store = new InMemoryPushNotificationStore();
+const sender = createLegacyAwarePushNotificationSender(store);
+
+// Hand both to your DefaultRequestHandler as usual.
+```
+
+v1.0-registered webhooks continue to receive the canonical `StreamResponse` body with `application/a2a+json`; v0.3-registered webhooks receive the bare-event JSON with `application/json`. Custom serializers (or overrides for the built-in `'0.3'` / `'1.0'` entries) can be supplied via the `serializers` option; user-supplied entries take precedence.

--- a/src/compat/v0_3/server/index.ts
+++ b/src/compat/v0_3/server/index.ts
@@ -19,3 +19,7 @@ export {
   LegacyA2AService,
   type LegacyGrpcServiceOptions,
 } from './grpc/index.js';
+export {
+  createLegacyAwarePushNotificationSender,
+  V03PushNotificationSerializer,
+} from './push_notification/index.js';

--- a/src/compat/v0_3/server/push_notification/index.ts
+++ b/src/compat/v0_3/server/push_notification/index.ts
@@ -1,0 +1,48 @@
+/**
+ * v0.3 compat-layer push-notification serializer and helpers.
+ *
+ * The canonical push-notification machinery (store, sender) lives in
+ * `src/server/push_notification/`. This module adds the v0.3-aware
+ * serializer + a convenience factory that pre-registers it on a
+ * {@link DefaultPushNotificationSender}, so deployments that mount the
+ * v0.3 compat transports can deliver webhooks in the v0.3 wire format
+ * without manually wiring the serializer.
+ */
+
+import {
+  DefaultPushNotificationSender,
+  type DefaultPushNotificationSenderOptions,
+} from '../../../../server/push_notification/default_push_notification_sender.js';
+import type { PushNotificationStore } from '../../../../server/push_notification/push_notification_store.js';
+import { A2A_LEGACY_PROTOCOL_VERSION } from '../../../../constants.js';
+import { V03PushNotificationSerializer } from './v03_push_notification_serializer.js';
+
+export { V03PushNotificationSerializer };
+
+/**
+ * Constructs a {@link DefaultPushNotificationSender} with the v0.3
+ * serializer pre-registered under the legacy version key
+ * ({@link A2A_LEGACY_PROTOCOL_VERSION}, i.e. `'0.3'`).
+ *
+ * Webhooks registered over v0.3 transports (e.g. legacy gRPC, legacy
+ * JSON-RPC, legacy REST) carry their wire version through the
+ * {@link PushNotificationStore} and are dispatched with the v0.3-shaped
+ * body + `application/json` content type. Webhooks registered over the
+ * canonical v1.0 transports continue to use the built-in v1.0 serializer.
+ *
+ * Callers can override the pre-registered v0.3 entry — or add serializers
+ * for other versions — by supplying their own `serializers` map in
+ * `options`; user-supplied entries take precedence.
+ */
+export function createLegacyAwarePushNotificationSender(
+  pushNotificationStore: PushNotificationStore,
+  options: DefaultPushNotificationSenderOptions = {}
+): DefaultPushNotificationSender {
+  return new DefaultPushNotificationSender(pushNotificationStore, {
+    ...options,
+    serializers: {
+      [A2A_LEGACY_PROTOCOL_VERSION]: new V03PushNotificationSerializer(),
+      ...(options.serializers ?? {}),
+    },
+  });
+}

--- a/src/compat/v0_3/server/push_notification/index.ts
+++ b/src/compat/v0_3/server/push_notification/index.ts
@@ -14,21 +14,21 @@ import {
   type DefaultPushNotificationSenderOptions,
 } from '../../../../server/push_notification/default_push_notification_sender.js';
 import type { PushNotificationStore } from '../../../../server/push_notification/push_notification_store.js';
-import { A2A_LEGACY_PROTOCOL_VERSION } from '../../../../constants.js';
+import { ProtocolVersion } from '../../../../constants.js';
 import { V03PushNotificationSerializer } from './v03_push_notification_serializer.js';
 
 export { V03PushNotificationSerializer };
 
 /**
  * Constructs a {@link DefaultPushNotificationSender} with the v0.3
- * serializer pre-registered under the legacy version key
- * ({@link A2A_LEGACY_PROTOCOL_VERSION}, i.e. `'0.3'`).
+ * serializer pre-registered under {@link ProtocolVersion.V0_3} (`'0.3'`).
  *
  * Webhooks registered over v0.3 transports (e.g. legacy gRPC, legacy
  * JSON-RPC, legacy REST) carry their wire version through the
- * {@link PushNotificationStore} and are dispatched with the v0.3-shaped
- * body + `application/json` content type. Webhooks registered over the
- * canonical v1.0 transports continue to use the built-in v1.0 serializer.
+ * {@link PushNotificationStore} (when it implements `loadWithMetadata`)
+ * and are dispatched with the v0.3-shaped body + `application/json`
+ * content type. Webhooks registered over the canonical v1.0 transports
+ * continue to use the built-in v1.0 serializer.
  *
  * Callers can override the pre-registered v0.3 entry — or add serializers
  * for other versions — by supplying their own `serializers` map in
@@ -41,7 +41,7 @@ export function createLegacyAwarePushNotificationSender(
   return new DefaultPushNotificationSender(pushNotificationStore, {
     ...options,
     serializers: {
-      [A2A_LEGACY_PROTOCOL_VERSION]: new V03PushNotificationSerializer(),
+      [ProtocolVersion.V0_3]: new V03PushNotificationSerializer(),
       ...(options.serializers ?? {}),
     },
   });

--- a/src/compat/v0_3/server/push_notification/v03_push_notification_serializer.ts
+++ b/src/compat/v0_3/server/push_notification/v03_push_notification_serializer.ts
@@ -1,0 +1,71 @@
+import {
+  PushNotificationSerializer,
+  SerializedPushNotification,
+} from '../../../../server/push_notification/push_notification_serializer.js';
+import { StreamResponse } from '../../../../index.js';
+import { LEGACY_JSON_CONTENT_TYPE } from '../../constants.js';
+import { toCompatTask } from '../../translate/tasks.js';
+import {
+  toCompatTaskArtifactUpdateEvent,
+  toCompatTaskStatusUpdateEvent,
+} from '../../translate/tasks.js';
+
+/**
+ * The v0.3 push notification serializer.
+ *
+ * Per the v0.3 spec example (§9.5), the push-notification HTTP body is the
+ * **bare event object** (a v0.3 JSON `Task`, `TaskStatusUpdateEvent`, or
+ * `TaskArtifactUpdateEvent` discriminated by its `kind` field) with
+ * `Content-Type: application/json`. Notably:
+ *
+ *  - It is **not** wrapped in a `StreamResponse` discriminator (no outer
+ *    `task` / `statusUpdate` / `artifactUpdate` key) — that wrapper is a
+ *    v1.0 addition (§4.3.3).
+ *  - It is **not** wrapped in a JSON-RPC envelope (no `jsonrpc`, `id`,
+ *    `result`) — push notifications are unsolicited and have no in-flight
+ *    request to correlate against; the JSON-RPC envelope only appears on
+ *    the streaming (SSE) path in v0.3.
+ *
+ * The canonical {@link StreamResponse} payload is translated to the v0.3
+ * JSON shape via the per-case `toCompat*` translators in
+ * `compat/v0_3/translate/tasks.ts`, which also set the legacy `kind`
+ * discriminator (`'task'`, `'status-update'`, or `'artifact-update'`) the
+ * v0.3 schema requires.
+ *
+ * `message` payloads are rejected (consistent with v1.0 behavior); push
+ * notifications are defined for task / status / artifact events only.
+ */
+export class V03PushNotificationSerializer implements PushNotificationSerializer {
+  serialize(streamResponse: StreamResponse): SerializedPushNotification {
+    const payload = streamResponse.payload;
+    if (!payload) {
+      throw new Error('StreamResponse payload is undefined');
+    }
+
+    let legacyEvent: unknown;
+    switch (payload.$case) {
+      case 'task':
+        legacyEvent = toCompatTask(payload.value);
+        break;
+      case 'statusUpdate':
+        legacyEvent = toCompatTaskStatusUpdateEvent(payload.value);
+        break;
+      case 'artifactUpdate':
+        legacyEvent = toCompatTaskArtifactUpdateEvent(payload.value);
+        break;
+      case 'message':
+        throw new Error('Push notification should not be sent for message payload.');
+      default: {
+        // Exhaustive check: keeps this switch in sync with the StreamResponse
+        // payload union at compile time.
+        const _exhaustive: never = payload;
+        throw new Error(`Unknown payload case: ${(_exhaustive as { $case: string }).$case}`);
+      }
+    }
+
+    return {
+      body: JSON.stringify(legacyEvent),
+      contentType: LEGACY_JSON_CONTENT_TYPE,
+    };
+  }
+}

--- a/src/compat/v0_3/server/push_notification/v03_push_notification_serializer.ts
+++ b/src/compat/v0_3/server/push_notification/v03_push_notification_serializer.ts
@@ -4,23 +4,24 @@ import {
 } from '../../../../server/push_notification/push_notification_serializer.js';
 import { StreamResponse } from '../../../../index.js';
 import { LEGACY_JSON_CONTENT_TYPE } from '../../constants.js';
-import { toCompatTask } from '../../translate/tasks.js';
 import {
+  toCompatTask,
   toCompatTaskArtifactUpdateEvent,
   toCompatTaskStatusUpdateEvent,
 } from '../../translate/tasks.js';
+import { toCompatMessage } from '../../translate/messages.js';
 
 /**
  * The v0.3 push notification serializer.
  *
  * Per the v0.3 spec example (§9.5), the push-notification HTTP body is the
- * **bare event object** (a v0.3 JSON `Task`, `TaskStatusUpdateEvent`, or
- * `TaskArtifactUpdateEvent` discriminated by its `kind` field) with
- * `Content-Type: application/json`. Notably:
+ * **bare event object** (a v0.3 JSON `Task`, `Message`,
+ * `TaskStatusUpdateEvent`, or `TaskArtifactUpdateEvent` discriminated by
+ * its `kind` field) with `Content-Type: application/json`. Notably:
  *
  *  - It is **not** wrapped in a `StreamResponse` discriminator (no outer
- *    `task` / `statusUpdate` / `artifactUpdate` key) — that wrapper is a
- *    v1.0 addition (§4.3.3).
+ *    `task` / `message` / `statusUpdate` / `artifactUpdate` key) — that
+ *    wrapper is a v1.0 addition (§4.3.3).
  *  - It is **not** wrapped in a JSON-RPC envelope (no `jsonrpc`, `id`,
  *    `result`) — push notifications are unsolicited and have no in-flight
  *    request to correlate against; the JSON-RPC envelope only appears on
@@ -28,12 +29,11 @@ import {
  *
  * The canonical {@link StreamResponse} payload is translated to the v0.3
  * JSON shape via the per-case `toCompat*` translators in
- * `compat/v0_3/translate/tasks.ts`, which also set the legacy `kind`
- * discriminator (`'task'`, `'status-update'`, or `'artifact-update'`) the
+ * `compat/v0_3/translate/`, which set the legacy `kind` discriminator
+ * (`'task'`, `'message'`, `'status-update'`, or `'artifact-update'`) the
  * v0.3 schema requires.
  *
- * `message` payloads are rejected (consistent with v1.0 behavior); push
- * notifications are defined for task / status / artifact events only.
+ * All four payload variants are handled per spec §4.3.3.
  */
 export class V03PushNotificationSerializer implements PushNotificationSerializer {
   serialize(streamResponse: StreamResponse): SerializedPushNotification {
@@ -47,14 +47,15 @@ export class V03PushNotificationSerializer implements PushNotificationSerializer
       case 'task':
         legacyEvent = toCompatTask(payload.value);
         break;
+      case 'message':
+        legacyEvent = toCompatMessage(payload.value);
+        break;
       case 'statusUpdate':
         legacyEvent = toCompatTaskStatusUpdateEvent(payload.value);
         break;
       case 'artifactUpdate':
         legacyEvent = toCompatTaskArtifactUpdateEvent(payload.value);
         break;
-      case 'message':
-        throw new Error('Push notification should not be sent for message payload.');
       default: {
         // Exhaustive check: keeps this switch in sync with the StreamResponse
         // payload union at compile time.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,26 @@ export const A2A_PROTOCOL_VERSION = '1.0';
 export const A2A_LEGACY_PROTOCOL_VERSION = '0.3';
 
 /**
+ * Known A2A protocol wire versions.
+ *
+ * The string values match the canonical `Major.Minor` form transmitted in
+ * the `A2A-Version` HTTP header (§3.6.1) and stored on
+ * `ServerCallContext.requestedVersion`. Used as typed keys in version-keyed
+ * registries such as `DefaultPushNotificationSenderOptions.serializers`.
+ *
+ * Enum values are hard-coded string literals (TypeScript requires enum
+ * initializers to be constants); the matching exported string constants
+ * {@link A2A_PROTOCOL_VERSION} and {@link A2A_LEGACY_PROTOCOL_VERSION}
+ * remain the canonical sources of truth. The enum is interchangeable with
+ * those constants and with free-form `string` versions arriving over the
+ * wire.
+ */
+export enum ProtocolVersion {
+  V0_3 = '0.3',
+  V1_0 = '1.0',
+}
+
+/**
  * The JSON content type per §9.1.
  * JSON-RPC requests MUST use this content type.
  */

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -47,8 +47,16 @@ export {
 export type { PushNotificationSender } from './push_notification/push_notification_sender.js';
 export { DefaultPushNotificationSender } from './push_notification/default_push_notification_sender.js';
 export type { DefaultPushNotificationSenderOptions } from './push_notification/default_push_notification_sender.js';
-export type { PushNotificationStore } from './push_notification/push_notification_store.js';
+export type {
+  PushNotificationStore,
+  StoredPushNotificationConfig,
+} from './push_notification/push_notification_store.js';
 export { InMemoryPushNotificationStore } from './push_notification/push_notification_store.js';
+export type {
+  PushNotificationSerializer,
+  SerializedPushNotification,
+} from './push_notification/push_notification_serializer.js';
+export { V1PushNotificationSerializer } from './push_notification/push_notification_serializer.js';
 
 export type { User } from './authentication/user.js';
 export { UnauthenticatedUser } from './authentication/user.js';

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -174,9 +174,14 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
    *
    * Stores that only implement the canonical {@link PushNotificationStore.load}
    * method are silently lifted into the wrapped shape by tagging every
-   * entry with {@link A2A_LEGACY_PROTOCOL_VERSION} (`'0.3'`) per spec
-   * §3.6.2's absent-header default. See `src/compat/v0_3/README.md` for
-   * the implication on mixed-version deployments backed by custom stores.
+   * entry with the wire version of the request *triggering* this dispatch
+   * ({@link ServerCallContext.requestedVersion}). This keeps pure-v1.0
+   * deployments with custom stores warning-free — no implicit dependency
+   * on a `'0.3'` serializer they never opted into. Spec §3.6.2 ('0.3' on
+   * absent header) applies as the final defensive default when the
+   * triggering context itself carries no version. See
+   * `src/compat/v0_3/README.md` for the implication on v1.0 deployments
+   * with v0.3 compat opted in.
    */
   private async _loadStoredConfigs(
     taskId: string,
@@ -186,7 +191,8 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
       return await this.pushNotificationStore.loadWithMetadata(taskId, context);
     }
     const plain = await this.pushNotificationStore.load(taskId, context);
-    return plain.map((config) => ({ config, wireVersion: A2A_LEGACY_PROTOCOL_VERSION }));
+    const fallbackVersion = context.requestedVersion || A2A_LEGACY_PROTOCOL_VERSION;
+    return plain.map((config) => ({ config, wireVersion: fallbackVersion }));
   }
 
   /**

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -1,5 +1,9 @@
 import { TaskPushNotificationConfig, StreamResponse } from '../../index.js';
-import { A2A_PROTOCOL_VERSION } from '../../constants.js';
+import {
+  A2A_LEGACY_PROTOCOL_VERSION,
+  A2A_PROTOCOL_VERSION,
+  ProtocolVersion,
+} from '../../constants.js';
 import { ServerCallContext } from '../context.js';
 import { PushNotificationSender } from './push_notification_sender.js';
 import { PushNotificationStore, StoredPushNotificationConfig } from './push_notification_store.js';
@@ -20,10 +24,12 @@ export interface DefaultPushNotificationSenderOptions {
    */
   tokenHeaderName?: string;
   /**
-   * Per-wire-version serializers. Keys are A2A wire versions (e.g. `'1.0'`,
-   * `'0.3'`); values are the {@link PushNotificationSerializer}
-   * implementations that produce the HTTP body and content type for
-   * notifications going out to webhooks registered over that wire version.
+   * Per-wire-version push-notification serializers. Keys are A2A wire
+   * versions ({@link ProtocolVersion.V1_0} = `'1.0'`,
+   * {@link ProtocolVersion.V0_3} = `'0.3'`); values are the
+   * {@link PushNotificationSerializer} implementations that produce the
+   * HTTP body and content type for notifications going out to webhooks
+   * registered over that wire version.
    *
    * The sender always registers a built-in `'1.0'` serializer
    * ({@link V1PushNotificationSerializer}) at construction time; entries
@@ -34,8 +40,12 @@ export interface DefaultPushNotificationSenderOptions {
    * When a stored config carries a wire version with no registered
    * serializer, the sender logs a warning and falls back to the `'1.0'`
    * serializer for that dispatch.
+   *
+   * The typed key set (`ProtocolVersion`) is a developer affordance; the
+   * underlying registry accepts any string at runtime to remain forward
+   * compatible with future or custom wire versions.
    */
-  serializers?: Record<string, PushNotificationSerializer>;
+  serializers?: Partial<Record<ProtocolVersion, PushNotificationSerializer>>;
 }
 
 export class DefaultPushNotificationSender implements PushNotificationSender {
@@ -65,22 +75,33 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     // serializer for testing or alternative encodings).
     const builtinV1 = new V1PushNotificationSerializer();
     this.serializers = new Map<string, PushNotificationSerializer>([
-      [A2A_PROTOCOL_VERSION, builtinV1],
+      [ProtocolVersion.V1_0, builtinV1],
     ]);
     if (options.serializers) {
       for (const [version, serializer] of Object.entries(options.serializers)) {
-        this.serializers.set(version, serializer);
+        if (serializer) {
+          this.serializers.set(version, serializer);
+        }
       }
     }
     // Cache the v1.0 serializer for unknown-version fallback. We resolve
     // this from the registry (not the local `builtinV1`) so a user who
     // overrode '1.0' has their custom serializer used for fallback too.
-    this.fallbackSerializer = this.serializers.get(A2A_PROTOCOL_VERSION) ?? builtinV1;
+    this.fallbackSerializer = this.serializers.get(ProtocolVersion.V1_0) ?? builtinV1;
   }
 
   async send(streamResponse: StreamResponse, context: ServerCallContext): Promise<void> {
     const taskId = this._getTaskId(streamResponse);
-    const storedConfigs = await this.pushNotificationStore.load(taskId, context);
+    // Stand-alone Messages (the message-only stream pattern in §3.1.2 with
+    // no task association) cannot have a registered push config — skip the
+    // store round-trip. This also keeps the dispatch silent when the
+    // request handler forwards a bare Message event for which no task
+    // exists.
+    if (!taskId) {
+      return;
+    }
+
+    const storedConfigs = await this._loadStoredConfigs(taskId, context);
     if (!storedConfigs || storedConfigs.length === 0) {
       return;
     }
@@ -114,6 +135,17 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     });
   }
 
+  /**
+   * Returns the task id associated with a {@link StreamResponse}.
+   *
+   * Per spec §4.3.3 all four payload variants (`task`, `message`,
+   * `statusUpdate`, `artifactUpdate`) are valid push-notification payloads.
+   * For task / status / artifact events the task id is always present.
+   * For message events the task id is present iff the message is bound to
+   * an existing task (§3.4.2); stand-alone messages from the message-only
+   * stream pattern carry an empty `taskId`, in which case there can be no
+   * registered push config and the sender simply skips dispatch.
+   */
   private _getTaskId(streamResponse: StreamResponse): string {
     const payload = streamResponse.payload;
     if (!payload) {
@@ -124,9 +156,8 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
         return payload.value.id;
       case 'statusUpdate':
       case 'artifactUpdate':
-        return payload.value.taskId;
       case 'message':
-        throw new Error('Push notification should not be sent for message payload.');
+        return payload.value.taskId;
       default: {
         // Exhaustive check: if a new $case is added to the StreamResponse union
         // without updating this switch, TypeScript will report a compile error here.
@@ -134,6 +165,28 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
         throw new Error(`Unknown payload case: ${(_exhaustive as { $case: string }).$case}`);
       }
     }
+  }
+
+  /**
+   * Resolves stored configs from the {@link PushNotificationStore},
+   * preferring the wire-version-aware {@link PushNotificationStore.loadWithMetadata}
+   * when available.
+   *
+   * Stores that only implement the canonical {@link PushNotificationStore.load}
+   * method are silently lifted into the wrapped shape by tagging every
+   * entry with {@link A2A_LEGACY_PROTOCOL_VERSION} (`'0.3'`) per spec
+   * §3.6.2's absent-header default. See `src/compat/v0_3/README.md` for
+   * the implication on mixed-version deployments backed by custom stores.
+   */
+  private async _loadStoredConfigs(
+    taskId: string,
+    context: ServerCallContext
+  ): Promise<StoredPushNotificationConfig[]> {
+    if (this.pushNotificationStore.loadWithMetadata) {
+      return await this.pushNotificationStore.loadWithMetadata(taskId, context);
+    }
+    const plain = await this.pushNotificationStore.load(taskId, context);
+    return plain.map((config) => ({ config, wireVersion: A2A_LEGACY_PROTOCOL_VERSION }));
   }
 
   /**

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -1,8 +1,12 @@
 import { TaskPushNotificationConfig, StreamResponse } from '../../index.js';
+import { A2A_PROTOCOL_VERSION } from '../../constants.js';
 import { ServerCallContext } from '../context.js';
 import { PushNotificationSender } from './push_notification_sender.js';
-import { PushNotificationStore } from './push_notification_store.js';
-import { A2A_CONTENT_TYPE } from '../../constants.js';
+import { PushNotificationStore, StoredPushNotificationConfig } from './push_notification_store.js';
+import {
+  PushNotificationSerializer,
+  V1PushNotificationSerializer,
+} from './push_notification_serializer.js';
 
 export interface DefaultPushNotificationSenderOptions {
   /**
@@ -15,12 +19,34 @@ export interface DefaultPushNotificationSenderOptions {
    * @deprecated Use `pushConfig.authentication` with `AuthenticationInfo` instead.
    */
   tokenHeaderName?: string;
+  /**
+   * Per-wire-version serializers. Keys are A2A wire versions (e.g. `'1.0'`,
+   * `'0.3'`); values are the {@link PushNotificationSerializer}
+   * implementations that produce the HTTP body and content type for
+   * notifications going out to webhooks registered over that wire version.
+   *
+   * The sender always registers a built-in `'1.0'` serializer
+   * ({@link V1PushNotificationSerializer}) at construction time; entries
+   * supplied here override that default and add support for additional
+   * versions (e.g. legacy v0.3 via the compat layer's
+   * `V03PushNotificationSerializer`).
+   *
+   * When a stored config carries a wire version with no registered
+   * serializer, the sender logs a warning and falls back to the `'1.0'`
+   * serializer for that dispatch.
+   */
+  serializers?: Record<string, PushNotificationSerializer>;
 }
 
 export class DefaultPushNotificationSender implements PushNotificationSender {
   private readonly pushNotificationStore: PushNotificationStore;
   private notificationChain: Map<string, Promise<unknown>>;
-  private readonly options: Required<DefaultPushNotificationSenderOptions>;
+  private readonly options: Required<Omit<DefaultPushNotificationSenderOptions, 'serializers'>>;
+  private readonly serializers: Map<string, PushNotificationSerializer>;
+  private readonly fallbackSerializer: PushNotificationSerializer;
+  // Track wire versions we've already warned about (per sender instance) to
+  // avoid log spam when many notifications target the same unknown version.
+  private readonly warnedMissingSerializers: Set<string> = new Set();
 
   constructor(
     pushNotificationStore: PushNotificationStore,
@@ -29,16 +55,33 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     this.pushNotificationStore = pushNotificationStore;
     this.notificationChain = new Map();
     this.options = {
-      timeout: 5000,
-      tokenHeaderName: 'X-A2A-Notification-Token',
-      ...options,
+      timeout: options.timeout ?? 5000,
+      tokenHeaderName: options.tokenHeaderName ?? 'X-A2A-Notification-Token',
     };
+
+    // Seed the registry with the canonical v1.0 serializer, then overlay
+    // user-supplied entries. User entries with key '1.0' override the
+    // default, which is intentional (callers may want a custom v1.0
+    // serializer for testing or alternative encodings).
+    const builtinV1 = new V1PushNotificationSerializer();
+    this.serializers = new Map<string, PushNotificationSerializer>([
+      [A2A_PROTOCOL_VERSION, builtinV1],
+    ]);
+    if (options.serializers) {
+      for (const [version, serializer] of Object.entries(options.serializers)) {
+        this.serializers.set(version, serializer);
+      }
+    }
+    // Cache the v1.0 serializer for unknown-version fallback. We resolve
+    // this from the registry (not the local `builtinV1`) so a user who
+    // overrode '1.0' has their custom serializer used for fallback too.
+    this.fallbackSerializer = this.serializers.get(A2A_PROTOCOL_VERSION) ?? builtinV1;
   }
 
   async send(streamResponse: StreamResponse, context: ServerCallContext): Promise<void> {
     const taskId = this._getTaskId(streamResponse);
-    const pushConfigs = await this.pushNotificationStore.load(taskId, context);
-    if (!pushConfigs || pushConfigs.length === 0) {
+    const storedConfigs = await this.pushNotificationStore.load(taskId, context);
+    if (!storedConfigs || storedConfigs.length === 0) {
       return;
     }
 
@@ -49,12 +92,12 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     const newPromise = lastPromise
       .catch(() => {})
       .then(async () => {
-        const dispatches = pushConfigs.map(async (pushConfig) => {
+        const dispatches = storedConfigs.map(async (storedConfig) => {
           try {
-            await this._dispatchNotification(streamResponse, pushConfig, taskId);
+            await this._dispatchNotification(streamResponse, storedConfig, taskId);
           } catch (error) {
             console.error(
-              `Error sending push notification for task_id=${taskId} to URL: ${pushConfig.url}. Error:`,
+              `Error sending push notification for task_id=${taskId} to URL: ${storedConfig.config.url}. Error:`,
               error
             );
           }
@@ -94,6 +137,31 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
   }
 
   /**
+   * Resolves the serializer registered for the given wire version.
+   *
+   * Falls back to the v1.0 serializer (logging a warning at most once per
+   * unknown version per sender instance) if no entry is registered. The
+   * fallback keeps push delivery best-effort even when a custom compat
+   * layer registers webhooks under a wire version the sender wasn't
+   * configured for.
+   */
+  private _resolveSerializer(wireVersion: string): PushNotificationSerializer {
+    const serializer = this.serializers.get(wireVersion);
+    if (serializer) {
+      return serializer;
+    }
+    if (!this.warnedMissingSerializers.has(wireVersion)) {
+      this.warnedMissingSerializers.add(wireVersion);
+      console.warn(
+        `No push notification serializer registered for wire version '${wireVersion}'; ` +
+          `falling back to '${A2A_PROTOCOL_VERSION}'. Register one via ` +
+          `DefaultPushNotificationSenderOptions.serializers to silence this warning.`
+      );
+    }
+    return this.fallbackSerializer;
+  }
+
+  /**
    * Builds the authentication headers for a push notification request.
    *
    * Per §4.3.3, the agent MUST include auth credentials per the push
@@ -105,7 +173,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
    * 2. `pushConfig.token` (legacy) → sets the custom token header (deprecated)
    */
   private _buildAuthHeaders(pushConfig: TaskPushNotificationConfig): Record<string, string> {
-    const headers: Record<string, string> = { 'Content-Type': A2A_CONTENT_TYPE };
+    const headers: Record<string, string> = {};
 
     if (pushConfig.authentication?.scheme && pushConfig.authentication?.credentials) {
       headers['Authorization'] =
@@ -119,19 +187,26 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
 
   private async _dispatchNotification(
     streamResponse: StreamResponse,
-    pushConfig: TaskPushNotificationConfig,
+    storedConfig: StoredPushNotificationConfig,
     taskId: string
   ): Promise<void> {
+    const { config: pushConfig, wireVersion } = storedConfig;
     const url = pushConfig.url;
     const controller = new AbortController();
     // Abort the request if it takes longer than the configured timeout.
     const timeoutId = setTimeout(() => controller.abort(), this.options.timeout);
 
     try {
+      const serializer = this._resolveSerializer(wireVersion);
+      const { body, contentType } = serializer.serialize(streamResponse);
+
       const response = await fetch(url, {
         method: 'POST',
-        headers: this._buildAuthHeaders(pushConfig),
-        body: JSON.stringify(StreamResponse.toJSON(streamResponse)),
+        headers: {
+          'Content-Type': contentType,
+          ...this._buildAuthHeaders(pushConfig),
+        },
+        body,
         signal: controller.signal,
       });
 

--- a/src/server/push_notification/push_notification_serializer.ts
+++ b/src/server/push_notification/push_notification_serializer.ts
@@ -1,0 +1,53 @@
+import { StreamResponse } from '../../index.js';
+import { A2A_CONTENT_TYPE } from '../../constants.js';
+
+/**
+ * The serialized HTTP body and content type for a single push-notification
+ * dispatch.
+ */
+export interface SerializedPushNotification {
+  /** The HTTP body to POST to the webhook URL. */
+  body: string;
+  /** The value to set on the `Content-Type` request header. */
+  contentType: string;
+}
+
+/**
+ * Strategy for converting a canonical {@link StreamResponse} into the
+ * on-the-wire body of a single push-notification HTTP POST.
+ *
+ * The {@link DefaultPushNotificationSender} resolves a serializer per
+ * registered push-notification config based on the wire version the config
+ * was registered over (e.g. `'1.0'` for the current spec, `'0.3'` for the
+ * legacy compat layer). This allows v0.3-registered webhooks to keep
+ * receiving the v0.3-shaped JSON payload long after the original
+ * registration request has returned.
+ */
+export interface PushNotificationSerializer {
+  /**
+   * Serializes a {@link StreamResponse} into the HTTP body + content type
+   * for one push-notification dispatch.
+   *
+   * Implementations MUST reject `message` payloads (push notifications are
+   * defined for `task` / `statusUpdate` / `artifactUpdate` only, per
+   * §4.3.3). Throwing from this method aborts the dispatch and is logged
+   * by the sender; it does NOT propagate to the event loop or the caller.
+   */
+  serialize(streamResponse: StreamResponse): SerializedPushNotification;
+}
+
+/**
+ * The canonical v1.0 push-notification serializer (per spec §4.3.3).
+ *
+ * The body is the `StreamResponse` discriminated union encoded as JSON via
+ * the generated proto's `toJSON`, and the content type is
+ * `application/a2a+json`.
+ */
+export class V1PushNotificationSerializer implements PushNotificationSerializer {
+  serialize(streamResponse: StreamResponse): SerializedPushNotification {
+    return {
+      body: JSON.stringify(StreamResponse.toJSON(streamResponse)),
+      contentType: A2A_CONTENT_TYPE,
+    };
+  }
+}

--- a/src/server/push_notification/push_notification_serializer.ts
+++ b/src/server/push_notification/push_notification_serializer.ts
@@ -28,10 +28,10 @@ export interface PushNotificationSerializer {
    * Serializes a {@link StreamResponse} into the HTTP body + content type
    * for one push-notification dispatch.
    *
-   * Implementations MUST reject `message` payloads (push notifications are
-   * defined for `task` / `statusUpdate` / `artifactUpdate` only, per
-   * §4.3.3). Throwing from this method aborts the dispatch and is logged
-   * by the sender; it does NOT propagate to the event loop or the caller.
+   * Implementations MUST handle all four `StreamResponse` payload variants
+   * (`task`, `message`, `statusUpdate`, `artifactUpdate`) per spec §4.3.3.
+   * Any error thrown from this method aborts the dispatch and is logged by
+   * the sender; it does NOT propagate to the event loop or the caller.
    */
   serialize(streamResponse: StreamResponse): SerializedPushNotification;
 }

--- a/src/server/push_notification/push_notification_store.ts
+++ b/src/server/push_notification/push_notification_store.ts
@@ -54,14 +54,18 @@ export interface PushNotificationStore {
    *
    * Implementations that don't capture the originating wire version may
    * omit this method; the sender will fall back to {@link load} and treat
-   * every entry as wire version {@link A2A_LEGACY_PROTOCOL_VERSION}
-   * (`'0.3'`) per spec §3.6.2.
+   * every entry as the wire version of the request *triggering* the
+   * dispatch ({@link ServerCallContext.requestedVersion}), defaulting to
+   * {@link A2A_LEGACY_PROTOCOL_VERSION} (`'0.3'`) per spec §3.6.2 only
+   * when the triggering context carries no version.
    *
-   * Note for v0.3 compat layer users: the silent v0.3 default is fine for
-   * v0.3-only deployments, but in mixed v0.3 + v1.0 deployments backed by
-   * a custom store you SHOULD implement this method so v1.0-registered
-   * webhooks keep receiving v1.0-shaped bodies. See
-   * `src/compat/v0_3/README.md` for the broader caveat.
+   * Note for v0.3 compat layer users: this fallback is best-effort and
+   * matches the *triggering* request's wire version, not the wire version
+   * the webhook was originally registered over. In v1.0 deployments with
+   * v0.3 compat opted in and backed by a custom store you SHOULD
+   * implement this method so each webhook keeps receiving the body shape
+   * that matches its registration. See `src/compat/v0_3/README.md` for
+   * the broader caveat.
    */
   loadWithMetadata?(
     taskId: string,

--- a/src/server/push_notification/push_notification_store.ts
+++ b/src/server/push_notification/push_notification_store.ts
@@ -1,7 +1,29 @@
 import { TaskPushNotificationConfig } from '../../index.js';
+import { A2A_PROTOCOL_VERSION } from '../../constants.js';
 import { ServerCallContext } from '../context.js';
 import { OwnerResolver, resolveUserScope } from '../owner_resolver.js';
 import { ScopedStore } from '../utils.js';
+
+/**
+ * A push-notification config bundled with the A2A wire version it was
+ * originally registered over.
+ *
+ * The wire version is captured at registration time from
+ * `ServerCallContext.requestedVersion` so the sender can later look up the
+ * right {@link PushNotificationSerializer} when dispatching webhooks, even
+ * though the original request has long since returned.
+ *
+ * The wire version is the value passed by the transport (e.g. `'1.0'`,
+ * `'0.3'`). When the transport did not populate `requestedVersion` the
+ * stored value defaults to `'0.3'`, mirroring the
+ * `ABSENT_HEADER_VERSION` rule on `ServerCallContext` (§3.6.2).
+ */
+export interface StoredPushNotificationConfig {
+  /** The push-notification config as supplied by the client. */
+  config: TaskPushNotificationConfig;
+  /** The A2A wire version the config was registered over. */
+  wireVersion: string;
+}
 
 /**
  * Interface for push notification configuration storage.
@@ -11,6 +33,11 @@ import { ScopedStore } from '../utils.js';
  * one tenant or user are not accessible to another.
  * Per spec §13.1, servers MUST verify the client has appropriate access rights
  * for push notification configuration operations.
+ *
+ * Implementations MUST persist the originating wire version alongside each
+ * config (read from `context.requestedVersion` at save time) and surface it
+ * to {@link load} consumers so the push-notification sender can route to the
+ * correct {@link PushNotificationSerializer}.
  */
 export interface PushNotificationStore {
   save(
@@ -18,7 +45,7 @@ export interface PushNotificationStore {
     context: ServerCallContext,
     pushNotificationConfig: TaskPushNotificationConfig
   ): Promise<void>;
-  load(taskId: string, context: ServerCallContext): Promise<TaskPushNotificationConfig[]>;
+  load(taskId: string, context: ServerCallContext): Promise<StoredPushNotificationConfig[]>;
   delete(taskId: string, context: ServerCallContext, configId?: string): Promise<void>;
 }
 
@@ -29,12 +56,15 @@ export interface PushNotificationStore {
  *
  * Per spec §13.1, servers MUST ensure appropriate scope limitation based on the
  * authenticated caller's authorization boundaries.
+ *
+ * Each entry persists the A2A wire version (`context.requestedVersion`) it was
+ * registered over so the sender can serialize back to the same wire format.
  */
 export class InMemoryPushNotificationStore implements PushNotificationStore {
-  private readonly _scopedStore: ScopedStore<TaskPushNotificationConfig[]>;
+  private readonly _scopedStore: ScopedStore<StoredPushNotificationConfig[]>;
 
   constructor(ownerResolver: OwnerResolver = resolveUserScope) {
-    this._scopedStore = new ScopedStore<TaskPushNotificationConfig[]>(ownerResolver);
+    this._scopedStore = new ScopedStore<StoredPushNotificationConfig[]>(ownerResolver);
   }
 
   async save(
@@ -43,27 +73,36 @@ export class InMemoryPushNotificationStore implements PushNotificationStore {
     pushNotificationConfig: TaskPushNotificationConfig
   ): Promise<void> {
     const bucket = this._scopedStore.getOrCreateBucket(context);
-    const configs = bucket.get(taskId) || [];
+    const entries = bucket.get(taskId) || [];
 
     // Set ID if it's not already set
     if (!pushNotificationConfig.id) {
       pushNotificationConfig.id = taskId;
     }
 
-    // Remove existing config with the same ID if it exists
-    const existingIndex = configs.findIndex((config) => config.id === pushNotificationConfig.id);
+    // Capture the wire version from the request context. ServerCallContext
+    // always populates this field (defaulting to A2A_LEGACY_PROTOCOL_VERSION
+    // when the A2A-Version header is absent, per §3.6.2), so the fallback to
+    // A2A_PROTOCOL_VERSION below is defensive only and applies if a caller
+    // somehow constructs an entry without going through the normal context.
+    const wireVersion = context.requestedVersion || A2A_PROTOCOL_VERSION;
+
+    // Remove existing entry with the same config ID if it exists
+    const existingIndex = entries.findIndex(
+      (entry) => entry.config.id === pushNotificationConfig.id
+    );
     if (existingIndex !== -1) {
-      configs.splice(existingIndex, 1);
+      entries.splice(existingIndex, 1);
     }
 
-    // Add the new/updated config
-    configs.push(pushNotificationConfig);
-    bucket.set(taskId, configs);
+    // Add the new/updated entry
+    entries.push({ config: pushNotificationConfig, wireVersion });
+    bucket.set(taskId, entries);
   }
 
-  async load(taskId: string, context: ServerCallContext): Promise<TaskPushNotificationConfig[]> {
-    const configs = this._scopedStore.getBucket(context)?.get(taskId);
-    return configs || [];
+  async load(taskId: string, context: ServerCallContext): Promise<StoredPushNotificationConfig[]> {
+    const entries = this._scopedStore.getBucket(context)?.get(taskId);
+    return entries || [];
   }
 
   async delete(taskId: string, context: ServerCallContext, configId?: string): Promise<void> {
@@ -77,17 +116,17 @@ export class InMemoryPushNotificationStore implements PushNotificationStore {
       return;
     }
 
-    const configs = bucket.get(taskId);
-    if (!configs) {
+    const entries = bucket.get(taskId);
+    if (!entries) {
       return;
     }
 
-    const configIndex = configs.findIndex((config) => config.id === configId);
-    if (configIndex !== -1) {
-      configs.splice(configIndex, 1);
+    const entryIndex = entries.findIndex((entry) => entry.config.id === configId);
+    if (entryIndex !== -1) {
+      entries.splice(entryIndex, 1);
     }
 
-    if (configs.length === 0) {
+    if (entries.length === 0) {
       bucket.delete(taskId);
     }
   }

--- a/src/server/push_notification/push_notification_store.ts
+++ b/src/server/push_notification/push_notification_store.ts
@@ -1,22 +1,21 @@
 import { TaskPushNotificationConfig } from '../../index.js';
-import { A2A_PROTOCOL_VERSION } from '../../constants.js';
+import { A2A_LEGACY_PROTOCOL_VERSION } from '../../constants.js';
 import { ServerCallContext } from '../context.js';
 import { OwnerResolver, resolveUserScope } from '../owner_resolver.js';
 import { ScopedStore } from '../utils.js';
 
 /**
  * A push-notification config bundled with the A2A wire version it was
- * originally registered over.
- *
- * The wire version is captured at registration time from
- * `ServerCallContext.requestedVersion` so the sender can later look up the
- * right {@link PushNotificationSerializer} when dispatching webhooks, even
- * though the original request has long since returned.
+ * originally registered over. Returned by the optional
+ * {@link PushNotificationStore.loadWithMetadata} method so the
+ * {@link DefaultPushNotificationSender} can route to the correct
+ * push-notification serializer per dispatch.
  *
  * The wire version is the value passed by the transport (e.g. `'1.0'`,
- * `'0.3'`). When the transport did not populate `requestedVersion` the
- * stored value defaults to `'0.3'`, mirroring the
- * `ABSENT_HEADER_VERSION` rule on `ServerCallContext` (§3.6.2).
+ * `'0.3'`). When the transport did not populate
+ * `ServerCallContext.requestedVersion` the stored value defaults to
+ * `'0.3'`, mirroring the absent-header rule on `ServerCallContext`
+ * (§3.6.2).
  */
 export interface StoredPushNotificationConfig {
   /** The push-notification config as supplied by the client. */
@@ -33,11 +32,6 @@ export interface StoredPushNotificationConfig {
  * one tenant or user are not accessible to another.
  * Per spec §13.1, servers MUST verify the client has appropriate access rights
  * for push notification configuration operations.
- *
- * Implementations MUST persist the originating wire version alongside each
- * config (read from `context.requestedVersion` at save time) and surface it
- * to {@link load} consumers so the push-notification sender can route to the
- * correct {@link PushNotificationSerializer}.
  */
 export interface PushNotificationStore {
   save(
@@ -45,7 +39,35 @@ export interface PushNotificationStore {
     context: ServerCallContext,
     pushNotificationConfig: TaskPushNotificationConfig
   ): Promise<void>;
-  load(taskId: string, context: ServerCallContext): Promise<StoredPushNotificationConfig[]>;
+
+  /**
+   * Loads all stored push notification configs for the given task. This is
+   * the canonical, version-agnostic read path and is fully supported.
+   */
+  load(taskId: string, context: ServerCallContext): Promise<TaskPushNotificationConfig[]>;
+
+  /**
+   * Optional. Loads stored configs alongside the A2A wire version each was
+   * originally registered over. Used by
+   * {@link DefaultPushNotificationSender} to route the correct
+   * push-notification serializer per dispatch.
+   *
+   * Implementations that don't capture the originating wire version may
+   * omit this method; the sender will fall back to {@link load} and treat
+   * every entry as wire version {@link A2A_LEGACY_PROTOCOL_VERSION}
+   * (`'0.3'`) per spec §3.6.2.
+   *
+   * Note for v0.3 compat layer users: the silent v0.3 default is fine for
+   * v0.3-only deployments, but in mixed v0.3 + v1.0 deployments backed by
+   * a custom store you SHOULD implement this method so v1.0-registered
+   * webhooks keep receiving v1.0-shaped bodies. See
+   * `src/compat/v0_3/README.md` for the broader caveat.
+   */
+  loadWithMetadata?(
+    taskId: string,
+    context: ServerCallContext
+  ): Promise<StoredPushNotificationConfig[]>;
+
   delete(taskId: string, context: ServerCallContext, configId?: string): Promise<void>;
 }
 
@@ -58,7 +80,8 @@ export interface PushNotificationStore {
  * authenticated caller's authorization boundaries.
  *
  * Each entry persists the A2A wire version (`context.requestedVersion`) it was
- * registered over so the sender can serialize back to the same wire format.
+ * registered over so the sender can serialize back to the same wire format
+ * via {@link loadWithMetadata}.
  */
 export class InMemoryPushNotificationStore implements PushNotificationStore {
   private readonly _scopedStore: ScopedStore<StoredPushNotificationConfig[]>;
@@ -82,10 +105,11 @@ export class InMemoryPushNotificationStore implements PushNotificationStore {
 
     // Capture the wire version from the request context. ServerCallContext
     // always populates this field (defaulting to A2A_LEGACY_PROTOCOL_VERSION
-    // when the A2A-Version header is absent, per §3.6.2), so the fallback to
-    // A2A_PROTOCOL_VERSION below is defensive only and applies if a caller
-    // somehow constructs an entry without going through the normal context.
-    const wireVersion = context.requestedVersion || A2A_PROTOCOL_VERSION;
+    // when the A2A-Version header is absent, per §3.6.2), so the fallback
+    // below is defensive only and applies when a caller constructs an
+    // entry without going through the normal context. The fallback also
+    // resolves to '0.3' per §3.6.2's empty-header rule.
+    const wireVersion = context.requestedVersion || A2A_LEGACY_PROTOCOL_VERSION;
 
     // Remove existing entry with the same config ID if it exists
     const existingIndex = entries.findIndex(
@@ -100,9 +124,22 @@ export class InMemoryPushNotificationStore implements PushNotificationStore {
     bucket.set(taskId, entries);
   }
 
-  async load(taskId: string, context: ServerCallContext): Promise<StoredPushNotificationConfig[]> {
+  async load(taskId: string, context: ServerCallContext): Promise<TaskPushNotificationConfig[]> {
     const entries = this._scopedStore.getBucket(context)?.get(taskId);
-    return entries ? [...entries] : [];
+    // Deep-clone each config so caller-side mutations cannot reach into the
+    // store's internal bucket (defends both the array spine and inner
+    // config objects).
+    return entries ? entries.map((e) => structuredClone(e.config)) : [];
+  }
+
+  async loadWithMetadata(
+    taskId: string,
+    context: ServerCallContext
+  ): Promise<StoredPushNotificationConfig[]> {
+    const entries = this._scopedStore.getBucket(context)?.get(taskId);
+    // Deep-clone the whole wrapper for the same reason as load(). The
+    // wireVersion field is a primitive string and is copied by value.
+    return entries ? entries.map((e) => structuredClone(e)) : [];
   }
 
   async delete(taskId: string, context: ServerCallContext, configId?: string): Promise<void> {

--- a/src/server/push_notification/push_notification_store.ts
+++ b/src/server/push_notification/push_notification_store.ts
@@ -102,7 +102,7 @@ export class InMemoryPushNotificationStore implements PushNotificationStore {
 
   async load(taskId: string, context: ServerCallContext): Promise<StoredPushNotificationConfig[]> {
     const entries = this._scopedStore.getBucket(context)?.get(taskId);
-    return entries || [];
+    return entries ? [...entries] : [];
   }
 
   async delete(taskId: string, context: ServerCallContext, configId?: string): Promise<void> {

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -802,12 +802,24 @@ export class DefaultRequestHandler implements A2ARequestHandler {
    * Sends a push notification if configured.
    * Fire-and-forget: push notification delivery should not block the stream or response.
    * Errors are logged but do not propagate to the caller.
+   *
+   * Message payloads are skipped: per §4.3.3 push notifications are defined
+   * for task / status / artifact events only. Message events are valid
+   * stream responses (§3.1.2 message-only pattern) but invoking the sender
+   * with one would throw and produce a misleading
+   * `Failed to send push notification` log on every message event. Direct
+   * `PushNotificationSender.send` callers continue to get the explicit
+   * error per the sender's documented contract.
    */
   private async _sendPushNotificationIfNeeded(
     context: ServerCallContext,
     streamResponse: StreamResponse
   ): Promise<void> {
-    if (this.agentCard.capabilities?.pushNotifications && this.pushNotificationSender) {
+    if (
+      this.agentCard.capabilities?.pushNotifications &&
+      this.pushNotificationSender &&
+      streamResponse.payload?.$case !== 'message'
+    ) {
       this.pushNotificationSender.send(streamResponse, context).catch((error) => {
         console.error(`Failed to send push notification:`, error);
       });

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -647,19 +647,19 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
 
-    const configs = (await this.pushNotificationStore?.load(taskId, context)) || [];
-    if (configs.length === 0) {
+    const entries = (await this.pushNotificationStore?.load(taskId, context)) || [];
+    if (entries.length === 0) {
       throw new GenericError(`Push notification config not found for task ${taskId}.`);
     }
 
-    const config = configs.find((c) => c.id === params.id);
+    const entry = entries.find((e) => e.config.id === params.id);
 
-    if (!config) {
+    if (!entry) {
       throw new GenericError(
         `Push notification config with id '${params.id}' not found for task ${taskId}.`
       );
     }
-    return config;
+    return entry.config;
   }
 
   async listTaskPushNotificationConfigs(
@@ -675,8 +675,9 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
 
+    const entries = (await this.pushNotificationStore?.load(taskId, context)) || [];
     return {
-      configs: (await this.pushNotificationStore?.load(taskId, context)) || [],
+      configs: entries.map((entry) => entry.config),
       nextPageToken: '',
     };
   }

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -647,19 +647,19 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
 
-    const entries = (await this.pushNotificationStore?.load(taskId, context)) || [];
-    if (entries.length === 0) {
+    const configs = (await this.pushNotificationStore?.load(taskId, context)) || [];
+    if (configs.length === 0) {
       throw new GenericError(`Push notification config not found for task ${taskId}.`);
     }
 
-    const entry = entries.find((e) => e.config.id === params.id);
+    const config = configs.find((c) => c.id === params.id);
 
-    if (!entry) {
+    if (!config) {
       throw new GenericError(
         `Push notification config with id '${params.id}' not found for task ${taskId}.`
       );
     }
-    return entry.config;
+    return config;
   }
 
   async listTaskPushNotificationConfigs(
@@ -675,9 +675,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
 
-    const entries = (await this.pushNotificationStore?.load(taskId, context)) || [];
     return {
-      configs: entries.map((entry) => entry.config),
+      configs: (await this.pushNotificationStore?.load(taskId, context)) || [],
       nextPageToken: '',
     };
   }
@@ -803,23 +802,17 @@ export class DefaultRequestHandler implements A2ARequestHandler {
    * Fire-and-forget: push notification delivery should not block the stream or response.
    * Errors are logged but do not propagate to the caller.
    *
-   * Message payloads are skipped: per §4.3.3 push notifications are defined
-   * for task / status / artifact events only. Message events are valid
-   * stream responses (§3.1.2 message-only pattern) but invoking the sender
-   * with one would throw and produce a misleading
-   * `Failed to send push notification` log on every message event. Direct
-   * `PushNotificationSender.send` callers continue to get the explicit
-   * error per the sender's documented contract.
+   * Per §4.3.3 all four `StreamResponse` payload variants (`task`,
+   * `message`, `statusUpdate`, `artifactUpdate`) are valid push-notification
+   * payloads. The sender silently skips stand-alone Messages that carry no
+   * task association (message-only stream pattern in §3.1.2) since no
+   * push config can be registered for them.
    */
   private async _sendPushNotificationIfNeeded(
     context: ServerCallContext,
     streamResponse: StreamResponse
   ): Promise<void> {
-    if (
-      this.agentCard.capabilities?.pushNotifications &&
-      this.pushNotificationSender &&
-      streamResponse.payload?.$case !== 'message'
-    ) {
+    if (this.agentCard.capabilities?.pushNotifications && this.pushNotificationSender) {
       this.pushNotificationSender.send(streamResponse, context).catch((error) => {
         console.error(`Failed to send push notification:`, error);
       });

--- a/test/compat/v0_3/server/push_notification/create_legacy_aware_sender.spec.ts
+++ b/test/compat/v0_3/server/push_notification/create_legacy_aware_sender.spec.ts
@@ -52,7 +52,9 @@ describe('createLegacyAwarePushNotificationSender', () => {
   });
 
   afterEach(async () => {
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
   });
 
   function makeConfig(): TaskPushNotificationConfig {

--- a/test/compat/v0_3/server/push_notification/create_legacy_aware_sender.spec.ts
+++ b/test/compat/v0_3/server/push_notification/create_legacy_aware_sender.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express, { Request, Response } from 'express';
+import { Server } from 'http';
+import { AddressInfo } from 'net';
+
+import {
+  createLegacyAwarePushNotificationSender,
+  V03PushNotificationSerializer,
+} from '../../../../../src/compat/v0_3/server/push_notification/index.js';
+import { InMemoryPushNotificationStore } from '../../../../../src/server/push_notification/push_notification_store.js';
+import { ServerCallContext } from '../../../../../src/server/context.js';
+import {
+  StreamResponse,
+  TaskPushNotificationConfig,
+  TaskState,
+} from '../../../../../src/types/pb/a2a.js';
+import { A2A_LEGACY_PROTOCOL_VERSION, A2A_PROTOCOL_VERSION } from '../../../../../src/constants.js';
+import {
+  PushNotificationSerializer,
+  SerializedPushNotification,
+} from '../../../../../src/server/push_notification/push_notification_serializer.js';
+
+type Captured = { body: any; rawBody: string; headers: Record<string, string | undefined> };
+
+describe('createLegacyAwarePushNotificationSender', () => {
+  let received: Captured[];
+  let server: Server;
+  let url: string;
+  let store: InMemoryPushNotificationStore;
+
+  beforeEach(async () => {
+    received = [];
+    store = new InMemoryPushNotificationStore();
+    const app = express();
+    app.use(express.text({ type: '*/*' }));
+    app.post('/notify', (req: Request, res: Response) => {
+      const rawBody = typeof req.body === 'string' ? req.body : '';
+      received.push({
+        body: rawBody ? JSON.parse(rawBody) : undefined,
+        rawBody,
+        headers: req.headers as Record<string, string | undefined>,
+      });
+      res.status(200).json({ ok: true });
+    });
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        const port = (server.address() as AddressInfo).port;
+        url = `http://127.0.0.1:${port}/notify`;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  function makeConfig(): TaskPushNotificationConfig {
+    return {
+      tenant: '',
+      taskId: '',
+      id: 'cfg-1',
+      url,
+      token: '',
+      authentication: undefined,
+    };
+  }
+
+  function makeStatusUpdate(taskId: string): StreamResponse {
+    return {
+      payload: {
+        $case: 'statusUpdate',
+        value: {
+          taskId,
+          contextId: 'ctx',
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: '2026-04-15T14:00:00Z',
+          },
+          metadata: {},
+        },
+      },
+    };
+  }
+
+  it('pre-registers the V03 serializer under the legacy version key', async () => {
+    const sender = createLegacyAwarePushNotificationSender(store);
+    const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
+    await store.save('task-v03', ctxV03, makeConfig());
+
+    await sender.send(makeStatusUpdate('task-v03'), ctxV03);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['content-type']).toBe('application/json');
+    // Body should be the bare event object (V03 shape), not wrapped.
+    expect(received[0].body.kind).toBe('status-update');
+    expect(received[0].body).not.toHaveProperty('jsonrpc');
+    expect(received[0].body).not.toHaveProperty('statusUpdate');
+  });
+
+  it('still uses the v1.0 serializer for v1.0-tagged configs', async () => {
+    const sender = createLegacyAwarePushNotificationSender(store);
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save('task-v1', ctxV1, makeConfig());
+
+    await sender.send(makeStatusUpdate('task-v1'), ctxV1);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['content-type']).toBe('application/a2a+json');
+    // v1.0 body is the wrapped StreamResponse.
+    expect(received[0].body).toHaveProperty('statusUpdate');
+  });
+
+  it('lets user-supplied serializers[0.3] override the pre-registered V03 serializer', async () => {
+    const customV03: PushNotificationSerializer = {
+      serialize(): SerializedPushNotification {
+        return { body: '"custom-v03-body"', contentType: 'application/x-custom' };
+      },
+    };
+    const sender = createLegacyAwarePushNotificationSender(store, {
+      serializers: { [A2A_LEGACY_PROTOCOL_VERSION]: customV03 },
+    });
+    const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
+    await store.save('task-override', ctxV03, makeConfig());
+
+    await sender.send(makeStatusUpdate('task-override'), ctxV03);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['content-type']).toBe('application/x-custom');
+    expect(received[0].rawBody).toBe('"custom-v03-body"');
+  });
+
+  it('passes other options (timeout, tokenHeaderName) through', async () => {
+    const sender = createLegacyAwarePushNotificationSender(store, {
+      tokenHeaderName: 'X-My-Token',
+    });
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const cfg = makeConfig();
+    cfg.token = 'shh';
+    await store.save('task-opt', ctxV1, cfg);
+
+    await sender.send(makeStatusUpdate('task-opt'), ctxV1);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['x-my-token']).toBe('shh');
+    expect(received[0].headers['x-a2a-notification-token']).toBeUndefined();
+  });
+
+  it('exposes V03PushNotificationSerializer alongside the helper', () => {
+    expect(typeof V03PushNotificationSerializer).toBe('function');
+    expect(new V03PushNotificationSerializer().serialize).toBeTypeOf('function');
+  });
+});

--- a/test/compat/v0_3/server/push_notification/v03_push_notification_serializer.spec.ts
+++ b/test/compat/v0_3/server/push_notification/v03_push_notification_serializer.spec.ts
@@ -154,14 +154,24 @@ describe('V03PushNotificationSerializer', () => {
     expect(parsed).not.toHaveProperty('artifactUpdate');
   });
 
-  it('rejects message payloads (push notifications are for task/status/artifact only)', () => {
+  it('serializes a Message payload as bare v0.3 Message with kind="message"', () => {
+    // Per spec §4.3.3 messages are valid push-notification payloads. The
+    // v0.3 wire shape is the bare Message object discriminated by the
+    // `kind` field.
     const event: StreamResponse = {
       payload: {
         $case: 'message',
         value: {
           messageId: 'm-1',
           role: Role.ROLE_AGENT,
-          parts: [],
+          parts: [
+            {
+              content: { $case: 'text', value: 'hello' },
+              mediaType: 'text/plain',
+              filename: '',
+              metadata: {},
+            },
+          ],
           contextId: 'ctx-msg',
           taskId: 'task-msg',
           extensions: [],
@@ -170,9 +180,19 @@ describe('V03PushNotificationSerializer', () => {
         },
       },
     };
-    expect(() => serializer.serialize(event)).toThrow(
-      /Push notification should not be sent for message payload/
-    );
+
+    const { body, contentType } = serializer.serialize(event);
+    const parsed = JSON.parse(body);
+
+    expect(contentType).toBe('application/json');
+    expect(parsed.kind).toBe('message');
+    expect(parsed.messageId).toBe('m-1');
+    expect(parsed.contextId).toBe('ctx-msg');
+    expect(parsed.taskId).toBe('task-msg');
+    // Per v0.3 spec §9.5 the body MUST be the bare event object.
+    expect(parsed).not.toHaveProperty('jsonrpc');
+    expect(parsed).not.toHaveProperty('result');
+    expect(parsed).not.toHaveProperty('message');
   });
 
   it('throws when the StreamResponse has no payload', () => {

--- a/test/compat/v0_3/server/push_notification/v03_push_notification_serializer.spec.ts
+++ b/test/compat/v0_3/server/push_notification/v03_push_notification_serializer.spec.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect } from 'vitest';
+import { V03PushNotificationSerializer } from '../../../../../src/compat/v0_3/server/push_notification/v03_push_notification_serializer.js';
+import { LEGACY_JSON_CONTENT_TYPE } from '../../../../../src/compat/v0_3/constants.js';
+import { Role, StreamResponse, TaskState } from '../../../../../src/types/pb/a2a.js';
+
+describe('V03PushNotificationSerializer', () => {
+  const serializer = new V03PushNotificationSerializer();
+
+  it('emits the v0.3 legacy content type', () => {
+    const event: StreamResponse = {
+      payload: {
+        $case: 'task',
+        value: {
+          id: 'task-1',
+          contextId: 'ctx-1',
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: '2026-04-15T14:00:00Z',
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        },
+      },
+    };
+    const { contentType } = serializer.serialize(event);
+    expect(contentType).toBe(LEGACY_JSON_CONTENT_TYPE);
+    expect(LEGACY_JSON_CONTENT_TYPE).toBe('application/json');
+  });
+
+  it('serializes a Task payload as a bare v0.3 Task with kind="task"', () => {
+    const event: StreamResponse = {
+      payload: {
+        $case: 'task',
+        value: {
+          id: 'task-bare',
+          contextId: 'ctx-bare',
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: '2026-04-15T14:00:00Z',
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        },
+      },
+    };
+
+    const { body } = serializer.serialize(event);
+    const parsed = JSON.parse(body);
+
+    // Per v0.3 spec §9.5 the body MUST be the bare event object.
+    expect(parsed).not.toHaveProperty('jsonrpc');
+    expect(parsed).not.toHaveProperty('result');
+    expect(parsed).not.toHaveProperty('task');
+    expect(parsed).not.toHaveProperty('statusUpdate');
+    expect(parsed.kind).toBe('task');
+    expect(parsed.id).toBe('task-bare');
+    expect(parsed.contextId).toBe('ctx-bare');
+    expect(parsed.status.state).toBe('completed');
+  });
+
+  it('serializes a TaskStatusUpdateEvent as bare with kind="status-update" and computed final', () => {
+    const event: StreamResponse = {
+      payload: {
+        $case: 'statusUpdate',
+        value: {
+          taskId: 'task-su',
+          contextId: 'ctx-su',
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: '2026-04-15T14:00:00Z',
+          },
+          metadata: {},
+        },
+      },
+    };
+
+    const { body } = serializer.serialize(event);
+    const parsed = JSON.parse(body);
+
+    expect(parsed.kind).toBe('status-update');
+    expect(parsed.taskId).toBe('task-su');
+    expect(parsed.contextId).toBe('ctx-su');
+    expect(parsed.status.state).toBe('completed');
+    // Per the translator, COMPLETED → final: true.
+    expect(parsed.final).toBe(true);
+    expect(parsed).not.toHaveProperty('jsonrpc');
+    expect(parsed).not.toHaveProperty('statusUpdate');
+  });
+
+  it('marks non-terminal status states as final=false', () => {
+    const event: StreamResponse = {
+      payload: {
+        $case: 'statusUpdate',
+        value: {
+          taskId: 'task-wip',
+          contextId: 'ctx-wip',
+          status: {
+            state: TaskState.TASK_STATE_WORKING,
+            message: undefined,
+            timestamp: '2026-04-15T14:00:00Z',
+          },
+          metadata: {},
+        },
+      },
+    };
+    const parsed = JSON.parse(serializer.serialize(event).body);
+    expect(parsed.final).toBe(false);
+  });
+
+  it('serializes a TaskArtifactUpdateEvent as bare with kind="artifact-update"', () => {
+    const event: StreamResponse = {
+      payload: {
+        $case: 'artifactUpdate',
+        value: {
+          taskId: 'task-art',
+          contextId: 'ctx-art',
+          artifact: {
+            artifactId: 'art-1',
+            name: 'file.txt',
+            description: 'an artifact',
+            parts: [
+              {
+                content: { $case: 'text', value: 'hello' },
+                filename: 'file.txt',
+                mediaType: 'text/plain',
+                metadata: {},
+              },
+            ],
+            metadata: {},
+            extensions: [],
+          },
+          append: false,
+          lastChunk: true,
+          metadata: {},
+        },
+      },
+    };
+
+    const { body } = serializer.serialize(event);
+    const parsed = JSON.parse(body);
+
+    expect(parsed.kind).toBe('artifact-update');
+    expect(parsed.taskId).toBe('task-art');
+    expect(parsed.contextId).toBe('ctx-art');
+    expect(parsed.artifact.artifactId).toBe('art-1');
+    expect(parsed.append).toBe(false);
+    expect(parsed.lastChunk).toBe(true);
+    expect(parsed).not.toHaveProperty('jsonrpc');
+    expect(parsed).not.toHaveProperty('artifactUpdate');
+  });
+
+  it('rejects message payloads (push notifications are for task/status/artifact only)', () => {
+    const event: StreamResponse = {
+      payload: {
+        $case: 'message',
+        value: {
+          messageId: 'm-1',
+          role: Role.ROLE_AGENT,
+          parts: [],
+          contextId: 'ctx-msg',
+          taskId: 'task-msg',
+          extensions: [],
+          metadata: {},
+          referenceTaskIds: [],
+        },
+      },
+    };
+    expect(() => serializer.serialize(event)).toThrow(
+      /Push notification should not be sent for message payload/
+    );
+  });
+
+  it('throws when the StreamResponse has no payload', () => {
+    const event = { payload: undefined } as unknown as StreamResponse;
+    expect(() => serializer.serialize(event)).toThrow(/StreamResponse payload is undefined/);
+  });
+});

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -1542,13 +1542,11 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     assert.isTrue(afterClose.done, 'Stream should be closed after message-only response');
   });
 
-  it('sendMessageStream: should NOT invoke push notification sender for message payloads', async () => {
-    // Wire up a fresh handler with explicit push-notification components so
-    // we can spy on the sender. The agent card already has
-    // `capabilities.pushNotifications: true`, so without the message-payload
-    // guard the handler would invoke the sender on every event — which
-    // throws for `message` payloads and produces a misleading
-    // `Failed to send push notification` console.error.
+  it('sendMessageStream: handler invokes sender for stand-alone messages without error', async () => {
+    // The handler ALWAYS invokes the sender per §4.3.3 (which lists all
+    // four payload variants as valid). For stand-alone messages (no
+    // taskId), the sender's own _getTaskId-empty guard short-circuits
+    // dispatch silently — no webhook call, no error log.
     const pushNotificationStore = new InMemoryPushNotificationStore();
     const mockPushNotificationSender = new MockPushNotificationSender();
     const handlerWithPush = new DefaultRequestHandler(
@@ -1598,8 +1596,9 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     assert.lengthOf(events, 1);
     assert.equal(events[0].payload?.$case, 'message');
 
-    // The sender must NOT have been invoked for the message event.
-    expect(mockPushNotificationSender.send).not.toHaveBeenCalled();
+    // The handler hands the event to the sender (mock resolves to undefined
+    // without hitting the real send path).
+    expect(mockPushNotificationSender.send).toHaveBeenCalled();
 
     // No `Failed to send push notification` error should have been logged.
     const offendingCalls = errorSpy.mock.calls.filter((args) =>
@@ -2808,14 +2807,12 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     assert.deepEqual(thirdCallResponse, expectedThirdResponse);
   });
 
-  it('should NOT send push notification when message event is received (§4.3.3)', async () => {
-    // Per §4.3.3 push notifications are defined for task / status /
-    // artifact events only. Message events (§3.1.2 message-only pattern)
-    // must NOT trigger sender invocation: invoking the sender with a
-    // message payload throws and would emit a misleading
-    // `Failed to send push notification` error log on every message turn.
-    // Direct `PushNotificationSender.send` callers continue to receive the
-    // explicit error per the sender's documented contract.
+  it('should send push notification when message event is received (§4.3.3)', async () => {
+    // Per §4.3.3 all four StreamResponse payload variants (`task`,
+    // `message`, `statusUpdate`, `artifactUpdate`) are valid
+    // push-notification payloads. A message event bound to a task MUST
+    // reach the sender; the sender then routes to the right serializer.
+    // No `Failed to send push notification` error should be logged.
     const mockPushNotificationStore = new InMemoryPushNotificationStore();
     const mockPushNotificationSender = new MockPushNotificationSender();
 
@@ -2870,7 +2867,12 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     await handler.sendMessage(params, serverCallContext);
 
-    expect((mockPushNotificationSender as MockPushNotificationSender).send).not.toHaveBeenCalled();
+    expect((mockPushNotificationSender as MockPushNotificationSender).send).toHaveBeenCalled();
+    const callResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
+      .calls[0][0] as StreamResponse;
+    expect(callResponse.payload?.$case).toBe('message');
+    expect((callResponse.payload as { value: Message }).value.messageId).toBe('msg-reply-1');
+    // No misleading error log.
     const offendingCalls = errorSpy.mock.calls.filter((args) =>
       String(args[0]).includes('Failed to send push notification')
     );

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -1542,6 +1542,72 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     assert.isTrue(afterClose.done, 'Stream should be closed after message-only response');
   });
 
+  it('sendMessageStream: should NOT invoke push notification sender for message payloads', async () => {
+    // Wire up a fresh handler with explicit push-notification components so
+    // we can spy on the sender. The agent card already has
+    // `capabilities.pushNotifications: true`, so without the message-payload
+    // guard the handler would invoke the sender on every event — which
+    // throws for `message` payloads and produces a misleading
+    // `Failed to send push notification` console.error.
+    const pushNotificationStore = new InMemoryPushNotificationStore();
+    const mockPushNotificationSender = new MockPushNotificationSender();
+    const handlerWithPush = new DefaultRequestHandler(
+      testAgentCard,
+      mockTaskStore,
+      mockAgentExecutor,
+      executionEventBusManager,
+      pushNotificationStore,
+      mockPushNotificationSender
+    );
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const params: SendMessageRequest = {
+      message: createTestMessage('msg-no-push', 'message-only push-skip test'),
+    } as SendMessageRequest;
+
+    (mockAgentExecutor as MockAgentExecutor).execute.mockImplementation(async (_ctx, bus) => {
+      bus.publish(
+        AgentEvent.message({
+          messageId: 'msg-response-no-push',
+          role: Role.ROLE_AGENT,
+          contextId: '',
+          taskId: '',
+          parts: [
+            {
+              content: { $case: 'text', value: 'response' },
+              mediaType: 'text/plain',
+              filename: '',
+              metadata: {},
+            },
+          ],
+          metadata: {},
+          extensions: [],
+          referenceTaskIds: [],
+        })
+      );
+      bus.finished();
+    });
+
+    const events: StreamResponse[] = [];
+    const generator = handlerWithPush.sendMessageStream(params, serverCallContext);
+    for await (const event of generator) {
+      events.push(event);
+    }
+
+    // Stream produced the message as expected.
+    assert.lengthOf(events, 1);
+    assert.equal(events[0].payload?.$case, 'message');
+
+    // The sender must NOT have been invoked for the message event.
+    expect(mockPushNotificationSender.send).not.toHaveBeenCalled();
+
+    // No `Failed to send push notification` error should have been logged.
+    const offendingCalls = errorSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('Failed to send push notification')
+    );
+    expect(offendingCalls).toHaveLength(0);
+  });
+
   it('sendMessageStream: should throw when statusUpdate arrives before task', async () => {
     const taskId = 'task-order-1';
     const contextId = 'ctx-order-1';
@@ -2742,7 +2808,14 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     assert.deepEqual(thirdCallResponse, expectedThirdResponse);
   });
 
-  it('should send push notification when message event is received', async () => {
+  it('should NOT send push notification when message event is received (§4.3.3)', async () => {
+    // Per §4.3.3 push notifications are defined for task / status /
+    // artifact events only. Message events (§3.1.2 message-only pattern)
+    // must NOT trigger sender invocation: invoking the sender with a
+    // message payload throws and would emit a misleading
+    // `Failed to send push notification` error log on every message turn.
+    // Direct `PushNotificationSender.send` callers continue to receive the
+    // explicit error per the sender's documented contract.
     const mockPushNotificationStore = new InMemoryPushNotificationStore();
     const mockPushNotificationSender = new MockPushNotificationSender();
 
@@ -2794,13 +2867,14 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       bus.finished();
     });
 
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     await handler.sendMessage(params, serverCallContext);
 
-    expect((mockPushNotificationSender as MockPushNotificationSender).send).toHaveBeenCalled();
-    const callResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
-      .calls[0][0] as StreamResponse;
-    expect(callResponse.payload.$case).toBe('message');
-    expect((callResponse.payload as { value: Message }).value.messageId).toBe('msg-reply-1');
+    expect((mockPushNotificationSender as MockPushNotificationSender).send).not.toHaveBeenCalled();
+    const offendingCalls = errorSpy.mock.calls.filter((args) =>
+      String(args[0]).includes('Failed to send push notification')
+    );
+    expect(offendingCalls).toHaveLength(0);
   });
 
   it('should send push notification when statusUpdate event is received', async () => {

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -1156,7 +1156,10 @@ describe('Push Notification Integration Tests', () => {
   });
 
   describe('StreamResponse payload types', () => {
-    it('should throw if tried to send message payload', async () => {
+    it('should send message payload correctly (§4.3.3)', async () => {
+      // Per spec §4.3.3 messages are valid push-notification payloads. When
+      // bound to a task with a registered config the webhook receives the
+      // canonical StreamResponse JSON containing the message.
       const taskId = 'test-message-payload';
       const pushConfig: TaskPushNotificationConfig = {
         tenant: '',
@@ -1191,16 +1194,33 @@ describe('Push Notification Integration Tests', () => {
         },
       };
 
-      let threw = false;
-      try {
-        await pushNotificationSender.send(streamResponse, defaultContext);
-      } catch (error: any) {
-        threw = true;
-        assert.include(error.message, 'Push notification should not be sent for message payload');
-      }
-      assert.isTrue(threw, 'Should have thrown an error');
+      await pushNotificationSender.send(streamResponse, defaultContext);
 
-      // Verify no notifications were sent
+      assert.equal(receivedNotifications.length, 1);
+      assert.deepEqual(receivedNotifications[0].body, StreamResponse.toJSON(streamResponse));
+    });
+
+    it('should silently skip dispatch for stand-alone messages (no task association)', async () => {
+      // Message-only stream pattern (§3.1.2) has no taskId — no config can
+      // be registered for it, so the sender returns silently without
+      // hitting the store or webhook.
+      const streamResponse: StreamResponse = {
+        payload: {
+          $case: 'message',
+          value: {
+            messageId: 'msg-standalone',
+            taskId: '',
+            role: Role.ROLE_AGENT,
+            parts: [],
+            contextId: 'ctx-standalone',
+            extensions: [],
+            metadata: {},
+            referenceTaskIds: [],
+          },
+        },
+      };
+
+      await pushNotificationSender.send(streamResponse, defaultContext);
       assert.equal(receivedNotifications.length, 0);
     });
 

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -4,7 +4,10 @@ import { AddressInfo } from 'net';
 import express, { Request, Response } from 'express';
 
 import { DefaultPushNotificationSender } from '../../src/server/push_notification/default_push_notification_sender.js';
-import { InMemoryPushNotificationStore } from '../../src/server/push_notification/push_notification_store.js';
+import {
+  InMemoryPushNotificationStore,
+  PushNotificationStore,
+} from '../../src/server/push_notification/push_notification_store.js';
 import {
   PushNotificationSerializer,
   SerializedPushNotification,
@@ -21,6 +24,7 @@ import {
   A2A_CONTENT_TYPE,
   A2A_LEGACY_PROTOCOL_VERSION,
   A2A_PROTOCOL_VERSION,
+  ProtocolVersion,
 } from '../../src/constants.js';
 
 type Captured = {
@@ -236,14 +240,89 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
   });
 
-  it('rejects message payloads (built-in v1.0 serializer behavior)', async () => {
+  it('delivers message payloads with task association per §4.3.3', async () => {
+    // Per spec §4.3.3 push notifications accept all four StreamResponse
+    // payload variants. The built-in v1.0 serializer encodes the message as
+    // part of the canonical StreamResponse JSON wrapper.
     const sender = new DefaultPushNotificationSender(store);
     const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
     await store.save('task-msg', ctxV1, makeConfig(`${baseUrl}/notify`));
 
-    await expect(sender.send(makeMessage('task-msg'), ctxV1)).rejects.toThrow(
-      /Push notification should not be sent for message payload/
+    await sender.send(makeMessage('task-msg'), ctxV1);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
+    expect(received[0].body).toEqual(StreamResponse.toJSON(makeMessage('task-msg')));
+  });
+
+  it('silently skips dispatch for stand-alone messages (no task association)', async () => {
+    // Message-only stream pattern (§3.1.2): no taskId means no config can
+    // ever match. Sender returns silently without hitting the store.
+    const sender = new DefaultPushNotificationSender(store);
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+
+    await sender.send(makeMessage(''), ctxV1);
+
+    expect(received).toHaveLength(0);
+  });
+
+  it('falls back to load() with default 0.3 wire version when the store omits loadWithMetadata', async () => {
+    // Stub a custom store implementing only the required interface methods.
+    // The sender's silent-fallback path tags every entry as wire version
+    // '0.3' per spec §3.6.2's absent-header rule.
+    const customConfig = makeConfig(`${baseUrl}/notify`, { id: 'cfg-legacy' });
+    const customStore: PushNotificationStore = {
+      save: vi.fn(async () => {}),
+      load: vi.fn(async () => [customConfig]),
+      delete: vi.fn(async () => {}),
+    };
+
+    const v03Serializer: PushNotificationSerializer = {
+      serialize(): SerializedPushNotification {
+        return { body: '{"v":"0.3-fallback"}', contentType: 'application/json' };
+      },
+    };
+    const sender = new DefaultPushNotificationSender(customStore, {
+      serializers: { [ProtocolVersion.V0_3]: v03Serializer },
+    });
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+
+    await sender.send(makeStatusUpdate('task-legacy-store'), ctxV1);
+
+    // Even though the dispatch context is v1.0, the custom store has no
+    // loadWithMetadata so the sender defaults to '0.3' → v0.3 serializer
+    // wins.
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['content-type']).toBe('application/json');
+    expect(received[0].rawBody).toBe('{"v":"0.3-fallback"}');
+    expect(customStore.load).toHaveBeenCalledTimes(1);
+  });
+
+  it('fallback path routes to v1.0 serializer when no v0.3 serializer is registered', async () => {
+    // Same custom-store fallback path, but with the default sender config
+    // (only v1.0 serializer registered). The '0.3' default wire version
+    // hits the unknown-serializer fallback and resolves to v1.0 with a
+    // one-time warning.
+    const customConfig = makeConfig(`${baseUrl}/notify`, { id: 'cfg-legacy-v1' });
+    const customStore: PushNotificationStore = {
+      save: vi.fn(async () => {}),
+      load: vi.fn(async () => [customConfig]),
+      delete: vi.fn(async () => {}),
+    };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const sender = new DefaultPushNotificationSender(customStore);
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+
+    await sender.send(makeStatusUpdate('task-legacy-v1'), ctxV1);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
+    // Warning surfaced because '0.3' wasn't registered.
+    const matching = warn.mock.calls.filter((args) =>
+      String(args[0]).includes(`wire version '${ProtocolVersion.V0_3}'`)
     );
+    expect(matching).toHaveLength(1);
   });
 });
 

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -266,17 +266,16 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     expect(received).toHaveLength(0);
   });
 
-  it('falls back to load() with default 0.3 wire version when the store omits loadWithMetadata', async () => {
-    // Stub a custom store implementing only the required interface methods.
-    // The sender's silent-fallback path tags every entry as wire version
-    // '0.3' per spec §3.6.2's absent-header rule.
-    const customConfig = makeConfig(`${baseUrl}/notify`, { id: 'cfg-legacy' });
+  it('fallback path: uses context.requestedVersion when the store omits loadWithMetadata', async () => {
+    // Custom store path: when loadWithMetadata is absent, the sender tags
+    // each entry with the wire version of the triggering request. A v0.3
+    // trigger picks up the registered V03 serializer.
+    const customConfig = makeConfig(`${baseUrl}/notify`, { id: 'cfg-leg' });
     const customStore: PushNotificationStore = {
       save: vi.fn(async () => {}),
       load: vi.fn(async () => [customConfig]),
       delete: vi.fn(async () => {}),
     };
-
     const v03Serializer: PushNotificationSerializer = {
       serialize(): SerializedPushNotification {
         return { body: '{"v":"0.3-fallback"}', contentType: 'application/json' };
@@ -285,44 +284,69 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     const sender = new DefaultPushNotificationSender(customStore, {
       serializers: { [ProtocolVersion.V0_3]: v03Serializer },
     });
-    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
 
-    await sender.send(makeStatusUpdate('task-legacy-store'), ctxV1);
+    await sender.send(makeStatusUpdate('task-leg'), ctxV03);
 
-    // Even though the dispatch context is v1.0, the custom store has no
-    // loadWithMetadata so the sender defaults to '0.3' → v0.3 serializer
-    // wins.
     expect(received).toHaveLength(1);
     expect(received[0].headers['content-type']).toBe('application/json');
     expect(received[0].rawBody).toBe('{"v":"0.3-fallback"}');
     expect(customStore.load).toHaveBeenCalledTimes(1);
   });
 
-  it('fallback path routes to v1.0 serializer when no v0.3 serializer is registered', async () => {
-    // Same custom-store fallback path, but with the default sender config
-    // (only v1.0 serializer registered). The '0.3' default wire version
-    // hits the unknown-serializer fallback and resolves to v1.0 with a
-    // one-time warning.
-    const customConfig = makeConfig(`${baseUrl}/notify`, { id: 'cfg-legacy-v1' });
+  it("fallback path: defaults to '0.3' per §3.6.2 when context has no version", async () => {
+    // Defensive: a context constructed without requestedVersion (e.g. by a
+    // caller bypassing the transport layer) must still fall back to '0.3'
+    // per spec §3.6.2's absent-header rule.
+    const customConfig = makeConfig(`${baseUrl}/notify`, { id: 'cfg-defensive' });
     const customStore: PushNotificationStore = {
       save: vi.fn(async () => {}),
       load: vi.fn(async () => [customConfig]),
       delete: vi.fn(async () => {}),
     };
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const v03Serializer: PushNotificationSerializer = {
+      serialize(): SerializedPushNotification {
+        return { body: '{"v":"defensive-0.3"}', contentType: 'application/json' };
+      },
+    };
+    const sender = new DefaultPushNotificationSender(customStore, {
+      serializers: { [ProtocolVersion.V0_3]: v03Serializer },
+    });
+    const ctxEmpty = new ServerCallContext({ requestedVersion: '' });
 
+    await sender.send(makeStatusUpdate('task-defensive'), ctxEmpty);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['content-type']).toBe('application/json');
+    expect(received[0].rawBody).toBe('{"v":"defensive-0.3"}');
+  });
+
+  it('bare-minimum v1.0 setup: custom store without loadWithMetadata sends v1.0 bodies and emits no warning', async () => {
+    // Mirrors the README claim: a pure-v1.0 user with NO compat opt-in must
+    // not see any compat-layer noise (no warnings, no body shape mismatch)
+    // even when using a custom PushNotificationStore that does not
+    // implement loadWithMetadata.
+    const customConfig = makeConfig(`${baseUrl}/notify`, { id: 'cfg-bare-v1' });
+    const customStore: PushNotificationStore = {
+      save: vi.fn(async () => {}),
+      load: vi.fn(async () => [customConfig]),
+      delete: vi.fn(async () => {}),
+      // Intentionally omits loadWithMetadata.
+    };
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Default sender — only the built-in V1 serializer. No compat opt-in.
     const sender = new DefaultPushNotificationSender(customStore);
     const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
 
-    await sender.send(makeStatusUpdate('task-legacy-v1'), ctxV1);
+    await sender.send(makeStatusUpdate('task-bare-v1'), ctxV1);
 
+    // Webhook receives the canonical v1.0 body and content-type.
     expect(received).toHaveLength(1);
     expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
-    // Warning surfaced because '0.3' wasn't registered.
-    const matching = warn.mock.calls.filter((args) =>
-      String(args[0]).includes(`wire version '${ProtocolVersion.V0_3}'`)
-    );
-    expect(matching).toHaveLength(1);
+    expect(received[0].body).toEqual(StreamResponse.toJSON(makeStatusUpdate('task-bare-v1')));
+    // No warnings of any kind — pure v1.0 users have no reason to see
+    // compat-layer logs.
+    expect(warn).not.toHaveBeenCalled();
   });
 });
 

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -114,7 +114,9 @@ describe('DefaultPushNotificationSender serializer registry', () => {
   });
 
   afterEach(async () => {
-    await new Promise<void>((resolve) => server.close(() => resolve()));
+    if (server) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
     vi.restoreAllMocks();
   });
 

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Server } from 'http';
+import { AddressInfo } from 'net';
+import express, { Request, Response } from 'express';
+
+import { DefaultPushNotificationSender } from '../../src/server/push_notification/default_push_notification_sender.js';
+import { InMemoryPushNotificationStore } from '../../src/server/push_notification/push_notification_store.js';
+import {
+  PushNotificationSerializer,
+  SerializedPushNotification,
+  V1PushNotificationSerializer,
+} from '../../src/server/push_notification/push_notification_serializer.js';
+import { ServerCallContext } from '../../src/server/context.js';
+import {
+  Role,
+  StreamResponse,
+  TaskPushNotificationConfig,
+  TaskState,
+} from '../../src/types/pb/a2a.js';
+import {
+  A2A_CONTENT_TYPE,
+  A2A_LEGACY_PROTOCOL_VERSION,
+  A2A_PROTOCOL_VERSION,
+} from '../../src/constants.js';
+
+type Captured = {
+  body: any;
+  rawBody: string;
+  headers: Record<string, string | undefined>;
+  url: string;
+};
+
+function makeStatusUpdate(taskId: string, contextId = 'ctx-test'): StreamResponse {
+  return {
+    payload: {
+      $case: 'statusUpdate',
+      value: {
+        taskId,
+        contextId,
+        status: {
+          state: TaskState.TASK_STATE_WORKING,
+          message: undefined,
+          timestamp: '2026-04-15T14:00:00Z',
+        },
+        metadata: {},
+      },
+    },
+  };
+}
+
+function makeMessage(taskId: string): StreamResponse {
+  return {
+    payload: {
+      $case: 'message',
+      value: {
+        messageId: 'm-1',
+        role: Role.ROLE_AGENT,
+        parts: [],
+        contextId: 'ctx-test',
+        taskId,
+        extensions: [],
+        metadata: {},
+        referenceTaskIds: [],
+      },
+    },
+  };
+}
+
+function makeConfig(
+  url: string,
+  overrides: Partial<TaskPushNotificationConfig> = {}
+): TaskPushNotificationConfig {
+  return {
+    tenant: '',
+    taskId: '',
+    id: 'cfg-1',
+    url,
+    token: '',
+    authentication: undefined,
+    ...overrides,
+  };
+}
+
+describe('DefaultPushNotificationSender serializer registry', () => {
+  let received: Captured[];
+  let server: Server;
+  let baseUrl: string;
+  let store: InMemoryPushNotificationStore;
+
+  beforeEach(async () => {
+    received = [];
+    store = new InMemoryPushNotificationStore();
+    const app = express();
+    // Accept both v1.0 and v0.3 content types so the test webhook can decode
+    // either format.
+    app.use(express.text({ type: '*/*' }));
+    app.post('/notify', (req: Request, res: Response) => {
+      const rawBody = typeof req.body === 'string' ? req.body : '';
+      received.push({
+        body: rawBody ? JSON.parse(rawBody) : undefined,
+        rawBody,
+        headers: req.headers as Record<string, string | undefined>,
+        url: req.url,
+      });
+      res.status(200).json({ ok: true });
+    });
+    await new Promise<void>((resolve) => {
+      server = app.listen(0, () => {
+        const port = (server.address() as AddressInfo).port;
+        baseUrl = `http://127.0.0.1:${port}`;
+        resolve();
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    vi.restoreAllMocks();
+  });
+
+  it('uses the built-in v1.0 serializer for v1.0-tagged configs (regression)', async () => {
+    const sender = new DefaultPushNotificationSender(store);
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save('task-v1', ctxV1, makeConfig(`${baseUrl}/notify`));
+
+    await sender.send(makeStatusUpdate('task-v1'), ctxV1);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
+    expect(received[0].body).toEqual(StreamResponse.toJSON(makeStatusUpdate('task-v1')));
+  });
+
+  it('routes to a custom serializer registered for a non-default wire version', async () => {
+    const v03Serializer: PushNotificationSerializer = {
+      serialize(): SerializedPushNotification {
+        return { body: '{"kind":"task","fake":"v0.3-body"}', contentType: 'application/json' };
+      },
+    };
+    const sender = new DefaultPushNotificationSender(store, {
+      serializers: { [A2A_LEGACY_PROTOCOL_VERSION]: v03Serializer },
+    });
+    const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
+    await store.save('task-v03', ctxV03, makeConfig(`${baseUrl}/notify`));
+
+    await sender.send(makeStatusUpdate('task-v03'), ctxV03);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['content-type']).toBe('application/json');
+    expect(received[0].body).toEqual({ kind: 'task', fake: 'v0.3-body' });
+  });
+
+  it('uses the right serializer per stored entry when configs on one task have mixed versions', async () => {
+    const v03Serializer: PushNotificationSerializer = {
+      serialize(): SerializedPushNotification {
+        return { body: '{"v":"0.3"}', contentType: 'application/json' };
+      },
+    };
+    const sender = new DefaultPushNotificationSender(store, {
+      serializers: { [A2A_LEGACY_PROTOCOL_VERSION]: v03Serializer },
+    });
+
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
+
+    await store.save('task-mix', ctxV1, makeConfig(`${baseUrl}/notify`, { id: 'v1-cfg' }));
+    await store.save('task-mix', ctxV03, makeConfig(`${baseUrl}/notify`, { id: 'v03-cfg' }));
+
+    await sender.send(makeStatusUpdate('task-mix'), ctxV1);
+
+    expect(received).toHaveLength(2);
+    const bodies = received.map((r) => r.rawBody).sort();
+    expect(bodies).toContain('{"v":"0.3"}');
+    expect(bodies.some((b) => b.includes('"statusUpdate"'))).toBe(true);
+  });
+
+  it('falls back to the v1.0 serializer with a one-time warning for unknown wire versions', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sender = new DefaultPushNotificationSender(store);
+    // Register two configs under an unknown wire version on the same task so
+    // we can verify the warning is emitted only once per instance per
+    // unknown version.
+    const ctxUnknown = new ServerCallContext({ requestedVersion: '99.99' });
+    await store.save('task-unknown', ctxUnknown, makeConfig(`${baseUrl}/notify`, { id: 'cfg-a' }));
+    await store.save('task-unknown', ctxUnknown, makeConfig(`${baseUrl}/notify`, { id: 'cfg-b' }));
+
+    await sender.send(makeStatusUpdate('task-unknown'), ctxUnknown);
+
+    expect(received).toHaveLength(2);
+    // Both dispatches must produce v1.0 bodies.
+    for (const r of received) {
+      expect(r.headers['content-type']).toBe(A2A_CONTENT_TYPE);
+    }
+    // Only one warning despite two missing-serializer lookups.
+    const matching = warn.mock.calls.filter((args) =>
+      String(args[0]).includes("wire version '99.99'")
+    );
+    expect(matching).toHaveLength(1);
+  });
+
+  it('user-supplied serializers[1.0] override the built-in v1.0 serializer', async () => {
+    const customV1: PushNotificationSerializer = {
+      serialize(): SerializedPushNotification {
+        return { body: '"custom-v1-body"', contentType: 'application/custom' };
+      },
+    };
+    const sender = new DefaultPushNotificationSender(store, {
+      serializers: { [A2A_PROTOCOL_VERSION]: customV1 },
+    });
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save('task-override', ctxV1, makeConfig(`${baseUrl}/notify`));
+
+    await sender.send(makeStatusUpdate('task-override'), ctxV1);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['content-type']).toBe('application/custom');
+    expect(received[0].rawBody).toBe('"custom-v1-body"');
+  });
+
+  it('preserves auth headers alongside serializer-supplied content type', async () => {
+    const sender = new DefaultPushNotificationSender(store);
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save(
+      'task-auth',
+      ctxV1,
+      makeConfig(`${baseUrl}/notify`, {
+        authentication: { scheme: 'Bearer', credentials: 'token-xyz' },
+      })
+    );
+
+    await sender.send(makeStatusUpdate('task-auth'), ctxV1);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['authorization']).toBe('Bearer token-xyz');
+    expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
+  });
+
+  it('rejects message payloads (built-in v1.0 serializer behavior)', async () => {
+    const sender = new DefaultPushNotificationSender(store);
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save('task-msg', ctxV1, makeConfig(`${baseUrl}/notify`));
+
+    await expect(sender.send(makeMessage('task-msg'), ctxV1)).rejects.toThrow(
+      /Push notification should not be sent for message payload/
+    );
+  });
+});
+
+describe('V1PushNotificationSerializer', () => {
+  it('emits StreamResponse.toJSON body and the v1.0 content type', () => {
+    const serializer = new V1PushNotificationSerializer();
+    const event = makeStatusUpdate('task-x');
+    const result = serializer.serialize(event);
+    expect(result.contentType).toBe(A2A_CONTENT_TYPE);
+    expect(JSON.parse(result.body)).toEqual(StreamResponse.toJSON(event));
+  });
+});

--- a/test/server/push_notification_store.spec.ts
+++ b/test/server/push_notification_store.spec.ts
@@ -113,4 +113,24 @@ describe('InMemoryPushNotificationStore wire-version capture', () => {
     expect(loaded).toHaveLength(1);
     expect(loaded[0].config.id).toBe('task-id-default');
   });
+
+  it('load() returns a shallow copy that cannot mutate the stored bucket', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save('task-iso', context, makeConfig({ id: 'cfg-iso' }));
+
+    const first = await store.load('task-iso', context);
+    expect(first).toHaveLength(1);
+
+    // Caller-side mutations of the returned array must not affect the
+    // store's internal bucket.
+    first.pop();
+    first.push({
+      config: makeConfig({ id: 'attacker' }),
+      wireVersion: A2A_PROTOCOL_VERSION,
+    });
+
+    const second = await store.load('task-iso', context);
+    expect(second).toHaveLength(1);
+    expect(second[0].config.id).toBe('cfg-iso');
+  });
 });

--- a/test/server/push_notification_store.spec.ts
+++ b/test/server/push_notification_store.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { InMemoryPushNotificationStore } from '../../src/server/push_notification/push_notification_store.js';
+import { ServerCallContext } from '../../src/server/context.js';
+import { TaskPushNotificationConfig } from '../../src/types/pb/a2a.js';
+import { A2A_LEGACY_PROTOCOL_VERSION, A2A_PROTOCOL_VERSION } from '../../src/constants.js';
+
+function makeConfig(
+  overrides: Partial<TaskPushNotificationConfig> = {}
+): TaskPushNotificationConfig {
+  return {
+    tenant: '',
+    taskId: '',
+    id: '',
+    url: 'http://example.test/webhook',
+    token: '',
+    authentication: undefined,
+    ...overrides,
+  };
+}
+
+describe('InMemoryPushNotificationStore wire-version capture', () => {
+  let store: InMemoryPushNotificationStore;
+
+  beforeEach(() => {
+    store = new InMemoryPushNotificationStore();
+  });
+
+  it('captures the requested wire version from the context on save()', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const config = makeConfig({ id: 'cfg-1', url: 'http://example.test/wh1' });
+
+    await store.save('task-1', context, config);
+    const loaded = await store.load('task-1', context);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].config).toEqual(config);
+    expect(loaded[0].wireVersion).toBe(A2A_PROTOCOL_VERSION);
+  });
+
+  it('defaults the stored wire version to 0.3 when the context has no header', async () => {
+    // ServerCallContext applies ABSENT_HEADER_VERSION = '0.3' when no header
+    // is set (per spec §3.6.2). The store should surface that value.
+    const context = new ServerCallContext();
+    const config = makeConfig({ id: 'cfg-default', url: 'http://example.test/wh-default' });
+
+    await store.save('task-default', context, config);
+    const loaded = await store.load('task-default', context);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].wireVersion).toBe(A2A_LEGACY_PROTOCOL_VERSION);
+  });
+
+  it('preserves the stored wire version across multiple configs on the same task', async () => {
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
+
+    await store.save('task-mixed', ctxV1, makeConfig({ id: 'v1-cfg' }));
+    await store.save('task-mixed', ctxV03, makeConfig({ id: 'v03-cfg' }));
+
+    // The two saves use different ServerCallContext instances but with the
+    // same (default) user/tenant scope, so they share the same bucket and we
+    // can load them via either context.
+    const loaded = await store.load('task-mixed', ctxV1);
+
+    expect(loaded).toHaveLength(2);
+    const byId = Object.fromEntries(loaded.map((e) => [e.config.id, e.wireVersion]));
+    expect(byId['v1-cfg']).toBe(A2A_PROTOCOL_VERSION);
+    expect(byId['v03-cfg']).toBe(A2A_LEGACY_PROTOCOL_VERSION);
+  });
+
+  it('updates the stored wire version when a config with the same id is overwritten', async () => {
+    const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+
+    await store.save('task-overwrite', ctxV03, makeConfig({ id: 'cfg-overwrite' }));
+    await store.save(
+      'task-overwrite',
+      ctxV1,
+      makeConfig({ id: 'cfg-overwrite', url: 'http://example.test/changed' })
+    );
+
+    const loaded = await store.load('task-overwrite', ctxV1);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].wireVersion).toBe(A2A_PROTOCOL_VERSION);
+    expect(loaded[0].config.url).toBe('http://example.test/changed');
+  });
+
+  it('delete() matches against the inner config id, not the wrapper', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save('task-del', context, makeConfig({ id: 'keep' }));
+    await store.save('task-del', context, makeConfig({ id: 'remove' }));
+
+    await store.delete('task-del', context, 'remove');
+
+    const remaining = await store.load('task-del', context);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].config.id).toBe('keep');
+  });
+
+  it('load() returns an empty array when no configs are stored for the task', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const loaded = await store.load('missing-task', context);
+    expect(loaded).toEqual([]);
+  });
+
+  it('defaults a missing config id to the taskId on save', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const config = makeConfig({ id: '' });
+
+    await store.save('task-id-default', context, config);
+    const loaded = await store.load('task-id-default', context);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].config.id).toBe('task-id-default');
+  });
+});

--- a/test/server/push_notification_store.spec.ts
+++ b/test/server/push_notification_store.spec.ts
@@ -18,7 +18,76 @@ function makeConfig(
   };
 }
 
-describe('InMemoryPushNotificationStore wire-version capture', () => {
+describe('InMemoryPushNotificationStore.load() (canonical, version-agnostic read)', () => {
+  let store: InMemoryPushNotificationStore;
+
+  beforeEach(() => {
+    store = new InMemoryPushNotificationStore();
+  });
+
+  it('returns the stored configs without wire-version wrappers', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const config = makeConfig({ id: 'cfg-1', url: 'http://example.test/wh1' });
+
+    await store.save('task-1', context, config);
+    const loaded = await store.load('task-1', context);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0]).toEqual(config);
+  });
+
+  it('returns an empty array when no configs are stored for the task', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const loaded = await store.load('missing-task', context);
+    expect(loaded).toEqual([]);
+  });
+
+  it('defaults a missing config id to the taskId on save', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const config = makeConfig({ id: '' });
+
+    await store.save('task-id-default', context, config);
+    const loaded = await store.load('task-id-default', context);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].id).toBe('task-id-default');
+  });
+
+  it('delete() matches against the config id', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save('task-del', context, makeConfig({ id: 'keep' }));
+    await store.save('task-del', context, makeConfig({ id: 'remove' }));
+
+    await store.delete('task-del', context, 'remove');
+
+    const remaining = await store.load('task-del', context);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe('keep');
+  });
+
+  it('returns deep-cloned configs so caller mutations cannot reach internal state', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save('task-iso', context, makeConfig({ id: 'cfg-iso', url: 'http://orig/' }));
+
+    const first = await store.load('task-iso', context);
+    expect(first).toHaveLength(1);
+
+    // Caller-side mutations of both the array spine AND the inner config
+    // object must not affect subsequent reads.
+    first.pop();
+    first.push(makeConfig({ id: 'attacker' }));
+    const second = await store.load('task-iso', context);
+    expect(second).toHaveLength(1);
+    expect(second[0].id).toBe('cfg-iso');
+
+    // Inner-object mutation (validates the deep clone, not just shallow):
+    second[0].url = 'http://evil/';
+    const third = await store.load('task-iso', context);
+    expect(third[0].url).toBe('http://orig/');
+  });
+});
+
+describe('InMemoryPushNotificationStore.loadWithMetadata() wire-version capture', () => {
   let store: InMemoryPushNotificationStore;
 
   beforeEach(() => {
@@ -30,7 +99,7 @@ describe('InMemoryPushNotificationStore wire-version capture', () => {
     const config = makeConfig({ id: 'cfg-1', url: 'http://example.test/wh1' });
 
     await store.save('task-1', context, config);
-    const loaded = await store.load('task-1', context);
+    const loaded = await store.loadWithMetadata('task-1', context);
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0].config).toEqual(config);
@@ -44,7 +113,21 @@ describe('InMemoryPushNotificationStore wire-version capture', () => {
     const config = makeConfig({ id: 'cfg-default', url: 'http://example.test/wh-default' });
 
     await store.save('task-default', context, config);
-    const loaded = await store.load('task-default', context);
+    const loaded = await store.loadWithMetadata('task-default', context);
+
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].wireVersion).toBe(A2A_LEGACY_PROTOCOL_VERSION);
+  });
+
+  it("defaults to '0.3' when context.requestedVersion is explicitly empty (§3.6.2)", async () => {
+    // Defensive: caller constructs a context with explicit empty version.
+    // The store's fallback should still resolve to '0.3' (NOT '1.0') per
+    // §3.6.2's absent-header rule.
+    const context = new ServerCallContext({ requestedVersion: '' });
+    const config = makeConfig({ id: 'cfg-empty' });
+
+    await store.save('task-empty', context, config);
+    const loaded = await store.loadWithMetadata('task-empty', context);
 
     expect(loaded).toHaveLength(1);
     expect(loaded[0].wireVersion).toBe(A2A_LEGACY_PROTOCOL_VERSION);
@@ -60,7 +143,7 @@ describe('InMemoryPushNotificationStore wire-version capture', () => {
     // The two saves use different ServerCallContext instances but with the
     // same (default) user/tenant scope, so they share the same bucket and we
     // can load them via either context.
-    const loaded = await store.load('task-mixed', ctxV1);
+    const loaded = await store.loadWithMetadata('task-mixed', ctxV1);
 
     expect(loaded).toHaveLength(2);
     const byId = Object.fromEntries(loaded.map((e) => [e.config.id, e.wireVersion]));
@@ -79,58 +162,42 @@ describe('InMemoryPushNotificationStore wire-version capture', () => {
       makeConfig({ id: 'cfg-overwrite', url: 'http://example.test/changed' })
     );
 
-    const loaded = await store.load('task-overwrite', ctxV1);
+    const loaded = await store.loadWithMetadata('task-overwrite', ctxV1);
     expect(loaded).toHaveLength(1);
     expect(loaded[0].wireVersion).toBe(A2A_PROTOCOL_VERSION);
     expect(loaded[0].config.url).toBe('http://example.test/changed');
   });
 
-  it('delete() matches against the inner config id, not the wrapper', async () => {
+  it('returns deep-cloned wrappers so caller mutations cannot reach internal state', async () => {
     const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
-    await store.save('task-del', context, makeConfig({ id: 'keep' }));
-    await store.save('task-del', context, makeConfig({ id: 'remove' }));
+    await store.save(
+      'task-iso-meta',
+      context,
+      makeConfig({ id: 'cfg-iso-meta', url: 'http://orig/' })
+    );
 
-    await store.delete('task-del', context, 'remove');
-
-    const remaining = await store.load('task-del', context);
-    expect(remaining).toHaveLength(1);
-    expect(remaining[0].config.id).toBe('keep');
-  });
-
-  it('load() returns an empty array when no configs are stored for the task', async () => {
-    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
-    const loaded = await store.load('missing-task', context);
-    expect(loaded).toEqual([]);
-  });
-
-  it('defaults a missing config id to the taskId on save', async () => {
-    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
-    const config = makeConfig({ id: '' });
-
-    await store.save('task-id-default', context, config);
-    const loaded = await store.load('task-id-default', context);
-
-    expect(loaded).toHaveLength(1);
-    expect(loaded[0].config.id).toBe('task-id-default');
-  });
-
-  it('load() returns a shallow copy that cannot mutate the stored bucket', async () => {
-    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
-    await store.save('task-iso', context, makeConfig({ id: 'cfg-iso' }));
-
-    const first = await store.load('task-iso', context);
+    const first = await store.loadWithMetadata('task-iso-meta', context);
     expect(first).toHaveLength(1);
 
-    // Caller-side mutations of the returned array must not affect the
-    // store's internal bucket.
+    // Array-spine mutation:
     first.pop();
     first.push({
       config: makeConfig({ id: 'attacker' }),
       wireVersion: A2A_PROTOCOL_VERSION,
     });
-
-    const second = await store.load('task-iso', context);
+    const second = await store.loadWithMetadata('task-iso-meta', context);
     expect(second).toHaveLength(1);
-    expect(second[0].config.id).toBe('cfg-iso');
+    expect(second[0].config.id).toBe('cfg-iso-meta');
+
+    // Inner-object mutation:
+    second[0].config.url = 'http://evil/';
+    const third = await store.loadWithMetadata('task-iso-meta', context);
+    expect(third[0].config.url).toBe('http://orig/');
+  });
+
+  it('loadWithMetadata() returns empty array when no configs stored', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const loaded = await store.loadWithMetadata('missing-task', context);
+    expect(loaded).toEqual([]);
   });
 });

--- a/test/server/resource_scoping.spec.ts
+++ b/test/server/resource_scoping.spec.ts
@@ -201,7 +201,7 @@ describe('InMemoryPushNotificationStore tenant isolation', () => {
     // Tenant A can load the config
     const loadedA = await store.load('task-1', ctxA);
     expect(loadedA).toHaveLength(1);
-    expect(loadedA[0].id).to.equal('config-1');
+    expect(loadedA[0].config.id).to.equal('config-1');
 
     // Tenant B cannot load tenant A's configs
     const loadedB = await store.load('task-1', ctxB);
@@ -219,9 +219,9 @@ describe('InMemoryPushNotificationStore tenant isolation', () => {
     const loadedB = await store.load('task-1', ctxB);
 
     expect(loadedA).toHaveLength(1);
-    expect(loadedA[0].id).to.equal('config-a');
+    expect(loadedA[0].config.id).to.equal('config-a');
     expect(loadedB).toHaveLength(1);
-    expect(loadedB[0].id).to.equal('config-b');
+    expect(loadedB[0].config.id).to.equal('config-b');
   });
 
   it('should delete configs only within the tenant scope', async () => {
@@ -419,7 +419,7 @@ describe('InMemoryPushNotificationStore owner isolation', () => {
     // Alice can load her config
     const loadedAlice = await store.load('task-1', ctxAlice);
     expect(loadedAlice).toHaveLength(1);
-    expect(loadedAlice[0].id).toBe('config-1');
+    expect(loadedAlice[0].config.id).toBe('config-1');
 
     // Bob cannot load Alice's config
     const loadedBob = await store.load('task-1', ctxBob);
@@ -437,9 +437,9 @@ describe('InMemoryPushNotificationStore owner isolation', () => {
     const loadedBob = await store.load('task-1', ctxBob);
 
     expect(loadedAlice).toHaveLength(1);
-    expect(loadedAlice[0].id).toBe('config-a');
+    expect(loadedAlice[0].config.id).toBe('config-a');
     expect(loadedBob).toHaveLength(1);
-    expect(loadedBob[0].id).toBe('config-b');
+    expect(loadedBob[0].config.id).toBe('config-b');
   });
 
   it('should not allow cross-owner deletion', async () => {
@@ -455,12 +455,12 @@ describe('InMemoryPushNotificationStore owner isolation', () => {
     // Alice's config still exists
     const loadedAlice = await store.load('task-1', ctxAlice);
     expect(loadedAlice).toHaveLength(1);
-    expect(loadedAlice[0].id).toBe('config-1');
+    expect(loadedAlice[0].config.id).toBe('config-1');
 
     // Bob's config still exists
     const loadedBob = await store.load('task-1', ctxBob);
     expect(loadedBob).toHaveLength(1);
-    expect(loadedBob[0].id).toBe('config-2');
+    expect(loadedBob[0].config.id).toBe('config-2');
   });
 
   it('should isolate owners within the same tenant', async () => {

--- a/test/server/resource_scoping.spec.ts
+++ b/test/server/resource_scoping.spec.ts
@@ -201,7 +201,7 @@ describe('InMemoryPushNotificationStore tenant isolation', () => {
     // Tenant A can load the config
     const loadedA = await store.load('task-1', ctxA);
     expect(loadedA).toHaveLength(1);
-    expect(loadedA[0].config.id).to.equal('config-1');
+    expect(loadedA[0].id).to.equal('config-1');
 
     // Tenant B cannot load tenant A's configs
     const loadedB = await store.load('task-1', ctxB);
@@ -219,9 +219,9 @@ describe('InMemoryPushNotificationStore tenant isolation', () => {
     const loadedB = await store.load('task-1', ctxB);
 
     expect(loadedA).toHaveLength(1);
-    expect(loadedA[0].config.id).to.equal('config-a');
+    expect(loadedA[0].id).to.equal('config-a');
     expect(loadedB).toHaveLength(1);
-    expect(loadedB[0].config.id).to.equal('config-b');
+    expect(loadedB[0].id).to.equal('config-b');
   });
 
   it('should delete configs only within the tenant scope', async () => {
@@ -419,7 +419,7 @@ describe('InMemoryPushNotificationStore owner isolation', () => {
     // Alice can load her config
     const loadedAlice = await store.load('task-1', ctxAlice);
     expect(loadedAlice).toHaveLength(1);
-    expect(loadedAlice[0].config.id).toBe('config-1');
+    expect(loadedAlice[0].id).toBe('config-1');
 
     // Bob cannot load Alice's config
     const loadedBob = await store.load('task-1', ctxBob);
@@ -437,9 +437,9 @@ describe('InMemoryPushNotificationStore owner isolation', () => {
     const loadedBob = await store.load('task-1', ctxBob);
 
     expect(loadedAlice).toHaveLength(1);
-    expect(loadedAlice[0].config.id).toBe('config-a');
+    expect(loadedAlice[0].id).toBe('config-a');
     expect(loadedBob).toHaveLength(1);
-    expect(loadedBob[0].config.id).toBe('config-b');
+    expect(loadedBob[0].id).toBe('config-b');
   });
 
   it('should not allow cross-owner deletion', async () => {
@@ -455,12 +455,12 @@ describe('InMemoryPushNotificationStore owner isolation', () => {
     // Alice's config still exists
     const loadedAlice = await store.load('task-1', ctxAlice);
     expect(loadedAlice).toHaveLength(1);
-    expect(loadedAlice[0].config.id).toBe('config-1');
+    expect(loadedAlice[0].id).toBe('config-1');
 
     // Bob's config still exists
     const loadedBob = await store.load('task-1', ctxBob);
     expect(loadedBob).toHaveLength(1);
-    expect(loadedBob[0].config.id).toBe('config-2');
+    expect(loadedBob[0].id).toBe('config-2');
   });
 
   it('should isolate owners within the same tenant', async () => {

--- a/vitest.edge.config.ts
+++ b/vitest.edge.config.ts
@@ -18,6 +18,10 @@ export default defineWorkersConfig(
         'test/compat/v0_3/client/transports/grpc/**',
         'test/e2e.spec.ts',
         'test/server/push_notification_integration.spec.ts',
+        // Push-notification senders are exercised against a real Express webhook
+        // (sibling pure-unit serializer tests stay in the edge suite).
+        'test/server/push_notification_sender_serializer.spec.ts',
+        'test/compat/v0_3/server/push_notification/create_legacy_aware_sender.spec.ts',
         // Node modules should always be excluded
         '**/node_modules/**',
       ],


### PR DESCRIPTION
# Description

This pull request introduces a version-aware push notification system, enabling the server to deliver webhooks in the correct wire format based on the protocol version used at registration. The changes add a serializer abstraction, track the wire version per webhook registration, and provide a factory for v0.3 compatibility. Below are the most important changes:

**Push Notification Versioning and Serialization:**

* Introduced the `PushNotificationSerializer` interface and `SerializedPushNotification` type, allowing the server to serialize push notification payloads differently based on the wire protocol version. Added the canonical `V1PushNotificationSerializer` for v1.0 and a `V03PushNotificationSerializer` for v0.3 compatibility. 
* Updated `DefaultPushNotificationSender` to support per-version serializers via a new `serializers` option, resolve the correct serializer for each outgoing notification, and fall back to v1.0 with a warning if an unknown version is encountered. 

**Wire Version Tracking in Push Notification Store:**

* Modified the `PushNotificationStore` interface and its in-memory implementation to persist the wire protocol version (`wireVersion`) alongside each config at registration, and return it on load. Introduced the `StoredPushNotificationConfig` type for this purpose.


**v0.3 Compatibility Layer:**

* Added a `createLegacyAwarePushNotificationSender` factory and re-exported it (along with the v0.3 serializer) from the compat layer, making it easy to set up a sender that delivers v0.3-shaped webhooks for legacy transports.


These changes ensure that webhooks registered over legacy transports receive notifications in the expected v0.3 format, while modern clients continue to receive the v1.0 payloads.

Closes #487 🦕
