### PR TITLE
feat: centralize v1.0 to v0.3 error conversion logic in new translate module

### DIFF
--- a/src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -12,10 +12,10 @@
  * dispatcher selects between the two based on the method name (see
  * `isLegacyJsonRpcMethod`).
  */
-import { A2A_ERROR_CLASS_TO_CODE, A2A_ERROR_CODE } from '../../../../../errors.js';
 import type { ServerCallContext } from '../../../../../server/context.js';
 import type { A2ARequestHandler } from '../../../../../server/request_handler/a2a_request_handler.js';
 import { toCompatAgentCard } from '../../../translate/agent_card.js';
+import { toCompatJsonRpcError } from '../../../translate/errors.js';
 import { toCompatMessage } from '../../../translate/messages.js';
 import { toCompatTaskPushNotificationConfig } from '../../../translate/push_notifications.js';
 import {
@@ -291,33 +291,17 @@ export class LegacyJsonRpcTransportHandler {
   }
 
   /**
-   * Maps an error to a v0.3-shaped `JSONRPCError`.
+   * Maps an error to a v0.3-shaped {@link legacy.JSONRPCError}.
    *
-   * Unlike the v1.0 handler, v0.3 typed `JSONRPCError.data` as a plain
-   * `Record<string, unknown>` rather than the structured `ErrorDetail[]`
-   * array introduced in v1.0. To keep the response wire-compatible with
-   * v0.3 clients, this mapper deliberately omits the `data` field even
-   * when the source error would have carried structured details on the
-   * v1.0 path.
-   *
-   * `LegacyA2AError` instances are passed through unchanged via
-   * `toJSONRPCError()`. v1.0 SDK error classes
-   * (`TaskNotFoundError`, …) are mapped to their corresponding numeric
-   * codes (which are identical between v0.3 and v1.0 for the codes that
-   * exist in both). Unknown errors fall through to `INTERNAL_ERROR`.
+   * Thin wrapper around {@link toCompatJsonRpcError} kept on the
+   * transport handler for backward compatibility with existing call
+   * sites (including the handler's own `catch` blocks). The actual
+   * v1.0 → v0.3 demotion logic — pass `LegacyA2AError` through, map
+   * known v1.0 SDK error classes to their numeric codes, strip the
+   * enriched `details[]`/`ErrorInfo` payload — lives in the translate
+   * unit and is shared with the REST handler. See issue #488.
    */
   public static mapToLegacyJSONRPCError(error: unknown): legacy.JSONRPCError {
-    if (error instanceof A2AError) {
-      return error.toJSONRPCError();
-    }
-    if (error instanceof Error) {
-      const code = A2A_ERROR_CLASS_TO_CODE[error.name];
-      if (code !== undefined) {
-        return { code, message: error.message };
-      }
-    }
-
-    const message = (error instanceof Error && error.message) || 'An unexpected error occurred.';
-    return { code: A2A_ERROR_CODE.INTERNAL_ERROR, message };
+    return toCompatJsonRpcError(error);
   }
 }

--- a/src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -15,7 +15,7 @@
 import type { ServerCallContext } from '../../../../../server/context.js';
 import type { A2ARequestHandler } from '../../../../../server/request_handler/a2a_request_handler.js';
 import { toCompatAgentCard } from '../../../translate/agent_card.js';
-import { toCompatJsonRpcError } from '../../../translate/errors.js';
+import { toCompatErrorBody } from '../../../translate/errors.js';
 import { toCompatMessage } from '../../../translate/messages.js';
 import { toCompatTaskPushNotificationConfig } from '../../../translate/push_notifications.js';
 import {
@@ -293,15 +293,18 @@ export class LegacyJsonRpcTransportHandler {
   /**
    * Maps an error to a v0.3-shaped {@link legacy.JSONRPCError}.
    *
-   * Thin wrapper around {@link toCompatJsonRpcError} kept on the
+   * Thin wrapper around {@link toCompatErrorBody} kept on the
    * transport handler for backward compatibility with existing call
    * sites (including the handler's own `catch` blocks). The actual
    * v1.0 → v0.3 demotion logic — pass `LegacyA2AError` through, map
    * known v1.0 SDK error classes to their numeric codes, strip the
    * enriched `details[]`/`ErrorInfo` payload — lives in the translate
-   * unit and is shared with the REST handler. See issue #488.
+   * unit and is shared with the REST handler.
+   *
+   * The cast is safe because the underlying converter returns a body
+   * that is structurally identical to {@link legacy.JSONRPCError}.
    */
   public static mapToLegacyJSONRPCError(error: unknown): legacy.JSONRPCError {
-    return toCompatJsonRpcError(error);
+    return toCompatErrorBody(error) as legacy.JSONRPCError;
   }
 }

--- a/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
@@ -14,7 +14,6 @@
  * versions side-by-side.
  */
 
-import { A2A_ERROR_CLASS_TO_CODE, A2A_ERROR_CODE } from '../../../../../errors.js';
 import type { ServerCallContext } from '../../../../../server/context.js';
 import type { A2ARequestHandler } from '../../../../../server/request_handler/a2a_request_handler.js';
 import {
@@ -28,6 +27,7 @@ import type {
   Task as V1Task,
 } from '../../../../../types/pb/a2a.js';
 import { toCompatAgentCard } from '../../../translate/agent_card.js';
+import { type LegacyRestErrorBody, toCompatRestErrorBody } from '../../../translate/errors.js';
 import { toCompatMessage } from '../../../translate/messages.js';
 import {
   toCompatTaskPushNotificationConfig,
@@ -48,48 +48,26 @@ export { HTTP_STATUS, mapErrorToStatus };
 // HTTP Error Conversion (v0.3 wire shape)
 // ============================================================================
 
-/**
- * v0.3-shaped HTTP error body.
- *
- * The v0.3 reference implementation returned errors as a bare
- * `{ code, message, data? }` object (no `details[]` array, no `status`
- * field, no outer `{ error: {...} }` wrapper). v1.0 introduced the
- * structured `google.rpc.Status` JSON envelope, so this shape is kept
- * separate to preserve wire-compatibility with v0.3 clients.
- */
-export interface LegacyRestErrorBody {
-  code: number;
-  message: string;
-  data?: Record<string, unknown>;
-}
+// Re-export the v0.3 REST error body type and converter from the
+// translate unit so existing consumers (including the public
+// `LegacyRestErrorBody` / `toLegacyHTTPError` exports) keep working.
+// The actual v1.0 → v0.3 demotion logic — pass `LegacyA2AError`
+// through, map known v1.0 SDK error classes to their numeric codes,
+// strip the enriched `details[]`/`ErrorInfo` payload — lives in
+// `../../../translate/errors.ts` and is shared with the JSON-RPC
+// handler. See issue #488.
+export type { LegacyRestErrorBody };
 
 /**
  * Converts any error to a v0.3-shaped HTTP error body.
  *
- * `LegacyA2AError` instances pass through with their `code`, `message`,
- * and `data` carried over. v1.0 SDK error classes
- * (`TaskNotFoundError`, …) are mapped to their corresponding numeric
- * codes via {@link A2A_ERROR_CLASS_TO_CODE} (these codes are identical
- * between v0.3 and v1.0 for the codes that exist in both). Unknown
- * errors fall through to `INTERNAL_ERROR`.
- *
- * Mirrors `LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError` in
- * shape and uses the same centralized lookup table.
+ * Thin wrapper around {@link toCompatRestErrorBody} kept on this
+ * module for backward compatibility with existing call sites
+ * (including {@link LegacyRestTransportHandler.mapToLegacyHTTPError}
+ * and the Express layer in `../../express/rest_handler.ts`).
  */
 export function toLegacyHTTPError(error: unknown): LegacyRestErrorBody {
-  if (error instanceof LegacyA2AError) {
-    const body: LegacyRestErrorBody = { code: error.code, message: error.message };
-    if (error.data !== undefined) body.data = error.data;
-    return body;
-  }
-  if (error instanceof Error) {
-    const code = A2A_ERROR_CLASS_TO_CODE[error.name];
-    if (code !== undefined) {
-      return { code, message: error.message };
-    }
-  }
-  const message = (error instanceof Error && error.message) || 'An unexpected error occurred.';
-  return { code: A2A_ERROR_CODE.INTERNAL_ERROR, message };
+  return toCompatRestErrorBody(error);
 }
 
 // ============================================================================

--- a/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
@@ -27,7 +27,7 @@ import type {
   Task as V1Task,
 } from '../../../../../types/pb/a2a.js';
 import { toCompatAgentCard } from '../../../translate/agent_card.js';
-import { type LegacyRestErrorBody, toCompatRestErrorBody } from '../../../translate/errors.js';
+import { type LegacyRestErrorBody, toCompatErrorBody } from '../../../translate/errors.js';
 import { toCompatMessage } from '../../../translate/messages.js';
 import {
   toCompatTaskPushNotificationConfig,
@@ -55,19 +55,22 @@ export { HTTP_STATUS, mapErrorToStatus };
 // through, map known v1.0 SDK error classes to their numeric codes,
 // strip the enriched `details[]`/`ErrorInfo` payload — lives in
 // `../../../translate/errors.ts` and is shared with the JSON-RPC
-// handler. See issue #488.
+// handler.
 export type { LegacyRestErrorBody };
 
 /**
  * Converts any error to a v0.3-shaped HTTP error body.
  *
- * Thin wrapper around {@link toCompatRestErrorBody} kept on this
- * module for backward compatibility with existing call sites
- * (including {@link LegacyRestTransportHandler.mapToLegacyHTTPError}
- * and the Express layer in `../../express/rest_handler.ts`).
+ * Thin wrapper around {@link toCompatErrorBody} kept on this module
+ * for backward compatibility with existing call sites (including
+ * {@link LegacyRestTransportHandler.mapToLegacyHTTPError} and the
+ * Express layer in `../../express/rest_handler.ts`).
+ *
+ * The cast is safe because the underlying converter returns a body
+ * that is structurally identical to {@link LegacyRestErrorBody}.
  */
 export function toLegacyHTTPError(error: unknown): LegacyRestErrorBody {
-  return toCompatRestErrorBody(error);
+  return toCompatErrorBody(error) as LegacyRestErrorBody;
 }
 
 // ============================================================================

--- a/src/compat/v0_3/translate/errors.ts
+++ b/src/compat/v0_3/translate/errors.ts
@@ -36,7 +36,7 @@
 
 import { A2A_ERROR_CLASS_TO_CODE, A2A_ERROR_CODE } from '../../../errors.js';
 import { A2AError as LegacyA2AError } from '../server/error.js';
-import type * as legacy from '../types/types.js';
+import type { JSONRPCError } from '../types/types.js';
 
 /**
  * v0.3-shaped HTTP error body.
@@ -95,7 +95,8 @@ function demoteToLegacyShape(error: unknown): {
 
 /**
  * Converts any error to a v0.3 JSON-RPC error object suitable for use
- * as the `error` field of a {@link legacy.JSONRPCErrorResponse}.
+ * as the `error` field of a
+ * {@link import('../types/types.js').JSONRPCErrorResponse}.
  *
  * Crucially, the returned object never carries the v1.0 enriched
  * `details[]` array or any `ErrorInfo` payload — only `code`,
@@ -104,13 +105,13 @@ function demoteToLegacyShape(error: unknown): {
  * @see toCompatRestErrorBody — the same demotion logic shaped for the
  * REST transport.
  */
-export function toCompatJsonRpcError(error: unknown): legacy.JSONRPCError {
+export function toCompatJsonRpcError(error: unknown): JSONRPCError {
   const { code, message, data } = demoteToLegacyShape(error);
-  const body: legacy.JSONRPCError = { code, message };
-  if (data !== undefined) {
-    body.data = data;
-  }
-  return body;
+  return {
+    code,
+    message,
+    ...(data !== undefined ? { data } : {}),
+  };
 }
 
 /**
@@ -126,9 +127,9 @@ export function toCompatJsonRpcError(error: unknown): legacy.JSONRPCError {
  */
 export function toCompatRestErrorBody(error: unknown): LegacyRestErrorBody {
   const { code, message, data } = demoteToLegacyShape(error);
-  const body: LegacyRestErrorBody = { code, message };
-  if (data !== undefined) {
-    body.data = data;
-  }
-  return body;
+  return {
+    code,
+    message,
+    ...(data !== undefined ? { data } : {}),
+  };
 }

--- a/src/compat/v0_3/translate/errors.ts
+++ b/src/compat/v0_3/translate/errors.ts
@@ -1,0 +1,134 @@
+/**
+ * Error translator between v1.0 SDK errors and v0.3 wire shapes.
+ *
+ * v1.0 introduced an enriched error model — a `google.rpc.Status`-style
+ * envelope with a `details[]` array carrying typed `ErrorInfo` payloads
+ * (`@type`, `reason`, `domain`, `metadata`). v0.3 predates that model
+ * and uses simpler shapes:
+ *
+ *   - JSON-RPC:   `{ code, message, data? }`     — `data` is a plain
+ *                                                   `Record<string, unknown>`,
+ *                                                   not an array of typed
+ *                                                   details.
+ *   - REST:       `{ code, message, data? }`     — a bare object, no
+ *                                                   outer `{ error: … }`
+ *                                                   wrapper, no `status`
+ *                                                   field, no `details[]`.
+ *
+ * This module provides the demotion path used by the v0.3 JSON-RPC and
+ * REST compat handlers so they all share a single source of truth. See
+ * issue a2aproject/a2a-js#488 for the motivation.
+ *
+ * The v0.3 gRPC handler intentionally does NOT use this module: it still
+ * attaches `google.rpc.ErrorInfo` in the `grpc-status-details-bin`
+ * trailer because the binary trailer is invisible to v0.3 clients
+ * (which do not decode it) yet still useful to v1.0-aware clients
+ * talking to a v0.3 server. See
+ * `src/compat/v0_3/server/grpc/grpc_service.ts` for the rationale.
+ *
+ * Codes introduced in v1.0 (`-32005`, `-32006`, `-32008`, `-32009`) that
+ * have no v0.3 spec equivalent are passed through with their numeric
+ * code unchanged. v0.3 clients seeing an unknown `-32xxx` should treat
+ * it as an opaque internal error. This is a deliberate decision over
+ * collapsing them to `INTERNAL_ERROR` — it preserves debuggability for
+ * v0.3 clients that happen to recognise the new codes.
+ */
+
+import { A2A_ERROR_CLASS_TO_CODE, A2A_ERROR_CODE } from '../../../errors.js';
+import { A2AError as LegacyA2AError } from '../server/error.js';
+import type * as legacy from '../types/types.js';
+
+/**
+ * v0.3-shaped HTTP error body.
+ *
+ * The v0.3 reference implementation returned errors as a bare
+ * `{ code, message, data? }` object (no `details[]` array, no `status`
+ * field, no outer `{ error: {...} }` wrapper). v1.0 introduced the
+ * structured `google.rpc.Status` JSON envelope, so this shape is kept
+ * separate to preserve wire-compatibility with v0.3 clients.
+ */
+export interface LegacyRestErrorBody {
+  code: number;
+  message: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Internal helper: resolves any value thrown by user code into the
+ * `{ code, message, data? }` triple that both v0.3 wire shapes need.
+ *
+ *  1. {@link LegacyA2AError} instances are honoured verbatim — their
+ *     `code`, `message`, and `data` are surfaced as-is. This is the
+ *     escape hatch for code that wants full control of the v0.3
+ *     envelope (e.g. setting a custom `data` payload that v0.3 clients
+ *     can read).
+ *  2. v1.0 SDK error classes (`TaskNotFoundError`, …) are mapped to
+ *     their corresponding numeric codes via
+ *     {@link A2A_ERROR_CLASS_TO_CODE}. **The `data` field is omitted**
+ *     even when the v1.0 path would have attached an `ErrorInfo`
+ *     payload — this is the wire-shape stripping that issue #488 is
+ *     about.
+ *  3. Anything else (unknown `Error` subclass, non-`Error` throw)
+ *     becomes a generic `INTERNAL_ERROR` with a best-effort message.
+ */
+function demoteToLegacyShape(error: unknown): {
+  code: number;
+  message: string;
+  data?: Record<string, unknown>;
+} {
+  if (error instanceof LegacyA2AError) {
+    return {
+      code: error.code,
+      message: error.message,
+      ...(error.data !== undefined ? { data: error.data } : {}),
+    };
+  }
+  if (error instanceof Error) {
+    const code = A2A_ERROR_CLASS_TO_CODE[error.name];
+    if (code !== undefined) {
+      return { code, message: error.message };
+    }
+  }
+  const message = (error instanceof Error && error.message) || 'An unexpected error occurred.';
+  return { code: A2A_ERROR_CODE.INTERNAL_ERROR, message };
+}
+
+/**
+ * Converts any error to a v0.3 JSON-RPC error object suitable for use
+ * as the `error` field of a {@link legacy.JSONRPCErrorResponse}.
+ *
+ * Crucially, the returned object never carries the v1.0 enriched
+ * `details[]` array or any `ErrorInfo` payload — only `code`,
+ * `message`, and (when honouring a {@link LegacyA2AError}) `data`.
+ *
+ * @see toCompatRestErrorBody — the same demotion logic shaped for the
+ * REST transport.
+ */
+export function toCompatJsonRpcError(error: unknown): legacy.JSONRPCError {
+  const { code, message, data } = demoteToLegacyShape(error);
+  const body: legacy.JSONRPCError = { code, message };
+  if (data !== undefined) {
+    body.data = data;
+  }
+  return body;
+}
+
+/**
+ * Converts any error to a v0.3 HTTP+JSON REST error body.
+ *
+ * The result is a bare `{ code, message, data? }` object with no outer
+ * `{ error: … }` wrapper, no `status` field, and no `details[]` array
+ * — the wire shape v0.3 clients expect (and which v1.0 §11.6
+ * deliberately departs from).
+ *
+ * @see toCompatJsonRpcError — the same demotion logic shaped for the
+ * JSON-RPC transport.
+ */
+export function toCompatRestErrorBody(error: unknown): LegacyRestErrorBody {
+  const { code, message, data } = demoteToLegacyShape(error);
+  const body: LegacyRestErrorBody = { code, message };
+  if (data !== undefined) {
+    body.data = data;
+  }
+  return body;
+}

--- a/src/compat/v0_3/translate/errors.ts
+++ b/src/compat/v0_3/translate/errors.ts
@@ -15,9 +15,8 @@
  *                                                   wrapper, no `status`
  *                                                   field, no `details[]`.
  *
- * This module provides the demotion path used by the v0.3 JSON-RPC and
- * REST compat handlers so they all share a single source of truth. See
- * issue a2aproject/a2a-js#488 for the motivation.
+ * Both shapes are structurally identical, so a single converter
+ * ({@link toCompatErrorBody}) serves both transports.
  *
  * The v0.3 gRPC handler intentionally does NOT use this module: it still
  * attaches `google.rpc.ErrorInfo` in the `grpc-status-details-bin`
@@ -66,8 +65,7 @@ export interface LegacyRestErrorBody {
  *     their corresponding numeric codes via
  *     {@link A2A_ERROR_CLASS_TO_CODE}. **The `data` field is omitted**
  *     even when the v1.0 path would have attached an `ErrorInfo`
- *     payload — this is the wire-shape stripping that issue #488 is
- *     about.
+ *     payload — this is the v1.0 → v0.3 wire-shape demotion.
  *  3. Anything else (unknown `Error` subclass, non-`Error` throw)
  *     becomes a generic `INTERNAL_ERROR` with a best-effort message.
  */
@@ -94,38 +92,21 @@ function demoteToLegacyShape(error: unknown): {
 }
 
 /**
- * Converts any error to a v0.3 JSON-RPC error object suitable for use
- * as the `error` field of a
- * {@link import('../types/types.js').JSONRPCErrorResponse}.
+ * Converts any error to a v0.3-shaped error body.
+ *
+ * The returned object satisfies both the v0.3 JSON-RPC `JSONRPCError`
+ * shape (used as the `error` field of
+ * {@link import('../types/types.js').JSONRPCErrorResponse}) and the
+ * v0.3 REST {@link LegacyRestErrorBody} shape. The two were
+ * historically separate types but are structurally identical
+ * (`{ code, message, data? }`), so a single converter serves both
+ * transports.
  *
  * Crucially, the returned object never carries the v1.0 enriched
  * `details[]` array or any `ErrorInfo` payload — only `code`,
  * `message`, and (when honouring a {@link LegacyA2AError}) `data`.
- *
- * @see toCompatRestErrorBody — the same demotion logic shaped for the
- * REST transport.
  */
-export function toCompatJsonRpcError(error: unknown): JSONRPCError {
-  const { code, message, data } = demoteToLegacyShape(error);
-  return {
-    code,
-    message,
-    ...(data !== undefined ? { data } : {}),
-  };
-}
-
-/**
- * Converts any error to a v0.3 HTTP+JSON REST error body.
- *
- * The result is a bare `{ code, message, data? }` object with no outer
- * `{ error: … }` wrapper, no `status` field, and no `details[]` array
- * — the wire shape v0.3 clients expect (and which v1.0 §11.6
- * deliberately departs from).
- *
- * @see toCompatJsonRpcError — the same demotion logic shaped for the
- * JSON-RPC transport.
- */
-export function toCompatRestErrorBody(error: unknown): LegacyRestErrorBody {
+export function toCompatErrorBody(error: unknown): JSONRPCError | LegacyRestErrorBody {
   const { code, message, data } = demoteToLegacyShape(error);
   return {
     code,

--- a/src/compat/v0_3/translate/index.ts
+++ b/src/compat/v0_3/translate/index.ts
@@ -8,6 +8,7 @@
 export * from './agent_card.js';
 export * from './artifacts.js';
 export * from './enums.js';
+export * from './errors.js';
 export * from './messages.js';
 export * from './parts.js';
 export * from './push_notifications.js';

--- a/test/compat/v0_3/translate/errors.spec.ts
+++ b/test/compat/v0_3/translate/errors.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for `src/compat/v0_3/translate/errors.ts`.
+ *
+ * Verifies the v1.0 → v0.3 error demotion contract from issue
+ * a2aproject/a2a-js#488:
+ *
+ *   - `LegacyA2AError` passes through verbatim (code, message, data).
+ *   - Every v1.0 SDK error class maps to its numeric code via
+ *     `A2A_ERROR_CLASS_TO_CODE`.
+ *   - The enriched `details[]` array and `ErrorInfo` payload are
+ *     never emitted on v0.3 responses.
+ *   - REST bodies have NO outer `{ error: … }` wrapper and NO `status`
+ *     field — bare `{ code, message, data? }` only.
+ *   - Unknown errors fall back to `INTERNAL_ERROR` (`-32603`).
+ *   - The new v1.0-only codes (`-32005`, `-32006`, `-32008`, `-32009`)
+ *     pass through with their numeric code unchanged.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  type LegacyRestErrorBody,
+  toCompatJsonRpcError,
+  toCompatRestErrorBody,
+} from '../../../../src/compat/v0_3/translate/errors.js';
+import { A2AError as LegacyA2AError } from '../../../../src/compat/v0_3/server/error.js';
+import {
+  ContentTypeNotSupportedError,
+  ExtendedAgentCardNotConfiguredError,
+  ExtensionSupportRequiredError,
+  GenericError,
+  InvalidAgentResponseError,
+  PushNotificationNotSupportedError,
+  RequestMalformedError,
+  TaskNotCancelableError,
+  TaskNotFoundError,
+  UnsupportedOperationError,
+  VersionNotSupportedError,
+} from '../../../../src/errors.js';
+
+const v1ToLegacyCodeCases: ReadonlyArray<readonly [() => Error, number]> = [
+  [() => new TaskNotFoundError('a'), -32001],
+  [() => new TaskNotCancelableError('a'), -32002],
+  [() => new PushNotificationNotSupportedError('a'), -32003],
+  [() => new UnsupportedOperationError('a'), -32004],
+  // v1.0-only codes (no v0.3 spec equivalent): per issue #488 the
+  // numeric code passes through unchanged.
+  [() => new ContentTypeNotSupportedError('a'), -32005],
+  [() => new InvalidAgentResponseError('a'), -32006],
+  [() => new ExtendedAgentCardNotConfiguredError('a'), -32007],
+  [() => new ExtensionSupportRequiredError('a'), -32008],
+  [() => new VersionNotSupportedError('a'), -32009],
+  // SDK-internal classes (not part of the spec but raised by the SDK
+  // when validating requests / wrapping arbitrary throws).
+  [() => new RequestMalformedError('a'), -32602],
+  [() => new GenericError('a'), -32603],
+];
+
+describe('compat/v0_3/translate/errors - toCompatJsonRpcError', () => {
+  it('passes through LegacyA2AError unchanged', () => {
+    const err = LegacyA2AError.taskNotFound('t-1');
+    const out = toCompatJsonRpcError(err);
+    expect(out.code).toBe(-32001);
+    expect(out.message).toContain('t-1');
+  });
+
+  it('preserves the data field from a LegacyA2AError', () => {
+    const err = LegacyA2AError.invalidParams('boom', { hint: 'check x' });
+    const out = toCompatJsonRpcError(err);
+    expect(out.code).toBe(-32602);
+    expect(out.message).toBe('boom');
+    expect(out.data).toEqual({ hint: 'check x' });
+  });
+
+  v1ToLegacyCodeCases.forEach(([factory, expectedCode]) => {
+    const sample = factory();
+    it(`maps ${sample.name} to code ${expectedCode}`, () => {
+      const out = toCompatJsonRpcError(factory());
+      expect(out.code).toBe(expectedCode);
+      expect(out.message).toBe('a');
+    });
+  });
+
+  it('omits the data field on v1 SDK errors (v0.3 shape compatibility)', () => {
+    const out = toCompatJsonRpcError(new TaskNotFoundError('t'));
+    expect(out).not.toHaveProperty('data');
+    expect(Object.keys(out).sort()).toEqual(['code', 'message']);
+  });
+
+  it('never emits a details[] array or @type/reason/domain fields', () => {
+    const out = toCompatJsonRpcError(new TaskNotFoundError('t')) as unknown as Record<
+      string,
+      unknown
+    >;
+    expect(out).not.toHaveProperty('details');
+    expect(out).not.toHaveProperty('@type');
+    expect(out).not.toHaveProperty('reason');
+    expect(out).not.toHaveProperty('domain');
+  });
+
+  it('falls back to INTERNAL_ERROR for unknown Error subclasses', () => {
+    const out = toCompatJsonRpcError(new Error('boom'));
+    expect(out.code).toBe(-32603);
+    expect(out.message).toBe('boom');
+    expect(out).not.toHaveProperty('data');
+  });
+
+  it('falls back to INTERNAL_ERROR with a generic message for non-Error throws', () => {
+    const out = toCompatJsonRpcError('string-thrown');
+    expect(out.code).toBe(-32603);
+    expect(out.message).toBe('An unexpected error occurred.');
+  });
+
+  it('falls back to INTERNAL_ERROR with a generic message for null/undefined throws', () => {
+    expect(toCompatJsonRpcError(null).code).toBe(-32603);
+    expect(toCompatJsonRpcError(undefined).code).toBe(-32603);
+    expect(toCompatJsonRpcError(null).message).toBe('An unexpected error occurred.');
+  });
+});
+
+describe('compat/v0_3/translate/errors - toCompatRestErrorBody', () => {
+  it('passes through LegacyA2AError unchanged', () => {
+    const err = LegacyA2AError.taskNotFound('t-1');
+    const out = toCompatRestErrorBody(err);
+    expect(out.code).toBe(-32001);
+    expect(out.message).toContain('t-1');
+  });
+
+  it('preserves the data field from a LegacyA2AError', () => {
+    const err = LegacyA2AError.invalidParams('boom', { hint: 'check x' });
+    const out = toCompatRestErrorBody(err);
+    expect(out.code).toBe(-32602);
+    expect(out.data).toEqual({ hint: 'check x' });
+  });
+
+  v1ToLegacyCodeCases.forEach(([factory, expectedCode]) => {
+    const sample = factory();
+    it(`maps ${sample.name} to code ${expectedCode}`, () => {
+      const out = toCompatRestErrorBody(factory());
+      expect(out.code).toBe(expectedCode);
+      expect(out.message).toBe('a');
+    });
+  });
+
+  it('produces a bare body without an outer error wrapper or details array', () => {
+    const out: LegacyRestErrorBody = toCompatRestErrorBody(new TaskNotFoundError('t'));
+    const opaque = out as unknown as Record<string, unknown>;
+    expect(opaque).not.toHaveProperty('error');
+    expect(opaque).not.toHaveProperty('details');
+    expect(opaque).not.toHaveProperty('status');
+    expect(opaque).not.toHaveProperty('@type');
+    expect(Object.keys(out).sort()).toEqual(['code', 'message']);
+  });
+
+  it('omits the data field on v1 SDK errors (v0.3 shape compatibility)', () => {
+    const out = toCompatRestErrorBody(new TaskNotFoundError('t'));
+    expect(out).not.toHaveProperty('data');
+  });
+
+  it('falls back to INTERNAL_ERROR for unknown Error subclasses', () => {
+    const out = toCompatRestErrorBody(new Error('boom'));
+    expect(out.code).toBe(-32603);
+    expect(out.message).toBe('boom');
+  });
+
+  it('falls back to INTERNAL_ERROR with a generic message for non-Error throws', () => {
+    const out = toCompatRestErrorBody({ random: 'object' });
+    expect(out.code).toBe(-32603);
+    expect(out.message).toBe('An unexpected error occurred.');
+  });
+});
+
+describe('compat/v0_3/translate/errors - cross-transport consistency', () => {
+  it('emits the same code and message for every error across both transports', () => {
+    const samples: unknown[] = [
+      LegacyA2AError.taskNotFound('t-1'),
+      LegacyA2AError.invalidParams('boom', { hint: 'check x' }),
+      new TaskNotFoundError('a'),
+      new TaskNotCancelableError('a'),
+      new PushNotificationNotSupportedError('a'),
+      new UnsupportedOperationError('a'),
+      new ContentTypeNotSupportedError('a'),
+      new InvalidAgentResponseError('a'),
+      new ExtendedAgentCardNotConfiguredError('a'),
+      new ExtensionSupportRequiredError('a'),
+      new VersionNotSupportedError('a'),
+      new RequestMalformedError('a'),
+      new GenericError('a'),
+      new Error('boom'),
+      'string-thrown',
+      undefined,
+    ];
+
+    for (const sample of samples) {
+      const jsonRpc = toCompatJsonRpcError(sample);
+      const rest = toCompatRestErrorBody(sample);
+      expect(rest.code).toBe(jsonRpc.code);
+      expect(rest.message).toBe(jsonRpc.message);
+      expect(rest.data).toEqual(jsonRpc.data);
+    }
+  });
+});

--- a/test/compat/v0_3/translate/errors.spec.ts
+++ b/test/compat/v0_3/translate/errors.spec.ts
@@ -1,15 +1,14 @@
 /**
  * Tests for `src/compat/v0_3/translate/errors.ts`.
  *
- * Verifies the v1.0 → v0.3 error demotion contract from issue
- * a2aproject/a2a-js#488:
+ * Verifies the v1.0 → v0.3 error demotion contract:
  *
  *   - `LegacyA2AError` passes through verbatim (code, message, data).
  *   - Every v1.0 SDK error class maps to its numeric code via
  *     `A2A_ERROR_CLASS_TO_CODE`.
  *   - The enriched `details[]` array and `ErrorInfo` payload are
  *     never emitted on v0.3 responses.
- *   - REST bodies have NO outer `{ error: … }` wrapper and NO `status`
+ *   - Bodies have NO outer `{ error: … }` wrapper and NO `status`
  *     field — bare `{ code, message, data? }` only.
  *   - Unknown errors fall back to `INTERNAL_ERROR` (`-32603`).
  *   - The new v1.0-only codes (`-32005`, `-32006`, `-32008`, `-32009`)
@@ -17,11 +16,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import {
-  type LegacyRestErrorBody,
-  toCompatJsonRpcError,
-  toCompatRestErrorBody,
-} from '../../../../src/compat/v0_3/translate/errors.js';
+import { toCompatErrorBody } from '../../../../src/compat/v0_3/translate/errors.js';
 import { A2AError as LegacyA2AError } from '../../../../src/compat/v0_3/server/error.js';
 import {
   ContentTypeNotSupportedError,
@@ -42,8 +37,8 @@ const v1ToLegacyCodeCases: ReadonlyArray<readonly [() => Error, number]> = [
   [() => new TaskNotCancelableError('a'), -32002],
   [() => new PushNotificationNotSupportedError('a'), -32003],
   [() => new UnsupportedOperationError('a'), -32004],
-  // v1.0-only codes (no v0.3 spec equivalent): per issue #488 the
-  // numeric code passes through unchanged.
+  // v1.0-only codes (no v0.3 spec equivalent): the numeric code
+  // passes through unchanged.
   [() => new ContentTypeNotSupportedError('a'), -32005],
   [() => new InvalidAgentResponseError('a'), -32006],
   [() => new ExtendedAgentCardNotConfiguredError('a'), -32007],
@@ -55,17 +50,17 @@ const v1ToLegacyCodeCases: ReadonlyArray<readonly [() => Error, number]> = [
   [() => new GenericError('a'), -32603],
 ];
 
-describe('compat/v0_3/translate/errors - toCompatJsonRpcError', () => {
+describe('compat/v0_3/translate/errors - toCompatErrorBody', () => {
   it('passes through LegacyA2AError unchanged', () => {
     const err = LegacyA2AError.taskNotFound('t-1');
-    const out = toCompatJsonRpcError(err);
+    const out = toCompatErrorBody(err);
     expect(out.code).toBe(-32001);
     expect(out.message).toContain('t-1');
   });
 
   it('preserves the data field from a LegacyA2AError', () => {
     const err = LegacyA2AError.invalidParams('boom', { hint: 'check x' });
-    const out = toCompatJsonRpcError(err);
+    const out = toCompatErrorBody(err);
     expect(out.code).toBe(-32602);
     expect(out.message).toBe('boom');
     expect(out.data).toEqual({ hint: 'check x' });
@@ -74,128 +69,49 @@ describe('compat/v0_3/translate/errors - toCompatJsonRpcError', () => {
   v1ToLegacyCodeCases.forEach(([factory, expectedCode]) => {
     const sample = factory();
     it(`maps ${sample.name} to code ${expectedCode}`, () => {
-      const out = toCompatJsonRpcError(factory());
+      const out = toCompatErrorBody(factory());
       expect(out.code).toBe(expectedCode);
       expect(out.message).toBe('a');
     });
   });
 
   it('omits the data field on v1 SDK errors (v0.3 shape compatibility)', () => {
-    const out = toCompatJsonRpcError(new TaskNotFoundError('t'));
+    const out = toCompatErrorBody(new TaskNotFoundError('t'));
     expect(out).not.toHaveProperty('data');
-    expect(Object.keys(out).sort()).toEqual(['code', 'message']);
-  });
-
-  it('never emits a details[] array or @type/reason/domain fields', () => {
-    const out = toCompatJsonRpcError(new TaskNotFoundError('t')) as unknown as Record<
-      string,
-      unknown
-    >;
-    expect(out).not.toHaveProperty('details');
-    expect(out).not.toHaveProperty('@type');
-    expect(out).not.toHaveProperty('reason');
-    expect(out).not.toHaveProperty('domain');
-  });
-
-  it('falls back to INTERNAL_ERROR for unknown Error subclasses', () => {
-    const out = toCompatJsonRpcError(new Error('boom'));
-    expect(out.code).toBe(-32603);
-    expect(out.message).toBe('boom');
-    expect(out).not.toHaveProperty('data');
-  });
-
-  it('falls back to INTERNAL_ERROR with a generic message for non-Error throws', () => {
-    const out = toCompatJsonRpcError('string-thrown');
-    expect(out.code).toBe(-32603);
-    expect(out.message).toBe('An unexpected error occurred.');
-  });
-
-  it('falls back to INTERNAL_ERROR with a generic message for null/undefined throws', () => {
-    expect(toCompatJsonRpcError(null).code).toBe(-32603);
-    expect(toCompatJsonRpcError(undefined).code).toBe(-32603);
-    expect(toCompatJsonRpcError(null).message).toBe('An unexpected error occurred.');
-  });
-});
-
-describe('compat/v0_3/translate/errors - toCompatRestErrorBody', () => {
-  it('passes through LegacyA2AError unchanged', () => {
-    const err = LegacyA2AError.taskNotFound('t-1');
-    const out = toCompatRestErrorBody(err);
-    expect(out.code).toBe(-32001);
-    expect(out.message).toContain('t-1');
-  });
-
-  it('preserves the data field from a LegacyA2AError', () => {
-    const err = LegacyA2AError.invalidParams('boom', { hint: 'check x' });
-    const out = toCompatRestErrorBody(err);
-    expect(out.code).toBe(-32602);
-    expect(out.data).toEqual({ hint: 'check x' });
-  });
-
-  v1ToLegacyCodeCases.forEach(([factory, expectedCode]) => {
-    const sample = factory();
-    it(`maps ${sample.name} to code ${expectedCode}`, () => {
-      const out = toCompatRestErrorBody(factory());
-      expect(out.code).toBe(expectedCode);
-      expect(out.message).toBe('a');
-    });
   });
 
   it('produces a bare body without an outer error wrapper or details array', () => {
-    const out: LegacyRestErrorBody = toCompatRestErrorBody(new TaskNotFoundError('t'));
+    const out = toCompatErrorBody(new TaskNotFoundError('t'));
     const opaque = out as unknown as Record<string, unknown>;
     expect(opaque).not.toHaveProperty('error');
     expect(opaque).not.toHaveProperty('details');
     expect(opaque).not.toHaveProperty('status');
     expect(opaque).not.toHaveProperty('@type');
+    expect(opaque).not.toHaveProperty('reason');
+    expect(opaque).not.toHaveProperty('domain');
     expect(Object.keys(out).sort()).toEqual(['code', 'message']);
   });
 
-  it('omits the data field on v1 SDK errors (v0.3 shape compatibility)', () => {
-    const out = toCompatRestErrorBody(new TaskNotFoundError('t'));
+  it('falls back to INTERNAL_ERROR for unknown Error subclasses', () => {
+    const out = toCompatErrorBody(new Error('boom'));
+    expect(out.code).toBe(-32603);
+    expect(out.message).toBe('boom');
     expect(out).not.toHaveProperty('data');
   });
 
-  it('falls back to INTERNAL_ERROR for unknown Error subclasses', () => {
-    const out = toCompatRestErrorBody(new Error('boom'));
-    expect(out.code).toBe(-32603);
-    expect(out.message).toBe('boom');
-  });
-
   it('falls back to INTERNAL_ERROR with a generic message for non-Error throws', () => {
-    const out = toCompatRestErrorBody({ random: 'object' });
-    expect(out.code).toBe(-32603);
-    expect(out.message).toBe('An unexpected error occurred.');
+    const fromString = toCompatErrorBody('string-thrown');
+    expect(fromString.code).toBe(-32603);
+    expect(fromString.message).toBe('An unexpected error occurred.');
+
+    const fromObject = toCompatErrorBody({ random: 'object' });
+    expect(fromObject.code).toBe(-32603);
+    expect(fromObject.message).toBe('An unexpected error occurred.');
   });
-});
 
-describe('compat/v0_3/translate/errors - cross-transport consistency', () => {
-  it('emits the same code and message for every error across both transports', () => {
-    const samples: unknown[] = [
-      LegacyA2AError.taskNotFound('t-1'),
-      LegacyA2AError.invalidParams('boom', { hint: 'check x' }),
-      new TaskNotFoundError('a'),
-      new TaskNotCancelableError('a'),
-      new PushNotificationNotSupportedError('a'),
-      new UnsupportedOperationError('a'),
-      new ContentTypeNotSupportedError('a'),
-      new InvalidAgentResponseError('a'),
-      new ExtendedAgentCardNotConfiguredError('a'),
-      new ExtensionSupportRequiredError('a'),
-      new VersionNotSupportedError('a'),
-      new RequestMalformedError('a'),
-      new GenericError('a'),
-      new Error('boom'),
-      'string-thrown',
-      undefined,
-    ];
-
-    for (const sample of samples) {
-      const jsonRpc = toCompatJsonRpcError(sample);
-      const rest = toCompatRestErrorBody(sample);
-      expect(rest.code).toBe(jsonRpc.code);
-      expect(rest.message).toBe(jsonRpc.message);
-      expect(rest.data).toEqual(jsonRpc.data);
-    }
+  it('falls back to INTERNAL_ERROR with a generic message for null/undefined throws', () => {
+    expect(toCompatErrorBody(null).code).toBe(-32603);
+    expect(toCompatErrorBody(undefined).code).toBe(-32603);
+    expect(toCompatErrorBody(null).message).toBe('An unexpected error occurred.');
   });
 });


### PR DESCRIPTION
# Description

This pull request refactors and centralizes the logic for translating v1.0 SDK errors into v0.3 wire-compatible error shapes, ensuring consistent error demotion across both JSON-RPC and REST transports. The new shared module (`src/compat/v0_3/translate/errors.ts`) now handles all v1.0 → v0.3 error conversions, strips v1.0-enriched fields, and is thoroughly tested for contract compliance. Existing handler code is updated to delegate to this shared logic.

Closes #488🦕
