### PR TITLE
feat: default to 0.3 if version not provided

### DIFF
--- a/src/client/card-resolver.ts
+++ b/src/client/card-resolver.ts
@@ -1,4 +1,4 @@
-import { AGENT_CARD_PATH } from '../constants.js';
+import { A2A_PROTOCOL_VERSION, A2A_VERSION_HEADER, AGENT_CARD_PATH } from '../constants.js';
 import { AgentCard } from '../index.js';
 import { isLegacyAgentCard, parseLegacyAgentCard } from '../compat/v0_3/client/card-resolver.js';
 
@@ -11,13 +11,20 @@ export interface AgentCardResolverOptions {
    * When enabled, the resolver inspects each fetched agent-card
    * payload; if its shape matches v0.3 (top-level `url` without
    * `supportedInterfaces`, `preferredTransport`,
-   * `additionalInterfaces`, `supportsAuthenticatedExtendedCard`, or
-   * a `protocolVersion` in `[0.3, 1.0)`), it is translated to the
-   * v1.0 proto shape via `toCoreAgentCard`. Each synthesized
-   * `AgentInterface` is stamped with `protocolVersion: '0.3'` so
-   * that a {@link JsonRpcTransportFactory} configured with
+   * `additionalInterfaces`, `supportsAuthenticatedExtendedCard`, or a
+   * `protocolVersion` in `[0.3, 1.0)`), it is translated to the v1.0
+   * proto shape via `toCoreAgentCard`. Each synthesized
+   * `AgentInterface` is stamped with `protocolVersion: '0.3'` so that
+   * a `JsonRpcTransportFactory` configured with
    * `legacyCompat: { enabled: true }` selects the compat transport
    * automatically.
+   *
+   * The discovery request itself always announces the SDK's native
+   * v1.0 in the `A2A-Version` header — detection of v0.3 servers is
+   * based on the response shape (see {@link resolve}), not on the
+   * request value. This avoids a downgrade dance when both client
+   * and server speak v1.0 natively but both have legacyCompat
+   * enabled.
    *
    * Default: omitted (treated as disabled). When disabled, the v0.3
    * compat module is never loaded.
@@ -44,7 +51,9 @@ export class DefaultAgentCardResolver implements AgentCardResolver {
    */
   async resolve(baseUrl: string, path?: string): Promise<AgentCard> {
     const agentCardUrl = new URL(path ?? this.options?.path ?? AGENT_CARD_PATH, baseUrl);
-    const response = await this.fetchImpl(agentCardUrl);
+    const response = await this.fetchImpl(agentCardUrl, {
+      headers: { [A2A_VERSION_HEADER]: A2A_PROTOCOL_VERSION },
+    });
     if (!response.ok) {
       throw new Error(`Failed to fetch Agent Card from ${agentCardUrl}: ${response.status}`);
     }

--- a/src/compat/v0_3/README.md
+++ b/src/compat/v0_3/README.md
@@ -44,7 +44,18 @@ Notable policy decisions:
 - The v1.0 `OAuthFlows.deviceCode` flow is silently dropped going v1.0 → v0.3 (v0.3 has no equivalent).
 - `TaskStatusUpdateEvent.final` is computed from the status state going v1.0 → v0.3 (`true` for `completed`, `canceled`, `failed`, `rejected`).
 - `SendMessageConfiguration.returnImmediately` ↔ `MessageSendConfiguration.blocking` with inverted polarity.
-- `toCompatAgentCard` filters `supportedInterfaces` to those whose `protocolVersion` is empty or in `[0.3, 1.0)` and throws `VersionNotSupportedError` if none qualify.
+- `toCompatAgentCard(card)` (strict mode, default) filters `supportedInterfaces` to those whose `protocolVersion` is empty or in `[0.3, 1.0)` and throws `VersionNotSupportedError` if none qualify.
+- `toCompatAgentCard(card, { synthesize: true })` (synthesis mode) accepts every interface in `supportedInterfaces` regardless of `protocolVersion` and emits `protocolVersion: '0.3'` on the result. Used by `legacyAgentCardRouter` to serve a discoverable v0.3 card when the operator has opted into `legacyCompat` but only declared v1.0 interfaces; the same v1.0 interface URLs are presented under the v0.3 protocol version.
+
+## Version negotiation under `legacyCompat`
+
+Per A2A spec §3.6.2, clients that omit the `A2A-Version` header are treated as v0.3 requests. Without an opt-in, the SDK's strict validator rejects header-less requests against a v1.0-only agent card with `VersionNotSupportedError`. When `legacyCompat: { enabled: true }` is passed to a handler, two pieces work together to honor §3.6.2 without requiring operators to duplicate every v1.0 `supportedInterfaces` entry with a v0.3 stub:
+
+1. **Implicit v0.3 in `validateVersion`.** When called with `{ legacyCompat: true }`, the validator adds the legacy `'0.3'` version to the supported set for any binding the agent card already exposes at least one interface for. A header-less or `A2A-Version: 0.3` request therefore routes through the legacy handler chain (`LegacyJsonRpcTransportHandler`, `LegacyRestTransportHandler`, `legacyGrpcService`) even when the card declares only v1.0 interfaces. Requests for bindings the card doesn't expose at all are still rejected.
+
+2. **Synthesized v0.3 card.** The `legacyAgentCardRouter` calls `toCompatAgentCard(card, { synthesize: true })` so the well-known endpoint returns a discoverable v0.3-shaped card whose `(url, preferredTransport, additionalInterfaces)` reflect the v1.0 `supportedInterfaces` entries but whose `protocolVersion` is stamped as `'0.3'`. v0.3 clients can therefore both discover and use a v1.0-only server when the operator has opted into the compat layer.
+
+The v1.0 gRPC service factory (`src/server/grpc/grpc_service.ts`) intentionally does **not** carry a `legacyCompat` option; v0.3 gRPC clients are served by registering `legacyGrpcService` alongside the v1.0 `grpcService` on the same `Server`.
 
 ## Push Notifications
 

--- a/src/compat/v0_3/server/express/agent_card_handler.ts
+++ b/src/compat/v0_3/server/express/agent_card_handler.ts
@@ -110,7 +110,14 @@ export function legacyAgentCardRouter(options: LegacyAgentCardHandlerOptions): R
       const coreCard = await provider();
       let compatCard: legacy.AgentCard;
       try {
-        compatCard = toCompatAgentCard(coreCard);
+        // `synthesize: true` lets the legacy endpoint serve a
+        // discoverable v0.3 card even when the operator only declared
+        // v1.0 interfaces in `supportedInterfaces` — symmetric with
+        // the request handlers' implicit-v0.3 acceptance under
+        // `legacyCompat`. Strict filtering would force operators to
+        // duplicate every v1.0 entry with a v0.3 stub just to get a
+        // discoverable v0.3 surface; this avoids that.
+        compatCard = toCompatAgentCard(coreCard, { synthesize: true });
       } catch (error) {
         if (error instanceof VersionNotSupportedError) {
           res.append('Vary', A2A_VERSION_HEADER);

--- a/src/compat/v0_3/server/express/rest_handler.ts
+++ b/src/compat/v0_3/server/express/rest_handler.ts
@@ -176,7 +176,15 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
       tenant: (req.params.tenant as string) || undefined,
     });
     const agentCard = await transportHandler.getAgentCard();
-    validateVersion(context.requestedVersion, agentCard, 'HTTP+JSON');
+    // This router is only mounted when the operator opted into
+    // `legacyCompat`, so the validator implicitly accepts '0.3' for
+    // any binding the card already exposes (per §3.6.2). This lets a
+    // v1.0-only card serve legacy clients without forcing operators
+    // to duplicate every v1.0 `supportedInterfaces` entry with a v0.3
+    // stub.
+    validateVersion(context.requestedVersion, agentCard, 'HTTP+JSON', {
+      legacyCompat: { enabled: true },
+    });
     return context;
   };
 

--- a/src/compat/v0_3/server/grpc/grpc_service.ts
+++ b/src/compat/v0_3/server/grpc/grpc_service.ts
@@ -573,7 +573,15 @@ const _buildContext = async (
   });
 
   const agentCard = await requestHandler.getAgentCard();
-  validateVersion(context.requestedVersion, agentCard, 'GRPC');
+  // `legacyGrpcService` is only registered alongside the v1.0
+  // `grpcService` when the operator opts into the v0.3 compat layer,
+  // so the validator implicitly accepts '0.3' for any binding the
+  // card already exposes (per §3.6.2). A v1.0-only card therefore
+  // serves legacy gRPC clients without forcing operators to declare a
+  // duplicate v0.3 `supportedInterfaces` entry.
+  validateVersion(context.requestedVersion, agentCard, 'GRPC', {
+    legacyCompat: { enabled: true },
+  });
 
   return context;
 };

--- a/src/compat/v0_3/translate/agent_card.ts
+++ b/src/compat/v0_3/translate/agent_card.ts
@@ -280,7 +280,8 @@ export function toCompatAgentCard(
   core: V1AgentCard,
   options?: ToCompatAgentCardOptions
 ): legacy.AgentCard {
-  const legacyInterfaces = core.supportedInterfaces.filter(
+  const allInterfaces = core.supportedInterfaces ?? [];
+  const legacyInterfaces = allInterfaces.filter(
     (intf) => !intf.protocolVersion || isLegacyVersion(intf.protocolVersion)
   );
   // Under synthesis mode, fall back to *every* interface when none in
@@ -290,9 +291,7 @@ export function toCompatAgentCard(
   // deployments keep emitting the same v0.3 primary URL they did
   // before the synthesize option was introduced.
   const compatInterfaces =
-    options?.synthesize && legacyInterfaces.length === 0
-      ? core.supportedInterfaces
-      : legacyInterfaces;
+    options?.synthesize && legacyInterfaces.length === 0 ? allInterfaces : legacyInterfaces;
   if (compatInterfaces.length === 0) {
     throw new VersionNotSupportedError(
       'AgentCard must have at least one interface with a protocol version in [0.3, 1.0).'

--- a/src/compat/v0_3/translate/agent_card.ts
+++ b/src/compat/v0_3/translate/agent_card.ts
@@ -236,21 +236,63 @@ export function toCoreAgentCard(compat: legacy.AgentCard): V1AgentCard {
 }
 
 /**
+ * Options for {@link toCompatAgentCard}.
+ */
+export interface ToCompatAgentCardOptions {
+  /**
+   * When `true`, accept every entry in `supportedInterfaces` regardless
+   * of its `protocolVersion` (skipping the `[0.3, 1.0)` filter) and
+   * stamp the emitted card's `protocolVersion` as
+   * {@link PROTOCOL_VERSION_0_3} regardless of the source value.
+   *
+   * Designed for the SDK's opt-in compat layer: when a server is
+   * configured with `legacyCompat: { enabled: true }` but only declares
+   * v1.0 interfaces on its agent card, the well-known endpoint can
+   * still serve a discoverable v0.3 card to legacy clients. The
+   * resulting card advertises the same interface URLs as the v1.0
+   * card but presents them under the v0.3 protocol version, mirroring
+   * the validator's implicit-v0.3 acceptance for request handling.
+   *
+   * Default: `false` (strict behavior: filter to legacy-range
+   * interfaces and throw `VersionNotSupportedError` if none qualify).
+   */
+  synthesize?: boolean;
+}
+
+/**
  * Converts a v1.0 proto `AgentCard` into a v0.3 JSON `AgentCard`.
  *
- * Filters `supportedInterfaces` to those whose `protocolVersion` is
- * empty or in `[0.3, 1.0)`; the first surviving entry becomes the v0.3
- * primary `(url, preferredTransport)`, and the rest become
- * `additionalInterfaces`. Throws `VersionNotSupportedError` if no
- * interface qualifies.
+ * In the default (strict) mode, filters `supportedInterfaces` to those
+ * whose `protocolVersion` is empty or in `[0.3, 1.0)`; the first
+ * surviving entry becomes the v0.3 primary `(url, preferredTransport)`,
+ * and the rest become `additionalInterfaces`. Throws
+ * `VersionNotSupportedError` if no interface qualifies.
+ *
+ * When called with `{ synthesize: true }`, accepts every interface
+ * unconditionally and emits `protocolVersion: '0.3'` on the result —
+ * used by the well-known agent-card endpoint when the operator has
+ * opted into the v0.3 compat layer but declared only v1.0 interfaces.
  *
  * `capabilities.extendedAgentCard` is pulled back out to the card-level
  * `supportsAuthenticatedExtendedCard` field.
  */
-export function toCompatAgentCard(core: V1AgentCard): legacy.AgentCard {
-  const compatInterfaces = core.supportedInterfaces.filter(
+export function toCompatAgentCard(
+  core: V1AgentCard,
+  options?: ToCompatAgentCardOptions
+): legacy.AgentCard {
+  const legacyInterfaces = core.supportedInterfaces.filter(
     (intf) => !intf.protocolVersion || isLegacyVersion(intf.protocolVersion)
   );
+  // Under synthesis mode, fall back to *every* interface when none in
+  // the legacy range exist — this is the discoverable-card path for
+  // v1.0-only deployments that opted into `legacyCompat`. When legacy
+  // interfaces ARE declared, prefer them so existing dual-version
+  // deployments keep emitting the same v0.3 primary URL they did
+  // before the synthesize option was introduced.
+  const compatInterfaces =
+    options?.synthesize && legacyInterfaces.length === 0
+      ? core.supportedInterfaces
+      : legacyInterfaces;
   if (compatInterfaces.length === 0) {
     throw new VersionNotSupportedError(
       'AgentCard must have at least one interface with a protocol version in [0.3, 1.0).'
@@ -278,13 +320,24 @@ export function toCompatAgentCard(core: V1AgentCard): legacy.AgentCard {
         )
       : undefined;
 
+  // Under synthesize-fallback (no legacy-range interfaces, so we
+  // accepted non-legacy entries) the primary interface may be v1.0
+  // (or any other non-legacy version); the emitted v0.3 card always
+  // presents itself as v0.3 regardless of the underlying interface's
+  // declared version. Under strict / dual-version modes, fall back to
+  // `PROTOCOL_VERSION_0_3` only when the source field is empty.
+  const synthesizedFallback = options?.synthesize && legacyInterfaces.length === 0;
+  const emittedProtocolVersion = synthesizedFallback
+    ? PROTOCOL_VERSION_0_3
+    : primary.protocolVersion || PROTOCOL_VERSION_0_3;
+
   const result: legacy.AgentCard = {
     name: core.name,
     description: core.description,
     version: core.version,
     url: primary.url,
     preferredTransport: primary.protocolBinding,
-    protocolVersion: primary.protocolVersion || PROTOCOL_VERSION_0_3,
+    protocolVersion: emittedProtocolVersion,
     capabilities,
     defaultInputModes: [...core.defaultInputModes],
     defaultOutputModes: [...core.defaultOutputModes],

--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -106,10 +106,15 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
       const agentCard = await options.requestHandler.getAgentCard();
       // The agent card is the single source of truth for which protocol
       // versions this transport accepts. `requestedVersion` defaults to
-      // '0.3' when the A2A-Version header is absent (§3.6.2), so a
-      // header-less legacy client will only succeed if the card declares
-      // a v0.3 JSONRPC interface.
-      validateVersion(context.requestedVersion, agentCard, 'JSONRPC');
+      // '0.3' when the A2A-Version header is absent (§3.6.2). When
+      // `legacyCompat` is enabled, the validator implicitly accepts
+      // '0.3' for any binding the card already exposes, so v0.3
+      // clients (and header-less clients) succeed without requiring
+      // operators to duplicate every v1.0 `supportedInterfaces` entry
+      // with a v0.3 stub.
+      validateVersion(context.requestedVersion, agentCard, 'JSONRPC', {
+        legacyCompat: options.legacyCompat,
+      });
       const transportHandler = useLegacy ? legacyJsonRpcTransportHandler : jsonRpcTransportHandler;
       const rpcResponseOrStream = await transportHandler.handle(req.body, context);
 

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -175,7 +175,14 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
       tenant,
     });
     const agentCard = await restTransportHandler.getAgentCard();
-    validateVersion(context.requestedVersion, agentCard, 'HTTP+JSON');
+    // When `legacyCompat` is enabled, the validator implicitly accepts
+    // '0.3' for any binding the card already exposes (per §3.6.2),
+    // so v0.3 clients (and header-less clients) succeed without
+    // requiring operators to duplicate every v1.0 `supportedInterfaces`
+    // entry with a v0.3 stub.
+    validateVersion(context.requestedVersion, agentCard, 'HTTP+JSON', {
+      legacyCompat: options.legacyCompat,
+    });
     return context;
   };
 

--- a/src/server/version.ts
+++ b/src/server/version.ts
@@ -1,3 +1,4 @@
+import { A2A_LEGACY_PROTOCOL_VERSION } from '../constants.js';
 import { TransportProtocolName } from '../core.js';
 import { VersionNotSupportedError } from '../errors.js';
 import { AgentCard } from '../index.js';
@@ -31,23 +32,79 @@ export function getSupportedVersions(
 }
 
 /**
+ * Options for {@link validateVersion}.
+ */
+export interface ValidateVersionOptions {
+  /**
+   * Opt-in to v0.3 compatibility. When `{ enabled: true }`, the legacy
+   * v0.3 protocol version ({@link A2A_LEGACY_PROTOCOL_VERSION}) is
+   * treated as implicitly supported for any binding that the agent
+   * card exposes at least one interface for — even if the card itself
+   * doesn't declare a v0.3 `protocolVersion` entry.
+   *
+   * This honors the §3.6.2 default-to-`'0.3'` rule (clients that omit
+   * the `A2A-Version` header MUST be treated as v0.3 requests) under
+   * the SDK's opt-in compat layer. Operators that don't opt in
+   * (`legacyCompat: { enabled: false }` or omitted) keep the strict
+   * behavior — only explicitly declared versions are accepted.
+   *
+   * The `{ enabled: boolean }` shape mirrors the option used by every
+   * public handler / transport-factory option type that exposes
+   * legacy compat (`AgentCardHandlerOptions`, `JsonRpcHandlerOptions`,
+   * `RestHandlerOptions`, `AgentCardResolverOptions`,
+   * `JsonRpcTransportFactoryOptions`, `RestTransportFactoryOptions`,
+   * `GrpcTransportFactoryOptions`).
+   *
+   * Default: omitted (strict). Has no effect unless the agent card
+   * already advertises at least one interface for the requested
+   * binding; otherwise the implicit v0.3 entry would route requests
+   * to a binding the agent doesn't actually serve.
+   */
+  legacyCompat?: { enabled: boolean };
+}
+
+/**
  * Validates that the requested A2A protocol version is supported by the agent.
  *
  * Per §3.6.2: "Agents MUST process requests using the semantics of the
  * requested A2A-Version (matching Major.Minor). If the version is not
  * supported by the interface, agents MUST return a VersionNotSupportedError."
  *
+ * When `options.legacyCompat` is `true` AND the agent card exposes at
+ * least one interface for the requested binding, the legacy v0.3
+ * version is implicitly added to the supported set. This lets a v1.0
+ * server opted into the compat layer honor the §3.6.2 default-to-`'0.3'`
+ * rule (and explicit `A2A-Version: 0.3` requests) without forcing
+ * operators to duplicate every v1.0 `supportedInterfaces` entry with a
+ * matching v0.3 stub.
+ *
  * @param requestedVersion - The version requested by the client (from A2A-Version header).
  * @param agentCard - The agent card declaring supported interfaces/versions.
  * @param protocolBinding - The protocol binding to filter versions by.
+ * @param options - Validation options (see {@link ValidateVersionOptions}).
  * @throws {VersionNotSupportedError} If the requested version is not supported.
  */
 export function validateVersion(
   requestedVersion: string,
   agentCard: AgentCard,
-  protocolBinding?: TransportProtocolName
+  protocolBinding?: TransportProtocolName,
+  options?: ValidateVersionOptions
 ): void {
   const supported = getSupportedVersions(agentCard, protocolBinding);
+
+  if (options?.legacyCompat?.enabled) {
+    // Implicit v0.3 acceptance: only if the agent card actually
+    // exposes the requested binding (otherwise we'd accept v0.3 for a
+    // transport the agent doesn't serve, which would just defer the
+    // failure to the dispatcher with a less useful error).
+    const hasBindingInterface = (agentCard.supportedInterfaces ?? []).some(
+      (intf) => !protocolBinding || intf.protocolBinding === protocolBinding
+    );
+    if (hasBindingInterface) {
+      supported.add(A2A_LEGACY_PROTOCOL_VERSION);
+    }
+  }
+
   if (!supported.has(requestedVersion)) {
     throw new VersionNotSupportedError(
       `The requested A2A protocol version '${requestedVersion}' is not supported. ` +

--- a/test/client/card-resolver.spec.ts
+++ b/test/client/card-resolver.spec.ts
@@ -50,8 +50,51 @@ describe('DefaultAgentCardResolver', () => {
     expect(mockFetch).toHaveBeenCalledExactlyOnceWith(
       expect.objectContaining({
         href: 'https://example.com/.well-known/agent-card.json',
+      }),
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'A2A-Version': '1.0' }),
       })
     );
+  });
+
+  it('sends A2A-Version: 1.0 header by default (per §3.6.1)', async () => {
+    const resolver = new DefaultAgentCardResolver({ fetchImpl: mockFetch });
+    mockFetch.mockResolvedValue(new Response(JSON.stringify(testAgentCard), { status: 200 }));
+
+    await resolver.resolve('https://example.com');
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const init = mockFetch.mock.calls[0][1] as RequestInit | undefined;
+    expect((init?.headers as Record<string, string> | undefined)?.['A2A-Version']).toBe('1.0');
+  });
+
+  it('sends A2A-Version: 1.0 when legacyCompat.enabled is false', async () => {
+    const resolver = new DefaultAgentCardResolver({
+      fetchImpl: mockFetch,
+      legacyCompat: { enabled: false },
+    });
+    mockFetch.mockResolvedValue(new Response(JSON.stringify(testAgentCard), { status: 200 }));
+
+    await resolver.resolve('https://example.com');
+
+    const init = mockFetch.mock.calls[0][1] as RequestInit | undefined;
+    expect((init?.headers as Record<string, string> | undefined)?.['A2A-Version']).toBe('1.0');
+  });
+
+  it('sends A2A-Version: 1.0 even when legacyCompat.enabled is true (avoids downgrade dance)', async () => {
+    // The discovery header is the SDK's native version regardless of
+    // legacyCompat: v0.3 detection is response-shape based (see
+    // `no downgrade dance` matrix tests below).
+    const resolver = new DefaultAgentCardResolver({
+      fetchImpl: mockFetch,
+      legacyCompat: { enabled: true },
+    });
+    mockFetch.mockResolvedValue(new Response(JSON.stringify(testAgentCard), { status: 200 }));
+
+    await resolver.resolve('https://example.com');
+
+    const init = mockFetch.mock.calls[0][1] as RequestInit | undefined;
+    expect((init?.headers as Record<string, string> | undefined)?.['A2A-Version']).toBe('1.0');
   });
 
   const pathTests = [
@@ -88,7 +131,10 @@ describe('DefaultAgentCardResolver', () => {
 
       expect(actual).to.deep.equal(testAgentCard);
       expect(mockFetch).toHaveBeenCalledExactlyOnceWith(
-        expect.objectContaining({ href: test.expected })
+        expect.objectContaining({ href: test.expected }),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'A2A-Version': '1.0' }),
+        })
       );
     });
 
@@ -106,7 +152,10 @@ describe('DefaultAgentCardResolver', () => {
 
       expect(actual).to.deep.equal(testAgentCard);
       expect(mockFetch).toHaveBeenCalledExactlyOnceWith(
-        expect.objectContaining({ href: test.expected })
+        expect.objectContaining({ href: test.expected }),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'A2A-Version': '1.0' }),
+        })
       );
     });
   });
@@ -146,5 +195,94 @@ describe('DefaultAgentCardResolver', () => {
     } catch (e: any) {
       expect(e.message).to.include('Failed to fetch Agent Card from https://example.com');
     }
+  });
+
+  // Matrix: v1.0+legacyCompat client against the three server flavors.
+  // Confirms that the *response shape* (not the request header value)
+  // determines which protocol version is used downstream. Together
+  // these tests guarantee:
+  //   - v1.0 servers (with or without legacyCompat) → v1.0 transport
+  //     (no downgrade dance).
+  //   - Pure v0.3 legacy servers → v0.3 transport (auto-detected).
+  describe('v1.0+legacyCompat client: no downgrade dance matrix', () => {
+    // v1.0 card shape: response from either a plain v1.0 server OR a
+    // v1.0+legacyCompat server whose legacy router short-circuits on
+    // A2A-Version: 1.0 via next('router').
+    const v1ServerCard: AgentCard = {
+      ...testAgentCard,
+      supportedInterfaces: [
+        {
+          url: 'https://example.com/v1',
+          protocolBinding: 'JSONRPC',
+          tenant: '',
+          protocolVersion: '1.0',
+        },
+      ],
+    };
+
+    // v0.3 card shape: response from a pure v0.3 legacy server. The
+    // v0.3 spec predates the A2A-Version header so such a server
+    // ignores it and returns its v0.3 card regardless.
+    const v03ServerCard = {
+      name: 'Legacy Agent',
+      description: 'A v0.3 server that predates A2A-Version',
+      version: '0.3.0',
+      url: 'https://example.com/legacy',
+      preferredTransport: 'JSONRPC',
+      protocolVersion: '0.3',
+      capabilities: { streaming: true },
+      defaultInputModes: ['text/plain'],
+      defaultOutputModes: ['text/plain'],
+      skills: [{ id: 's1', name: 'Skill', description: 'desc', tags: [] as string[] }],
+    };
+
+    it('v1.0 server → v1.0 transport (passes card through unchanged)', async () => {
+      const resolver = new DefaultAgentCardResolver({
+        fetchImpl: mockFetch,
+        legacyCompat: { enabled: true },
+      });
+      mockFetch.mockResolvedValue(new Response(JSON.stringify(v1ServerCard), { status: 200 }));
+
+      const card = await resolver.resolve('https://example.com');
+
+      expect(card.supportedInterfaces).to.have.length(1);
+      expect(card.supportedInterfaces[0]!.protocolVersion).to.equal('1.0');
+      // The factory will pick the v1.0 JsonRpcTransport for '1.0'.
+    });
+
+    it('v1.0+legacyCompat server → v1.0 transport (same v1.0 card; legacy router short-circuits on A2A-Version: 1.0)', async () => {
+      // A v1.0+legacyCompat server seeing A2A-Version: 1.0 returns
+      // its native v1.0 card (its legacy agent-card router does
+      // next('router') for non-legacy versions). Same wire shape as
+      // the plain v1.0 server above.
+      const resolver = new DefaultAgentCardResolver({
+        fetchImpl: mockFetch,
+        legacyCompat: { enabled: true },
+      });
+      mockFetch.mockResolvedValue(new Response(JSON.stringify(v1ServerCard), { status: 200 }));
+
+      const card = await resolver.resolve('https://example.com');
+
+      expect(card.supportedInterfaces).to.have.length(1);
+      expect(card.supportedInterfaces[0]!.protocolVersion).to.equal('1.0');
+    });
+
+    it('pure v0.3 server → v0.3 transport (response-shape detection + translation)', async () => {
+      const resolver = new DefaultAgentCardResolver({
+        fetchImpl: mockFetch,
+        legacyCompat: { enabled: true },
+      });
+      mockFetch.mockResolvedValue(new Response(JSON.stringify(v03ServerCard), { status: 200 }));
+
+      const card = await resolver.resolve('https://example.com');
+
+      // The resolver detected the v0.3 shape via isLegacyAgentCard
+      // and translated it to v1.0 internal shape with '0.3' stamped
+      // on every interface — so the factory will pick
+      // LegacyJsonRpcTransport.
+      expect(card.supportedInterfaces).to.have.length(1);
+      expect(card.supportedInterfaces[0]!.protocolVersion).to.equal('0.3');
+      expect(card.supportedInterfaces[0]!.url).to.equal('https://example.com/legacy');
+    });
   });
 });

--- a/test/compat/v0_3/client/card_resolver.spec.ts
+++ b/test/compat/v0_3/client/card_resolver.spec.ts
@@ -223,4 +223,17 @@ describe('DefaultAgentCardResolver with legacyCompat', () => {
 
     expect(card.supportedInterfaces).toBeUndefined();
   });
+
+  it('sends A2A-Version: 1.0 on discovery even when legacyCompat.enabled is true', async () => {
+    const mockFetch = makeMockFetch(minimalLegacyCard());
+    const resolver = new DefaultAgentCardResolver({
+      fetchImpl: mockFetch,
+      legacyCompat: { enabled: true },
+    });
+
+    await resolver.resolve('https://example.com');
+
+    const init = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect((init?.headers as Record<string, string> | undefined)?.['A2A-Version']).toBe('1.0');
+  });
 });

--- a/test/compat/v0_3/server/express/agent_card_handler.spec.ts
+++ b/test/compat/v0_3/server/express/agent_card_handler.spec.ts
@@ -160,7 +160,10 @@ describe('agentCardHandler with legacyCompat', () => {
       const response = await request(app).get('/.well-known/agent-card.json').expect(200);
 
       // v0.3 cards have a top-level `url`/`preferredTransport` shape and
-      // no `supportedInterfaces` array.
+      // no `supportedInterfaces` array. The dual-version card declares
+      // a v0.3 interface explicitly, so synthesis prefers it (the
+      // synthesize fallback only fires when NO legacy interface
+      // qualifies).
       assert.equal(response.body.name, 'Test Agent');
       assert.equal(response.body.url, 'https://api.example/legacy');
       assert.equal(response.body.preferredTransport, 'JSONRPC');
@@ -258,7 +261,11 @@ describe('agentCardHandler with legacyCompat', () => {
     });
 
     it('preserves an upstream Vary value on the VersionNotSupportedError (400) path', async () => {
-      const app = createAppWithUpstreamVary(modernOnlyCard(), { enabled: true });
+      // The only way the legacy router still throws
+      // VersionNotSupportedError under synthesis is when the v1.0 card
+      // has NO interfaces at all (so there's nothing to synthesize).
+      const emptyCard: AgentCard = { ...modernOnlyCard(), supportedInterfaces: [] };
+      const app = createAppWithUpstreamVary(emptyCard, { enabled: true });
       const response = await request(app)
         .get('/.well-known/agent-card.json')
         .set('A2A-Version', '0.3')
@@ -338,8 +345,14 @@ describe('agentCardHandler with legacyCompat', () => {
   });
 
   describe('error handling', () => {
-    it('returns 400 with a v0.3-shaped error when no legacy interface is advertised', async () => {
-      const app = createApp(modernOnlyCard(), { enabled: true });
+    it('returns 400 with a v0.3-shaped error when the v1.0 card has no interfaces at all', async () => {
+      // With synthesis enabled, a v1.0-only card normally produces a
+      // discoverable v0.3 card from the v1.0 interfaces. The only way
+      // to still trigger VersionNotSupportedError on the legacy path is
+      // a card with NO interfaces at all — there's nothing to
+      // synthesize from.
+      const emptyCard: AgentCard = { ...modernOnlyCard(), supportedInterfaces: [] };
+      const app = createApp(emptyCard, { enabled: true });
       const response = await request(app)
         .get('/.well-known/agent-card.json')
         .set('A2A-Version', '0.3')
@@ -364,6 +377,92 @@ describe('agentCardHandler with legacyCompat', () => {
     });
   });
 
+  describe('synthesized v0.3 card from a v1.0-only card', () => {
+    it('serves a synthesized v0.3 card on header-less requests against a v1.0-only card', async () => {
+      // With legacyCompat enabled, the legacy agent-card router now
+      // synthesizes a v0.3 card from the v1.0 interfaces instead of
+      // throwing VersionNotSupportedError. This mirrors the validator's
+      // implicit-v0.3 acceptance for request handling.
+      const app = createApp(modernOnlyCard(), { enabled: true });
+
+      const response = await request(app).get('/.well-known/agent-card.json').expect(200);
+
+      // v0.3 card shape: top-level url/preferredTransport, no
+      // supportedInterfaces array, protocolVersion === '0.3'.
+      assert.equal(response.body.url, 'https://api.example/v1');
+      assert.equal(response.body.preferredTransport, 'JSONRPC');
+      assert.equal(response.body.protocolVersion, '0.3');
+      assert.isUndefined(response.body.supportedInterfaces);
+    });
+
+    it('serves a synthesized v0.3 card on explicit A2A-Version: 0.3 against a v1.0-only card', async () => {
+      const app = createApp(modernOnlyCard(), { enabled: true });
+
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '0.3')
+        .expect(200);
+
+      assert.equal(response.body.url, 'https://api.example/v1');
+      assert.equal(response.body.protocolVersion, '0.3');
+    });
+
+    it('still serves the modern v1.0 card on explicit A2A-Version: 1.0', async () => {
+      const app = createApp(modernOnlyCard(), { enabled: true });
+
+      const response = await request(app)
+        .get('/.well-known/agent-card.json')
+        .set('A2A-Version', '1.0')
+        .expect(200);
+
+      // v1.0 shape preserved for v1.0 clients.
+      assert.isArray(response.body.supportedInterfaces);
+      assert.isUndefined(response.body.url);
+    });
+
+    it('emits Vary and ETag for synthesized cards too', async () => {
+      const app = createApp(modernOnlyCard(), { enabled: true });
+
+      const response = await request(app).get('/.well-known/agent-card.json').expect(200);
+
+      assert.equal(response.headers['vary'], 'A2A-Version');
+      assert.isDefined(response.headers['etag']);
+    });
+
+    it('passes through all v1.0 interfaces as additionalInterfaces in the synthesized card', async () => {
+      const multiBindingCard: AgentCard = {
+        ...modernOnlyCard(),
+        supportedInterfaces: [
+          {
+            url: 'https://api.example/v1/jsonrpc',
+            protocolBinding: 'JSONRPC',
+            tenant: '',
+            protocolVersion: '1.0',
+          },
+          {
+            url: 'https://api.example/v1/grpc',
+            protocolBinding: 'GRPC',
+            tenant: '',
+            protocolVersion: '1.0',
+          },
+        ],
+      };
+      const app = createApp(multiBindingCard, { enabled: true });
+
+      const response = await request(app).get('/.well-known/agent-card.json').expect(200);
+
+      // Primary is the first v1.0 interface; the rest become
+      // additionalInterfaces in v0.3 shape.
+      assert.equal(response.body.url, 'https://api.example/v1/jsonrpc');
+      assert.equal(response.body.preferredTransport, 'JSONRPC');
+      assert.equal(response.body.protocolVersion, '0.3');
+      assert.isArray(response.body.additionalInterfaces);
+      assert.equal(response.body.additionalInterfaces.length, 1);
+      assert.equal(response.body.additionalInterfaces[0].url, 'https://api.example/v1/grpc');
+      assert.equal(response.body.additionalInterfaces[0].transport, 'GRPC');
+    });
+  });
+
   describe('back-compat (legacyCompat omitted)', () => {
     it('serves the v1.0 card regardless of A2A-Version header', async () => {
       const app = createApp(legacyOnlyCard());
@@ -385,6 +484,18 @@ describe('legacyAgentCardRouter (standalone)', () => {
     const response = await request(app).get('/.well-known/agent-card.json').expect(200);
 
     assert.equal(response.body.url, 'https://api.example/a2a');
+    assert.equal(response.body.preferredTransport, 'JSONRPC');
+    assert.equal(response.body.protocolVersion, '0.3');
+  });
+
+  it('synthesizes a v0.3 card from a v1.0-only card when mounted directly', async () => {
+    // The standalone router uses the same `synthesize: true` mode as
+    // when it's mounted by the core agentCardHandler under
+    // `legacyCompat: { enabled: true }`.
+    const app = createLegacyOnlyApp(modernOnlyCard());
+    const response = await request(app).get('/.well-known/agent-card.json').expect(200);
+
+    assert.equal(response.body.url, 'https://api.example/v1');
     assert.equal(response.body.preferredTransport, 'JSONRPC');
     assert.equal(response.body.protocolVersion, '0.3');
   });

--- a/test/compat/v0_3/server/express/agent_card_handler.spec.ts
+++ b/test/compat/v0_3/server/express/agent_card_handler.spec.ts
@@ -378,11 +378,7 @@ describe('agentCardHandler with legacyCompat', () => {
   });
 
   describe('synthesized v0.3 card from a v1.0-only card', () => {
-    it('serves a synthesized v0.3 card on header-less requests against a v1.0-only card', async () => {
-      // With legacyCompat enabled, the legacy agent-card router now
-      // synthesizes a v0.3 card from the v1.0 interfaces instead of
-      // throwing VersionNotSupportedError. This mirrors the validator's
-      // implicit-v0.3 acceptance for request handling.
+    it('serves a synthesized v0.3 card on header-less requests (server-side §3.6.2 default-to-0.3 fallback)', async () => {
       const app = createApp(modernOnlyCard(), { enabled: true });
 
       const response = await request(app).get('/.well-known/agent-card.json').expect(200);

--- a/test/compat/v0_3/translate/agent_card.spec.ts
+++ b/test/compat/v0_3/translate/agent_card.spec.ts
@@ -280,5 +280,157 @@ describe('agent_card', () => {
       const core = toCoreAgentCard(compat);
       expect(core.supportedInterfaces[0]!.protocolBinding).toBe('JSONRPC');
     });
+
+    describe('synthesize option', () => {
+      function v1OnlyCore(): V1AgentCard {
+        return {
+          name: 'Agent',
+          description: 'desc',
+          version: '1.2.3',
+          supportedInterfaces: [
+            {
+              url: 'https://api.example/v1',
+              protocolBinding: 'JSONRPC',
+              tenant: '',
+              protocolVersion: '1.0',
+            },
+          ],
+          provider: undefined,
+          capabilities: {
+            streaming: undefined,
+            pushNotifications: undefined,
+            extensions: [],
+            extendedAgentCard: undefined,
+          },
+          securitySchemes: {},
+          securityRequirements: [],
+          defaultInputModes: [],
+          defaultOutputModes: [],
+          skills: [],
+          signatures: [],
+        };
+      }
+
+      it('accepts a v1.0-only card without throwing', () => {
+        const core = v1OnlyCore();
+        expect(() => toCompatAgentCard(core, { synthesize: true })).not.toThrow();
+      });
+
+      it('emits protocolVersion 0.3 regardless of the source version', () => {
+        const core = v1OnlyCore();
+        const compat = toCompatAgentCard(core, { synthesize: true });
+        expect(compat.protocolVersion).toBe('0.3');
+      });
+
+      it('keeps the underlying v1.0 interface URL and binding', () => {
+        const core = v1OnlyCore();
+        const compat = toCompatAgentCard(core, { synthesize: true });
+        expect(compat.url).toBe('https://api.example/v1');
+        expect(compat.preferredTransport).toBe('JSONRPC');
+      });
+
+      it('passes through additional v1.0 interfaces as additionalInterfaces', () => {
+        const core = v1OnlyCore();
+        core.supportedInterfaces.push({
+          url: 'https://api.example/grpc',
+          protocolBinding: 'GRPC',
+          tenant: '',
+          protocolVersion: '1.0',
+        });
+        const compat = toCompatAgentCard(core, { synthesize: true });
+        expect(compat.url).toBe('https://api.example/v1');
+        expect(compat.additionalInterfaces).toHaveLength(1);
+        expect(compat.additionalInterfaces?.[0]).toEqual({
+          url: 'https://api.example/grpc',
+          transport: 'GRPC',
+        });
+      });
+
+      it('still throws when there are no interfaces at all', () => {
+        const core = v1OnlyCore();
+        core.supportedInterfaces = [];
+        expect(() => toCompatAgentCard(core, { synthesize: true })).toThrow(
+          VersionNotSupportedError
+        );
+      });
+
+      it('forces protocolVersion to 0.3 even when a v1.0 entry is the primary', () => {
+        // Belt-and-braces: even if the source primary interface declares
+        // a non-legacy version explicitly, the synthesized card must
+        // present itself as v0.3 to legacy clients.
+        const core = v1OnlyCore();
+        const compat = toCompatAgentCard(core, { synthesize: true });
+        // primary core interface is v1.0 but emitted version is v0.3.
+        expect(core.supportedInterfaces[0]!.protocolVersion).toBe('1.0');
+        expect(compat.protocolVersion).toBe('0.3');
+      });
+
+      it('default (no options) preserves strict filter and throws on v1.0-only', () => {
+        const core = v1OnlyCore();
+        expect(() => toCompatAgentCard(core)).toThrow(VersionNotSupportedError);
+      });
+
+      it('default (synthesize: false) preserves strict filter and throws on v1.0-only', () => {
+        const core = v1OnlyCore();
+        expect(() => toCompatAgentCard(core, { synthesize: false })).toThrow(
+          VersionNotSupportedError
+        );
+      });
+
+      it('synthesize: true still prefers a declared v0.3 interface when present (dual card)', () => {
+        // Synthesis is a fallback for cards with NO legacy interface.
+        // When a v0.3 entry is declared explicitly it MUST still be
+        // picked as the primary, so dual-version deployments don't
+        // observe a URL change after the synthesize option is added.
+        const core: V1AgentCard = {
+          ...v1OnlyCore(),
+          supportedInterfaces: [
+            {
+              url: 'https://api.example/v1',
+              protocolBinding: 'JSONRPC',
+              tenant: '',
+              protocolVersion: '1.0',
+            },
+            {
+              url: 'https://api.example/legacy',
+              protocolBinding: 'JSONRPC',
+              tenant: '',
+              protocolVersion: '0.3',
+            },
+          ],
+        };
+        const compat = toCompatAgentCard(core, { synthesize: true });
+        expect(compat.url).toBe('https://api.example/legacy');
+        expect(compat.protocolVersion).toBe('0.3');
+      });
+
+      it('synthesize: true with mixed versions (no legacy entry) falls back to the first interface', () => {
+        // No legacy-range entry -> the fallback kicks in and the
+        // first non-legacy entry becomes the primary, with emitted
+        // protocolVersion stamped as 0.3.
+        const core: V1AgentCard = {
+          ...v1OnlyCore(),
+          supportedInterfaces: [
+            {
+              url: 'https://api.example/v1',
+              protocolBinding: 'JSONRPC',
+              tenant: '',
+              protocolVersion: '1.0',
+            },
+            {
+              url: 'https://api.example/v2',
+              protocolBinding: 'JSONRPC',
+              tenant: '',
+              protocolVersion: '2.0',
+            },
+          ],
+        };
+        const compat = toCompatAgentCard(core, { synthesize: true });
+        expect(compat.url).toBe('https://api.example/v1');
+        expect(compat.protocolVersion).toBe('0.3');
+        expect(compat.additionalInterfaces).toHaveLength(1);
+        expect(compat.additionalInterfaces?.[0]?.url).toBe('https://api.example/v2');
+      });
+    });
   });
 });

--- a/test/compat/v0_3/translate/agent_card.spec.ts
+++ b/test/compat/v0_3/translate/agent_card.spec.ts
@@ -354,6 +354,17 @@ describe('agent_card', () => {
         );
       });
 
+      it('does not crash when supportedInterfaces is undefined (defensive)', () => {
+        const core = v1OnlyCore();
+        // Cast through unknown to satisfy the non-nullable proto type
+        // while modelling a real-world malformed input.
+        (core as unknown as { supportedInterfaces?: unknown }).supportedInterfaces = undefined;
+        expect(() => toCompatAgentCard(core, { synthesize: true })).toThrow(
+          VersionNotSupportedError
+        );
+        expect(() => toCompatAgentCard(core)).toThrow(VersionNotSupportedError);
+      });
+
       it('forces protocolVersion to 0.3 even when a v1.0 entry is the primary', () => {
         // Belt-and-braces: even if the source primary interface declares
         // a non-legacy version explicitly, the synthesized card must

--- a/test/server/express/express_app.spec.ts
+++ b/test/server/express/express_app.spec.ts
@@ -651,7 +651,12 @@ describe('A2AExpressApp', () => {
       setupA2ARoutes(expressApp, mockRequestHandler);
     });
 
-    it('should accept requests without A2A-Version header (defaults to 0.3)', async () => {
+    it('should reject header-less requests against a v1.0-only card when legacyCompat is omitted', async () => {
+      // Without legacyCompat, the v1.0-only `testAgentCard` rejects
+      // the §3.6.2 default-to-'0.3' because '0.3' is not declared in
+      // `supportedInterfaces`. This is the strict-mode behavior; the
+      // implicit-v0.3 acceptance is gated on opting into the compat
+      // layer (see the `legacy v0.3 JSON-RPC dispatch` block).
       const response = await request(expressApp)
         .post('/')
         .send(createRpcRequest('1', 'GetTask', { id: 'test-task' }))
@@ -768,17 +773,47 @@ describe('A2AExpressApp', () => {
       expect(legacyHandleStub).toHaveBeenCalledTimes(1);
     });
 
-    it('rejects legacy requests when the card declares no v0.3 interface', async () => {
-      // testAgentCard only declares the v1.0 interface; no compat opt-in.
+    it('accepts header-less legacy requests against a v1.0-only card when legacyCompat is enabled', async () => {
+      // testAgentCard only declares the v1.0 interface. With
+      // legacyCompat enabled, the validator implicitly accepts the
+      // §3.6.2 default-to-'0.3' for any binding the card already
+      // exposes — so a header-less v0.3-shaped request still routes
+      // to the legacy handler without forcing operators to duplicate
+      // every v1.0 entry with a v0.3 stub.
       (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(testAgentCard);
+      legacyHandleStub.mockResolvedValue({
+        jsonrpc: '2.0',
+        id: 'req-4',
+        result: { kind: 'task' },
+      });
 
-      const response = await request(expressApp)
+      await request(expressApp)
         .post('/')
         .send(createRpcRequest('req-4', 'message/send'))
-        .expect(500);
+        .expect(200);
 
-      expect(response.body.error.code).to.equal(A2A_ERROR_CODE.VERSION_NOT_SUPPORTED);
-      expect(legacyHandleStub).not.toHaveBeenCalled();
+      expect(legacyHandleStub).toHaveBeenCalledTimes(1);
+      expect(handleStub).not.toHaveBeenCalled();
+    });
+
+    it('accepts explicit A2A-Version: 0.3 against a v1.0-only card when legacyCompat is enabled', async () => {
+      // Same as above but with the header explicitly set rather than
+      // relying on the §3.6.2 missing-header default.
+      (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(testAgentCard);
+      legacyHandleStub.mockResolvedValue({
+        jsonrpc: '2.0',
+        id: 'req-explicit-03',
+        result: { kind: 'task' },
+      });
+
+      await request(expressApp)
+        .post('/')
+        .set('A2A-Version', '0.3')
+        .send(createRpcRequest('req-explicit-03', 'message/send'))
+        .expect(200);
+
+      expect(legacyHandleStub).toHaveBeenCalledTimes(1);
+      expect(handleStub).not.toHaveBeenCalled();
     });
 
     it('streams SSE responses on the legacy path', async () => {

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -844,7 +844,12 @@ describe('restHandler', () => {
   });
 
   describe('A2A-Version header validation', () => {
-    it('should reject requests without A2A-Version header (defaults to 0.3, not supported)', async () => {
+    it('should reject header-less requests against a v1.0-only card when legacyCompat is omitted', async () => {
+      // Without legacyCompat, the v1.0-only `testAgentCard` rejects
+      // the §3.6.2 default-to-'0.3' because '0.3' is not declared in
+      // `supportedInterfaces`. This is the strict-mode behavior; the
+      // implicit-v0.3 acceptance is gated on opting into the compat
+      // layer (see the `legacy v0.3 REST dispatch` block below).
       const response = await request(app).get('/tasks/task-1').expect(400);
 
       assert.property(response.body, 'error');
@@ -866,6 +871,60 @@ describe('restHandler', () => {
       assert.property(response.body, 'error');
       assert.equal(response.body.error.details[0].reason, 'VERSION_NOT_SUPPORTED');
       assert.include(response.body.error.message, '9.9');
+    });
+
+    it('should accept header-less requests against a v1.0-only card when legacyCompat is enabled', async () => {
+      // With legacyCompat enabled, the validator implicitly accepts
+      // the §3.6.2 default-to-'0.3' for any binding the card already
+      // exposes, so a v0.3 client sending no header against a
+      // v1.0-only `testAgentCard` is now accepted.
+      (mockRequestHandler.getTask as Mock).mockResolvedValue(testTask);
+      const compatApp = express();
+      compatApp.use(
+        restHandler({
+          requestHandler: mockRequestHandler,
+          userBuilder: UserBuilder.noAuthentication,
+          legacyCompat: { enabled: true },
+        })
+      );
+
+      await request(compatApp).get('/tasks/task-1').expect(200);
+    });
+
+    it('should accept explicit A2A-Version: 0.3 against a v1.0-only card when legacyCompat is enabled', async () => {
+      (mockRequestHandler.getTask as Mock).mockResolvedValue(testTask);
+      const compatApp = express();
+      compatApp.use(
+        restHandler({
+          requestHandler: mockRequestHandler,
+          userBuilder: UserBuilder.noAuthentication,
+          legacyCompat: { enabled: true },
+        })
+      );
+
+      // /tasks/:taskId is a v1.0 path; the legacy router only owns
+      // `/v1/...`, so the v1.0 router handles this request — but its
+      // validator now accepts '0.3' under legacyCompat.
+      await request(compatApp).get('/tasks/task-1').set('A2A-Version', '0.3').expect(200);
+    });
+
+    it('should still reject unsupported versions (e.g. 9.9) when legacyCompat is enabled', async () => {
+      const compatApp = express();
+      compatApp.use(
+        restHandler({
+          requestHandler: mockRequestHandler,
+          userBuilder: UserBuilder.noAuthentication,
+          legacyCompat: { enabled: true },
+        })
+      );
+
+      const response = await request(compatApp)
+        .get('/tasks/task-1')
+        .set('A2A-Version', '9.9')
+        .expect(400);
+
+      assert.property(response.body, 'error');
+      assert.equal(response.body.error.details[0].reason, 'VERSION_NOT_SUPPORTED');
     });
   });
 
@@ -1040,17 +1099,29 @@ describe('restHandler', () => {
       expect(legacySendMessageStub).toHaveBeenCalledTimes(1);
     });
 
-    it('rejects legacy requests when the card declares no v0.3 interface', async () => {
-      // Restore the v1.0-only card.
+    it('accepts legacy requests against a v1.0-only card when legacyCompat is enabled', async () => {
+      // Restore the v1.0-only card; with legacyCompat enabled, the
+      // validator implicitly accepts the §3.6.2 default-to-'0.3' for
+      // any binding the card already exposes — so the legacy router
+      // handles the request even though the card declares no v0.3
+      // HTTP+JSON interface.
       (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(testAgentCard);
+      legacySendMessageStub.mockResolvedValue({
+        kind: 'task',
+        id: 'legacy-task-v1card',
+        contextId: 'ctx',
+        status: { state: 'working' },
+      });
 
       const response = await request(dualApp)
         .post('/v1/message:send')
         .send(legacyMessageBody)
-        .expect(400);
+        .expect(201);
 
-      assert.equal(response.body.code, -32009); // VERSION_NOT_SUPPORTED
-      expect(legacySendMessageStub).not.toHaveBeenCalled();
+      assert.equal(response.body.kind, 'task');
+      assert.equal(response.body.id, 'legacy-task-v1card');
+      expect(legacySendMessageStub).toHaveBeenCalledTimes(1);
+      expect(v1SendMessageStub).not.toHaveBeenCalled();
     });
 
     it('streams SSE responses on the legacy path', async () => {

--- a/test/server/version.spec.ts
+++ b/test/server/version.spec.ts
@@ -169,6 +169,67 @@ describe('protocolBinding filtering', () => {
   });
 });
 
+describe('validateVersion with legacyCompat option', () => {
+  it('accepts 0.3 against a v1.0-only card for the requested binding', () => {
+    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
+    expect(() =>
+      validateVersion('0.3', card, 'JSONRPC', { legacyCompat: { enabled: true } })
+    ).not.toThrow();
+  });
+
+  it('still rejects 0.3 when the card has no interface for the binding at all', () => {
+    // Card only declares HTTP+JSON; a JSONRPC request must not slip
+    // through the legacyCompat door because the agent doesn't serve
+    // JSONRPC.
+    const card = createAgentCard([{ protocolBinding: 'HTTP+JSON', protocolVersion: '1.0' }]);
+    expect(() =>
+      validateVersion('0.3', card, 'JSONRPC', { legacyCompat: { enabled: true } })
+    ).toThrow(VersionNotSupportedError);
+  });
+
+  it('still rejects 0.3 when the card has no interfaces at all', () => {
+    const card = createAgentCard([]);
+    expect(() =>
+      validateVersion('0.3', card, 'JSONRPC', { legacyCompat: { enabled: true } })
+    ).toThrow(VersionNotSupportedError);
+  });
+
+  it('still rejects unsupported versions (e.g. 9.9) with legacyCompat enabled', () => {
+    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
+    expect(() =>
+      validateVersion('9.9', card, 'JSONRPC', { legacyCompat: { enabled: true } })
+    ).toThrow(VersionNotSupportedError);
+  });
+
+  it('accepts 0.3 even when protocolBinding is omitted, as long as some interface exists', () => {
+    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
+    expect(() =>
+      validateVersion('0.3', card, undefined, { legacyCompat: { enabled: true } })
+    ).not.toThrow();
+  });
+
+  it('continues to accept declared v1.0 versions when legacyCompat is enabled', () => {
+    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
+    expect(() =>
+      validateVersion('1.0', card, 'JSONRPC', { legacyCompat: { enabled: true } })
+    ).not.toThrow();
+  });
+
+  it('legacyCompat: { enabled: false } behaves identically to omitted option', () => {
+    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
+    expect(() =>
+      validateVersion('0.3', card, 'JSONRPC', { legacyCompat: { enabled: false } })
+    ).toThrow(VersionNotSupportedError);
+  });
+
+  it('does not modify the agent card when synthesizing the v0.3 entry', () => {
+    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
+    validateVersion('0.3', card, 'JSONRPC', { legacyCompat: { enabled: true } });
+    // getSupportedVersions should still report only the explicitly declared versions.
+    expect(getSupportedVersions(card).has('0.3')).toBe(false);
+  });
+});
+
 describe('ServerCallContext version', () => {
   it('should default requestedVersion to 0.3 when not provided', () => {
     const context = new ServerCallContext();


### PR DESCRIPTION
# Description

This pull request enhances the v0.3 compatibility ("legacyCompat") layer, making it easier for operators to support legacy clients without duplicating interface declarations. The main improvement is that, when `legacyCompat` is enabled, servers can serve v0.3 clients using only v1.0 interface declarations—both for request validation and for the discoverable agent card endpoint. The changes also clarify and document this behavior, update validation logic, and add/refine tests.

Closes #474  🦕
