### PR TITLE
feat: implement TCK workflow and SUT for tests, adjust ci

### DIFF
--- a/.github/workflows/run-itk-nightly.yaml
+++ b/.github/workflows/run-itk-nightly.yaml
@@ -16,7 +16,7 @@ on:
   # PR workflow's `branches: ["main", "epic"]` configuration. Drop the
   # `epic` entry once this is merged to `main` and the cron takes over.
   push:
-    branches: ["main", "epic"]
+    branches: ["main", "epic/**"]
     paths:
       - 'src/**'
       - 'itk/**'

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -2,7 +2,7 @@ name: Run ITK
 
 on:
   push:
-    branches: ["main", "epic"]
+    branches: ["main", "epic/**"]
   pull_request:
     paths:
       - 'src/**'

--- a/.github/workflows/run-tck.yaml
+++ b/.github/workflows/run-tck.yaml
@@ -2,9 +2,9 @@ name: Run TCK
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main", "epic/**"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main", "epic/**"]
     paths-ignore:
       - '**.md'
       - 'LICENSE'
@@ -12,18 +12,18 @@ on:
       - 'test/**'
       - 'src/samples/**'
 
-
 env:
-  # Tag of the TCK
-  TCK_VERSION: 0.3.0.beta3
+  # Tag of the TCK to check out from a2aproject/a2a-tck. Pinned so that
+  # a new TCK release that introduces failing requirements does not
+  # silently break this workflow.
+  TCK_VERSION: 1.0.0.alpha2
   # Tells uv to not need a venv, and instead use system
   UV_SYSTEM_PYTHON: 1
-  # Base URL for the SUT agent
+  # Base URL for the SUT agent. The TCK probes
+  # `${SUT_BASE_URL}/.well-known/agent-card.json` and uses the
+  # `supportedInterfaces` entries from the returned card to dispatch
+  # per-transport tests.
   SUT_BASE_URL: http://localhost:41241
-  # Base URL for the SUT agent JSON-RPC transport
-  SUT_JSONRPC_URL: http://localhost:41241/a2a/jsonrpc
-  # Slow system on CI
-  TCK_STREAMING_TIMEOUT: 5.0
 
 # Only run the latest job
 concurrency:
@@ -65,8 +65,8 @@ jobs:
         working-directory: tck/a2a-tck
       - name: Start SUT
         run: |
-          cd tck
-          npm run tck:sut-agent &
+          npm --prefix tck run tck:sut-agent > sut.log 2>&1 &
+          echo $! > sut.pid
       - name: Wait for SUT to start
         run: |
           URL="${{ env.SUT_BASE_URL }}/.well-known/agent-card.json"
@@ -76,46 +76,59 @@ jobs:
           START_TIME=$(date +%s)
 
           while true; do
-            # Calculate elapsed time
             CURRENT_TIME=$(date +%s)
             ELAPSED_TIME=$((CURRENT_TIME - START_TIME))
-
-            # Check for timeout
             if [ "$ELAPSED_TIME" -ge "$TIMEOUT" ]; then
                 echo "❌ Timeout: Server did not respond with status $EXPECTED_STATUS within $TIMEOUT seconds."
+                echo "----- SUT log -----"
+                cat sut.log || true
                 exit 1
             fi
 
-            # Get HTTP status code. || true is to reporting a failure to connect as an error
             HTTP_STATUS=$(curl --output /dev/null --silent --write-out "%{http_code}" "$URL") || true
-            echo "STATUS: ${HTTP_STATUS}"
-
-            # Check if we got the correct status code
             if [ "$HTTP_STATUS" -eq "$EXPECTED_STATUS" ]; then
                 echo "✅ Server is up! Received status $HTTP_STATUS after $ELAPSED_TIME seconds."
-                break;
+                break
             fi
 
-            # Wait before retrying
             echo "⏳ Server not ready (status: $HTTP_STATUS). Retrying in $RETRY_INTERVAL seconds..."
             sleep "$RETRY_INTERVAL"
           done
-          
-      - name: Run TCK (mandatory)
-        id: run-tck-mandatory
-        timeout-minutes: 5
+
+      - name: Run TCK (MUST)
+        id: run-tck-must
+        timeout-minutes: 10
         run: |
-          ./run_tck.py --sut-url ${{ env.SUT_JSONRPC_URL }} --category mandatory --transports jsonrpc,rest,grpc
+          ./run_tck.py --sut-host ${{ env.SUT_BASE_URL }} --level must -v
         working-directory: tck/a2a-tck
-      - name: Run TCK (capabilities)
-        id: run-tck-capabilities
-        timeout-minutes: 5
+
+      - name: Run TCK (SHOULD)
+        id: run-tck-should
+        if: always() && steps.run-tck-must.outcome != 'cancelled'
+        timeout-minutes: 10
         run: |
-          ./run_tck.py --sut-url ${{ env.SUT_JSONRPC_URL }} --category capabilities --transports jsonrpc,rest,grpc
+          ./run_tck.py --sut-host ${{ env.SUT_BASE_URL }} --level should -v
         working-directory: tck/a2a-tck
+
+      - name: Upload compatibility reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tck-reports-node-${{ matrix.node-version }}
+          path: tck/a2a-tck/reports/
+          if-no-files-found: warn
+
+      - name: Print SUT log
+        if: always()
+        run: |
+          echo "----- SUT log -----"
+          cat sut.log || true
+
       - name: Stop SUT
         if: always()
         run: |
-          # Find and kill the SUT process
-          pkill -f "npm run tck:sut-agent" || true
-          sleep 2
+          if [ -f sut.pid ]; then
+            kill "$(cat sut.pid)" 2>/dev/null || true
+          fi
+          pkill -f "tsx agent/index.ts" 2>/dev/null || true
+          sleep 1

--- a/itk/run_error_tests.sh
+++ b/itk/run_error_tests.sh
@@ -139,7 +139,10 @@ else
   FAILED=$((FAILED + 1))
 fi
 
-check_json "$BODY" "error.status" "FAILED_PRECONDITION" "error.status is FAILED_PRECONDITION"
+# VersionNotSupported is a capability-gated rejection — UNIMPLEMENTED
+# distinguishes "agent does not implement this version" from "current
+# state forbids this request" (FAILED_PRECONDITION).
+check_json "$BODY" "error.status" "UNIMPLEMENTED" "error.status is UNIMPLEMENTED"
 check_json "$BODY" "error.details.0.reason" "VERSION_NOT_SUPPORTED" "ErrorInfo reason"
 
 # --- REST: Content-Type on error response ---
@@ -149,11 +152,13 @@ CT=$(curl -s -o /dev/null -w "%{content_type}" \
   -H "A2A-Version: 1.0" \
   "${BASE_REST}/tasks/nonexistent-task-id")
 
-if echo "$CT" | grep -q "application/a2a+json"; then
-  echo "  ✓ Content-Type is application/a2a+json"
+# The REST binding emits plain `application/json` for both success
+# and error responses so generic HTTP+JSON clients can interoperate.
+if echo "$CT" | grep -q "application/json"; then
+  echo "  ✓ Content-Type is application/json"
   PASSED=$((PASSED + 1))
 else
-  echo "  ✗ Content-Type (expected application/a2a+json, got ${CT})"
+  echo "  ✗ Content-Type (expected application/json, got ${CT})"
   FAILED=$((FAILED + 1))
 fi
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -151,13 +151,17 @@ export function buildErrorInfo(
 export const A2A_ERROR_GRPC_STATUS: Record<string, string> = {
   TaskNotFoundError: 'NOT_FOUND',
   TaskNotCancelableError: 'FAILED_PRECONDITION',
-  PushNotificationNotSupportedError: 'FAILED_PRECONDITION',
-  UnsupportedOperationError: 'FAILED_PRECONDITION',
+  // Capability-gated rejections (PushNotifications, UnsupportedOperation,
+  // VersionNotSupported) surface as UNIMPLEMENTED rather than
+  // FAILED_PRECONDITION so a client can distinguish "agent does not
+  // implement this" from "current state forbids this operation".
+  PushNotificationNotSupportedError: 'UNIMPLEMENTED',
+  UnsupportedOperationError: 'UNIMPLEMENTED',
   ContentTypeNotSupportedError: 'INVALID_ARGUMENT',
   InvalidAgentResponseError: 'INTERNAL',
   ExtendedAgentCardNotConfiguredError: 'FAILED_PRECONDITION',
   ExtensionSupportRequiredError: 'FAILED_PRECONDITION',
-  VersionNotSupportedError: 'FAILED_PRECONDITION',
+  VersionNotSupportedError: 'UNIMPLEMENTED',
   RequestMalformedError: 'INVALID_ARGUMENT',
   GenericError: 'INTERNAL',
 };

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -151,10 +151,6 @@ export function buildErrorInfo(
 export const A2A_ERROR_GRPC_STATUS: Record<string, string> = {
   TaskNotFoundError: 'NOT_FOUND',
   TaskNotCancelableError: 'FAILED_PRECONDITION',
-  // Capability-gated rejections (PushNotifications, UnsupportedOperation,
-  // VersionNotSupported) surface as UNIMPLEMENTED rather than
-  // FAILED_PRECONDITION so a client can distinguish "agent does not
-  // implement this" from "current state forbids this operation".
   PushNotificationNotSupportedError: 'UNIMPLEMENTED',
   UnsupportedOperationError: 'UNIMPLEMENTED',
   ContentTypeNotSupportedError: 'INVALID_ARGUMENT',

--- a/src/server/events/execution_event_queue.ts
+++ b/src/server/events/execution_event_queue.ts
@@ -1,5 +1,5 @@
 import { ExecutionEventBus, AgentExecutionEvent } from './execution_event_bus.js';
-import { TERMINAL_STATE_LIST } from '../utils.js';
+import { INTERRUPTED_STATE_LIST, TERMINAL_STATE_LIST } from '../utils.js';
 
 /**
  * An async queue that subscribes to an ExecutionEventBus for events
@@ -39,11 +39,21 @@ export class ExecutionEventQueue {
       if (this.eventQueue.length > 0) {
         const event = this.eventQueue.shift()!;
         yield event;
+        // A consumer's event loop terminates on:
+        //   * a Message (the only event a stateless agent ever produces);
+        //   * a terminal Task status (COMPLETED / FAILED / CANCELED /
+        //     REJECTED) — the task can never produce further events;
+        //   * an interrupted Task status (INPUT_REQUIRED / AUTH_REQUIRED)
+        //     — the executor has returned and is awaiting a fresh
+        //     message, so blocking consumers must stop iterating; the
+        //     underlying bus stays alive in `DefaultRequestHandler` so
+        //     resubscribers can attach later.
         if (
           event.kind === 'message' ||
           (event.kind === 'statusUpdate' &&
             event.data.status &&
-            TERMINAL_STATE_LIST.includes(event.data.status.state))
+            (TERMINAL_STATE_LIST.includes(event.data.status.state) ||
+              INTERRUPTED_STATE_LIST.includes(event.data.status.state)))
         ) {
           this.handleFinished();
           break;

--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -10,11 +10,11 @@ import { JSONRPCResponse } from '../transports/jsonrpc/jsonrpc_transport_handler
 import { A2ARequestHandler } from '../request_handler/a2a_request_handler.js';
 import { JsonRpcTransportHandler } from '../transports/jsonrpc/jsonrpc_transport_handler.js';
 import { ServerCallContext } from '../context.js';
-import { A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER } from '../../constants.js';
+import { A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER, JSON_CONTENT_TYPE } from '../../constants.js';
 import { UserBuilder } from './common.js';
 import { SSE_HEADERS, formatSSEEvent, formatSSEErrorEvent } from '../../sse_utils.js';
 import { Extensions } from '../../extensions.js';
-import { RequestMalformedError } from '../../errors.js';
+import { ContentTypeNotSupportedError, RequestMalformedError } from '../../errors.js';
 import { validateVersion } from '../version.js';
 import { LegacyJsonRpcTransportHandler, isLegacyJsonRpcMethod } from '../../compat/v0_3/index.js';
 import { LEGACY_HTTP_EXTENSION_HEADER } from '../../compat/v0_3/constants.js';
@@ -79,6 +79,11 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
 
   const router = express.Router();
 
+  // §9.1 JSON-RPC requests MUST use `application/json`. Reject any
+  // other content type with `ContentTypeNotSupportedError` (-32005)
+  // rather than letting `express.json()` ignore the body and the
+  // dispatcher fall back to a misleading `InvalidParamsError` (-32602).
+  router.use(contentTypeGuard);
   router.use(express.json(), jsonErrorHandler);
 
   router.post('/', async (req: Request, res: Response) => {
@@ -131,17 +136,38 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
       if (typeof (rpcResponseOrStream as AsyncGenerator)?.[Symbol.asyncIterator] === 'function') {
         const stream = rpcResponseOrStream as AsyncGenerator<JSONRPCResponse, void, undefined>;
 
-        // Set SSE headers using shared utility
+        // Peek the first event BEFORE flushing SSE headers so that an
+        // early failure (e.g. `resubscribe` on a terminal task, which
+        // throws `UnsupportedOperationError`) surfaces as a proper
+        // JSON-RPC error response with the right HTTP status rather
+        // than a 200 SSE stream carrying a single error event — the
+        // latter looks like a successful subscription to most clients.
+        const iterator = stream[Symbol.asyncIterator]();
+        let firstResult: IteratorResult<JSONRPCResponse>;
+        try {
+          firstResult = await iterator.next();
+        } catch (streamError) {
+          console.error(`Pre-stream error for request ${req.body?.id}:`, streamError);
+          const errorResponse: JSONRPCErrorResponse = {
+            jsonrpc: '2.0',
+            id: req.body?.id || null,
+            error: mapToError(streamError),
+          };
+          res.status(200).json(errorResponse);
+          return;
+        }
+
+        // First event succeeded — now switch to SSE.
         Object.entries(SSE_HEADERS).forEach(([key, value]) => {
           res.setHeader(key, value);
         });
-
         res.flushHeaders();
 
         try {
-          for await (const event of stream) {
-            // Each event from the stream is already a JSONRPCResult
-            // Use shared formatSSEEvent utility
+          if (!firstResult.done) {
+            res.write(formatSSEEvent(firstResult.value));
+          }
+          for await (const event of { [Symbol.asyncIterator]: () => iterator }) {
             res.write(formatSSEEvent(event));
           }
         } catch (streamError) {
@@ -188,6 +214,41 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
 
   return router;
 }
+
+/**
+ * Express middleware that rejects requests whose Content-Type is not
+ * `application/json` (§9.1) with `ContentTypeNotSupportedError`
+ * (-32005). Bodyless requests (GET, OPTIONS, …) and requests without a
+ * Content-Type header pass through; only POSTs that explicitly declare
+ * a non-JSON content type are rejected.
+ */
+const contentTypeGuard: RequestHandler = (req, res, next) => {
+  // Only enforce on requests that actually carry a body. The JSON-RPC
+  // binding is POST-only, but we deliberately keep the check tied to
+  // the Content-Type header so other verbs (used for health probes,
+  // CORS preflights, etc.) keep working.
+  const rawContentType = req.header('content-type');
+  if (!rawContentType) {
+    next();
+    return;
+  }
+  // Strip charset and other params before comparing.
+  const mediaType = rawContentType.split(';', 1)[0].trim().toLowerCase();
+  if (mediaType === JSON_CONTENT_TYPE) {
+    next();
+    return;
+  }
+  const errorResponse: JSONRPCErrorResponse = {
+    jsonrpc: '2.0',
+    id: null,
+    error: JsonRpcTransportHandler.mapToJSONRPCError(
+      new ContentTypeNotSupportedError(
+        `Unsupported Content-Type "${rawContentType}"; expected application/json.`
+      )
+    ),
+  };
+  res.status(415).json(errorResponse);
+};
 
 export const jsonErrorHandler: ErrorRequestHandler = (
   err: unknown,

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -37,7 +37,7 @@ import {
   TaskPushNotificationConfig,
 } from '../../types/pb/a2a.js';
 import { ToProto } from '../../types/converters/to_proto.js';
-import { RequestMalformedError } from '../../errors.js';
+import { ContentTypeNotSupportedError, RequestMalformedError } from '../../errors.js';
 
 /**
  * Options for configuring the HTTP+JSON/REST handler.
@@ -84,6 +84,33 @@ const restErrorHandler: ErrorRequestHandler = (
       .json(toHTTPError(new RequestMalformedError('Invalid JSON payload.'), 400));
   }
   next(err);
+};
+
+/**
+ * Express middleware that rejects body-bearing REST requests whose
+ * Content-Type is neither `application/json` nor `application/a2a+json`,
+ * surfacing a `ContentTypeNotSupportedError` mapped to HTTP 415.
+ */
+const restContentTypeGuard: RequestHandler = (req, res, next) => {
+  const rawContentType = req.header('content-type');
+  // Only enforce on requests that actually carry a body. GET / DELETE
+  // without a Content-Type header are routine; CORS preflights live on
+  // OPTIONS and must keep working.
+  if (!rawContentType) {
+    next();
+    return;
+  }
+  const mediaType = rawContentType.split(';', 1)[0].trim().toLowerCase();
+  if (mediaType === JSON_CONTENT_TYPE || mediaType === A2A_CONTENT_TYPE) {
+    next();
+    return;
+  }
+  const error = new ContentTypeNotSupportedError(
+    `Unsupported Content-Type "${rawContentType}"; expected application/json or application/a2a+json.`
+  );
+  res
+    .status(HTTP_STATUS.UNSUPPORTED_MEDIA_TYPE)
+    .json(toHTTPError(error, HTTP_STATUS.UNSUPPORTED_MEDIA_TYPE));
 };
 
 // Route patterns removed - using explicit route definitions instead
@@ -142,9 +169,18 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
 
   router.use(
     (_req: Request, res: Response, next: NextFunction) => {
-      res.setHeader('Content-Type', A2A_CONTENT_TYPE);
+      // §11.1 SHOULD use `application/a2a+json`, but we emit the
+      // broader `application/json` so every standard HTTP+JSON client
+      // (including those without A2A-specific media-type handling) can
+      // interoperate. Both content types are still accepted on input.
+      res.setHeader('Content-Type', JSON_CONTENT_TYPE);
       next();
     },
+    // A body-bearing request (POST / PUT / DELETE) with an unsupported
+    // Content-Type must surface as `ContentTypeNotSupportedError`
+    // mapped to HTTP 415, not as a generic 400 once `express.json()`
+    // silently skips parsing. Bodyless requests pass through.
+    restContentTypeGuard,
     express.json({ type: [JSON_CONTENT_TYPE, A2A_CONTENT_TYPE], strict: false }),
     restErrorHandler
   );

--- a/src/server/grpc/grpc_service.ts
+++ b/src/server/grpc/grpc_service.ts
@@ -237,15 +237,19 @@ const mapToError = (error: unknown): Partial<grpc.ServiceError> => {
   let code = grpc.status.UNKNOWN;
   if (error instanceof TaskNotFoundError) code = grpc.status.NOT_FOUND;
   else if (error instanceof TaskNotCancelableError) code = grpc.status.FAILED_PRECONDITION;
-  else if (error instanceof PushNotificationNotSupportedError)
-    code = grpc.status.FAILED_PRECONDITION;
-  else if (error instanceof UnsupportedOperationError) code = grpc.status.FAILED_PRECONDITION;
+  // Capability-gated rejections (push notifications, version negotiation,
+  // any other unsupported operation) map to UNIMPLEMENTED.
+  // FAILED_PRECONDITION is reserved for the cancel / extended-card /
+  // extension preconditions, so clients can distinguish "agent does
+  // not implement this" from "current state forbids this operation".
+  else if (error instanceof PushNotificationNotSupportedError) code = grpc.status.UNIMPLEMENTED;
+  else if (error instanceof UnsupportedOperationError) code = grpc.status.UNIMPLEMENTED;
   else if (error instanceof ContentTypeNotSupportedError) code = grpc.status.INVALID_ARGUMENT;
   else if (error instanceof InvalidAgentResponseError) code = grpc.status.INTERNAL;
   else if (error instanceof ExtendedAgentCardNotConfiguredError)
     code = grpc.status.FAILED_PRECONDITION;
   else if (error instanceof ExtensionSupportRequiredError) code = grpc.status.FAILED_PRECONDITION;
-  else if (error instanceof VersionNotSupportedError) code = grpc.status.FAILED_PRECONDITION;
+  else if (error instanceof VersionNotSupportedError) code = grpc.status.UNIMPLEMENTED;
   else if (error instanceof RequestMalformedError) code = grpc.status.INVALID_ARGUMENT;
   else if (error instanceof GenericError) code = grpc.status.INTERNAL;
 

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -389,34 +389,28 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         );
       })
       .finally(() => {
-        this._tearDownOrKeepBus(taskId, eventBus, stateTracker());
+        // Closes the bus for terminal tasks; kept alive for
+        // INPUT_REQUIRED / AUTH_REQUIRED so follow-up sends and
+        // resubscribers can still attach.
+        this._settleBus(taskId, eventBus, stateTracker());
       });
   }
 
   /**
-   * Decides whether to fully tear down the event bus or keep it alive
-   * for a future resubscribe / follow-up message.
+   * Settles the event bus once the executor returns.
    *
-   * The bus is torn down when the task reached a terminal state
-   * (COMPLETED / FAILED / CANCELED / REJECTED) — no further events can
-   * arrive — and also when no Task was ever produced (the bare-Message
-   * pattern in §3.1.2). For an interrupted state
-   * (INPUT_REQUIRED / AUTH_REQUIRED) the bus is retained so that
-   * `tasks/resubscribe` can attach and a follow-up `message/send` with
-   * the same `taskId` resumes execution through `createOrGetByTaskId`.
+   * Terminal states (and the bare-Message pattern in §3.1.2) close the
+   * bus immediately. Interrupted states (INPUT_REQUIRED / AUTH_REQUIRED)
+   * keep it alive so a follow-up `message/send` can resume the same
+   * execution via `createOrGetByTaskId`, and `tasks/resubscribe` can
+   * attach in the meantime (§3.4.3).
    */
-  private _tearDownOrKeepBus(
+  private _settleBus(
     taskId: string,
     eventBus: ExecutionEventBus,
     lastState: TaskState | undefined
   ): void {
-    const isInterrupted = lastState !== undefined && INTERRUPTED_STATE_LIST.includes(lastState);
-    if (isInterrupted) {
-      // Bus stays alive AND unsignalled. Active consumers have already
-      // unblocked via the interrupted-state check inside
-      // `ExecutionEventQueue.events()`, and resubscribers can attach
-      // via `getByTaskId(taskId)` until the next send_message resumes
-      // execution and ultimately drives the task to a terminal state.
+    if (lastState !== undefined && INTERRUPTED_STATE_LIST.includes(lastState)) {
       return;
     }
     eventBus.finished();
@@ -491,7 +485,10 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         eventBus.publish(AgentEvent.statusUpdate(errorTaskStatus));
       })
       .finally(() => {
-        this._tearDownOrKeepBus(taskId, eventBus, stateTracker());
+        // Closes the bus for terminal tasks; kept alive for
+        // INPUT_REQUIRED / AUTH_REQUIRED so follow-up sends and
+        // resubscribers can still attach.
+        this._settleBus(taskId, eventBus, stateTracker());
       });
   }
 

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -176,7 +176,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       ) {
         throw new RequestMalformedError(
           `contextId mismatch: message contextId '${incomingMessage.contextId}' ` +
-          `does not match task '${task.id}' contextId '${task.contextId}'`
+            `does not match task '${task.id}' contextId '${task.contextId}'`
         );
       }
       // Add incomingMessage to history and save the task.

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -176,7 +176,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       ) {
         throw new RequestMalformedError(
           `contextId mismatch: message contextId '${incomingMessage.contextId}' ` +
-            `does not match task '${task.id}' contextId '${task.contextId}'`
+          `does not match task '${task.id}' contextId '${task.contextId}'`
         );
       }
       // Add incomingMessage to history and save the task.
@@ -1063,12 +1063,16 @@ export type ExtendedAgentCardProvider = (context: ServerCallContext) => Promise<
  */
 function trackLatestTaskState(bus: ExecutionEventBus): () => TaskState | undefined {
   let lastState: TaskState | undefined;
-  bus.on('event', (event) => {
+  const listener = (event: AgentExecutionEvent) => {
     if (event.kind === 'task' && event.data.status?.state !== undefined) {
       lastState = event.data.status.state;
     } else if (event.kind === 'statusUpdate' && event.data.status?.state !== undefined) {
       lastState = event.data.status.state;
     }
-  });
-  return () => lastState;
+  };
+  bus.on('event', listener);
+  return () => {
+    bus.off('event', listener);
+    return lastState;
+  };
 }

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -56,7 +56,7 @@ import { PushNotificationSender } from '../push_notification/push_notification_s
 import { DefaultPushNotificationSender } from '../push_notification/default_push_notification_sender.js';
 import { ServerCallContext } from '../context.js';
 import { DEFAULT_PAGE_SIZE } from '../../constants.js';
-import { TERMINAL_STATE_LIST, isTask, StreamPattern } from '../utils.js';
+import { INTERRUPTED_STATE_LIST, TERMINAL_STATE_LIST, isTask, StreamPattern } from '../utils.js';
 import { AgentCardSignatureGenerator } from '../../signature.js';
 import { extractErrorMessage } from '../../errors.js';
 
@@ -162,7 +162,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         throw new TaskNotFoundError(`Task not found: ${incomingMessage.taskId}`);
       }
       if (task.status?.state !== undefined && TERMINAL_STATE_LIST.includes(task.status.state)) {
-        // Throw UnsupportedOperationError as required by TCK for terminal tasks.
+        // Terminal tasks are immutable per §3.5 — refinements must
+        // start a new task in the same context.
         throw new UnsupportedOperationError(
           `Task ${task.id} is in a terminal state (${task.status!.state}) and cannot be modified.`
         );
@@ -323,6 +324,13 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     requestContext: RequestContext,
     finalMessageForAgent: Message
   ): void {
+    // Subscribe a lightweight listener that tracks the last task state
+    // published on the bus. We can't rely on `resultManager.getCurrentTask()`
+    // in the `.finally` block because the consumer loop that drains the
+    // queue into `ResultManager` runs in a separate microtask: by the
+    // time `.finally()` runs, the consumer has not necessarily processed
+    // the events yet.
+    const stateTracker = trackLatestTaskState(eventBus);
     this.agentExecutor
       .execute(requestContext, eventBus)
       .catch((err: unknown) => {
@@ -381,9 +389,38 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         );
       })
       .finally(() => {
-        eventBus.finished();
-        this.eventBusManager.cleanupByTaskId(taskId);
+        this._tearDownOrKeepBus(taskId, eventBus, stateTracker());
       });
+  }
+
+  /**
+   * Decides whether to fully tear down the event bus or keep it alive
+   * for a future resubscribe / follow-up message.
+   *
+   * The bus is torn down when the task reached a terminal state
+   * (COMPLETED / FAILED / CANCELED / REJECTED) — no further events can
+   * arrive — and also when no Task was ever produced (the bare-Message
+   * pattern in §3.1.2). For an interrupted state
+   * (INPUT_REQUIRED / AUTH_REQUIRED) the bus is retained so that
+   * `tasks/resubscribe` can attach and a follow-up `message/send` with
+   * the same `taskId` resumes execution through `createOrGetByTaskId`.
+   */
+  private _tearDownOrKeepBus(
+    taskId: string,
+    eventBus: ExecutionEventBus,
+    lastState: TaskState | undefined
+  ): void {
+    const isInterrupted = lastState !== undefined && INTERRUPTED_STATE_LIST.includes(lastState);
+    if (isInterrupted) {
+      // Bus stays alive AND unsignalled. Active consumers have already
+      // unblocked via the interrupted-state check inside
+      // `ExecutionEventQueue.events()`, and resubscribers can attach
+      // via `getByTaskId(taskId)` until the next send_message resumes
+      // execution and ultimately drives the task to a terminal state.
+      return;
+    }
+    eventBus.finished();
+    this.eventBusManager.cleanupByTaskId(taskId);
   }
 
   /**
@@ -403,6 +440,9 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     resultManager: ResultManager
   ): void {
     const finalMessageForAgent = requestContext.userMessage;
+    // See `_runExecutor` for why we snoop the bus directly instead of
+    // re-reading state from `resultManager` in the `.finally` block.
+    const stateTracker = trackLatestTaskState(eventBus);
     this.agentExecutor
       .execute(requestContext, eventBus)
       .catch((err: unknown) => {
@@ -451,8 +491,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         eventBus.publish(AgentEvent.statusUpdate(errorTaskStatus));
       })
       .finally(() => {
-        eventBus.finished();
-        this.eventBusManager.cleanupByTaskId(taskId);
+        this._tearDownOrKeepBus(taskId, eventBus, stateTracker());
       });
   }
 
@@ -1008,3 +1047,28 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 }
 
 export type ExtendedAgentCardProvider = (context: ServerCallContext) => Promise<AgentCard>;
+
+/**
+ * Subscribes a lightweight listener on `bus` that records the most
+ * recent task state published — either via a `Task` event or a
+ * `TaskStatusUpdateEvent`. Returns a thunk that the caller invokes in
+ * the executor's `.finally` block to read the last seen state.
+ *
+ * Used by `_runExecutor` / `_runStreamExecutor` to decide whether to
+ * tear down the bus after `execute()` returns. Reading state from the
+ * `ResultManager` directly is unsafe at that point: the consumer loop
+ * that drains the bus into the `ResultManager` runs in a separate
+ * microtask, so the `ResultManager`'s view of the task may still lag
+ * the publish call.
+ */
+function trackLatestTaskState(bus: ExecutionEventBus): () => TaskState | undefined {
+  let lastState: TaskState | undefined;
+  bus.on('event', (event) => {
+    if (event.kind === 'task' && event.data.status?.state !== undefined) {
+      lastState = event.data.status.state;
+    } else if (event.kind === 'statusUpdate' && event.data.status?.state !== undefined) {
+      lastState = event.data.status.state;
+    }
+  });
+  return () => lastState;
+}

--- a/src/server/transports/rest/rest_transport_handler.ts
+++ b/src/server/transports/rest/rest_transport_handler.ts
@@ -56,6 +56,7 @@ export const HTTP_STATUS = {
   UNAUTHORIZED: 401,
   NOT_FOUND: 404,
   CONFLICT: 409,
+  UNSUPPORTED_MEDIA_TYPE: 415,
   INTERNAL_SERVER_ERROR: 500,
   NOT_IMPLEMENTED: 501,
 } as const;
@@ -71,7 +72,7 @@ export function mapErrorToStatus(error: unknown): number {
   if (error instanceof TaskNotCancelableError) return HTTP_STATUS.BAD_REQUEST;
   if (error instanceof PushNotificationNotSupportedError) return HTTP_STATUS.BAD_REQUEST;
   if (error instanceof UnsupportedOperationError) return HTTP_STATUS.BAD_REQUEST;
-  if (error instanceof ContentTypeNotSupportedError) return HTTP_STATUS.BAD_REQUEST;
+  if (error instanceof ContentTypeNotSupportedError) return HTTP_STATUS.UNSUPPORTED_MEDIA_TYPE;
   if (error instanceof InvalidAgentResponseError) return HTTP_STATUS.INTERNAL_SERVER_ERROR;
   if (error instanceof ExtendedAgentCardNotConfiguredError) return HTTP_STATUS.BAD_REQUEST;
   if (error instanceof ExtensionSupportRequiredError) return HTTP_STATUS.BAD_REQUEST;

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -11,6 +11,20 @@ const TERMINAL_STATE_LIST: TaskState[] = [
 export { TERMINAL_STATE_LIST };
 
 /**
+ * Non-terminal states that pause the executor and require a follow-up
+ * message before progress can resume. The agent's `execute()` is
+ * expected to return after publishing one of these states, but the
+ * underlying task remains live so a client can resubscribe — or send a
+ * fresh message with the same `taskId` — to continue the flow. See
+ * §3.5 (task lifecycle) of the A2A specification.
+ */
+const INTERRUPTED_STATE_LIST: TaskState[] = [
+  TaskState.TASK_STATE_INPUT_REQUIRED,
+  TaskState.TASK_STATE_AUTH_REQUIRED,
+];
+export { INTERRUPTED_STATE_LIST };
+
+/**
  * Generates a timestamp in ISO 8601 format.
  * @returns The current timestamp as a string.
  */

--- a/tck/agent/index.ts
+++ b/tck/agent/index.ts
@@ -1,287 +1,491 @@
+/**
+ * A2A TCK System Under Test (SUT) agent.
+ *
+ * Implements the message-prefix-routed executor behavior expected by the
+ * a2a-tck Gherkin scenarios (see https://github.com/a2aproject/a2a-tck
+ * `scenarios/core_operations.feature` and `scenarios/streaming.feature`).
+ *
+ * The TCK probes one agent over three transports — JSON-RPC, REST
+ * (HTTP+JSON) and gRPC. Each test sends a message with a well-known
+ * `messageId` prefix and asserts on the resulting events. The executor
+ * dispatches per-prefix, mirroring the reference a2a-python SUT at
+ * `a2a-tck/sut/a2a-python/sut_agent.py`.
+ */
 import express from 'express';
 import { Server, ServerCredentials } from '@grpc/grpc-js';
-import { v4 as uuidv4 } from 'uuid'; // For generating unique IDs
+import { v4 as uuidv4 } from 'uuid';
 
 import {
   AgentCard,
-  Task,
-  TaskStatusUpdateEvent,
+  AGENT_CARD_PATH,
+  Artifact,
   Message,
-  TaskState,
+  Part,
   Role,
+  Task,
+  TaskArtifactUpdateEvent,
+  TaskState,
+  TaskStatusUpdateEvent,
 } from '../../src/index.js';
 import {
-  InMemoryTaskStore,
-  TaskStore,
-  AgentExecutor,
-  RequestContext,
-  ExecutionEventBus,
-  DefaultRequestHandler,
   AgentEvent,
+  AgentExecutor,
+  DefaultRequestHandler,
+  ExecutionEventBus,
+  InMemoryTaskStore,
+  RequestContext,
+  TaskStore,
 } from '../../src/server/index.js';
 import {
-  jsonRpcHandler,
   agentCardHandler,
+  jsonRpcHandler,
   restHandler,
   UserBuilder,
 } from '../../src/server/express/index.js';
-import { grpcService, A2AService } from '../../src/server/grpc/index.js';
+import { A2AService, grpcService } from '../../src/server/grpc/index.js';
+
+const REST_PATH = '/a2a/rest';
 
 /**
- * SUTAgentExecutor implements the agent's core logic.
+ * SUT executor. Routes incoming messages by their `messageId` prefix to
+ * pre-baked behaviors matching the TCK Gherkin scenarios.
  */
-class SUTAgentExecutor implements AgentExecutor {
-  private runningTask: Set<string> = new Set();
-  private lastContextId?: string;
+class TckAgentExecutor implements AgentExecutor {
+  /** Track currently-running tasks so cancel() can short-circuit. */
+  private readonly running = new Set<string>();
 
-  public cancelTask = async (taskId: string, eventBus: ExecutionEventBus): Promise<void> => {
-    this.runningTask.delete(taskId);
-    const cancelledUpdate: TaskStatusUpdateEvent = {
-      taskId: taskId,
-      contextId: this.lastContextId ?? uuidv4(),
-      status: {
-        state: TaskState.TASK_STATE_CANCELED,
-        timestamp: new Date().toISOString(),
-        message: undefined,
-      },
-      metadata: {},
-    };
-    eventBus.publish(AgentEvent.statusUpdate(cancelledUpdate));
-  };
+  async execute(context: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
+    const taskId = context.taskId;
+    const contextId = context.contextId;
+    const userMessage = context.userMessage;
+    const messageId = userMessage?.messageId ?? '';
 
-  async execute(requestContext: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
-    const userMessage = requestContext.userMessage;
-    const existingTask = requestContext.task;
+    // Publish initial Task event for new tasks. ResultManager requires a
+    // task event before any status / artifact updates so that
+    // subsequent transitions have something to apply on top of.
+    if (!context.task) {
+      this.publishTask(eventBus, taskId, contextId, userMessage);
+    }
 
-    // Determine IDs for the task and context
-    const taskId = requestContext.taskId;
-    const contextId = requestContext.contextId;
+    this.running.add(taskId);
 
-    this.lastContextId = contextId;
-    this.runningTask.add(taskId);
+    try {
+      // ----------------------------------------------------------------
+      // Streaming-only scenarios first — their prefixes share a
+      // namespace with the non-streaming "tck-artifact-*" set so
+      // ordering matters.
+      // ----------------------------------------------------------------
 
-    console.log(
-      `[SUTAgentExecutor] Processing message ${userMessage.messageId} for task ${taskId} (context: ${contextId})`
-    );
+      if (messageId.startsWith('tck-stream-artifact-chunked')) {
+        this.publishWorking(eventBus, taskId, contextId);
+        this.publishArtifact(eventBus, taskId, contextId, [textPart('chunk-1 ')], {
+          append: true,
+        });
+        this.publishArtifact(eventBus, taskId, contextId, [textPart('chunk-2')], {
+          append: true,
+          lastChunk: true,
+        });
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED);
+        return;
+      }
 
-    // 1. Publish initial Task event if it's a new task
-    if (!existingTask) {
-      const initialTask: Task = {
-        id: taskId,
-        contextId: contextId,
+      if (messageId.startsWith('test-resubscribe-message-id')) {
+        this.publishWorking(eventBus, taskId, contextId);
+        // Reference SUT sleeps 2x the streaming timeout (2s * 2 = 4s)
+        // to give resubscription tests a window to disconnect and
+        // reattach before the task completes.
+        await this.sleep(4000, taskId);
+        if (!this.running.has(taskId)) {
+          return;
+        }
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED);
+        return;
+      }
+
+      if (messageId.startsWith('tck-stream-artifact-text')) {
+        this.publishWorking(eventBus, taskId, contextId);
+        this.publishArtifact(eventBus, taskId, contextId, [textPart('Streamed text content')]);
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED);
+        return;
+      }
+
+      if (messageId.startsWith('tck-stream-artifact-file')) {
+        this.publishWorking(eventBus, taskId, contextId);
+        this.publishArtifact(eventBus, taskId, contextId, [filePart('output.txt', 'text/plain')]);
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED);
+        return;
+      }
+
+      if (
+        messageId.startsWith('tck-stream-001') ||
+        messageId.startsWith('tck-stream-003') ||
+        messageId.startsWith('tck-stream-ordering-001')
+      ) {
+        const text = messageId.startsWith('tck-stream-ordering-001')
+          ? 'Ordered output'
+          : messageId.startsWith('tck-stream-001')
+            ? 'Stream hello from TCK'
+            : 'Stream task lifecycle';
+        this.publishWorking(eventBus, taskId, contextId);
+        this.publishArtifact(eventBus, taskId, contextId, [textPart(text)]);
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED);
+        return;
+      }
+
+      if (messageId.startsWith('tck-stream-002')) {
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED);
+        return;
+      }
+
+      // ----------------------------------------------------------------
+      // Non-streaming behaviours.
+      // ----------------------------------------------------------------
+
+      if (messageId.startsWith('tck-artifact-file-url')) {
+        this.publishArtifact(eventBus, taskId, contextId, [
+          fileUrlPart('https://example.com/output.txt', 'output.txt', 'text/plain'),
+        ]);
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED);
+        return;
+      }
+
+      if (messageId.startsWith('tck-message-response')) {
+        // Bare message response — no task lifecycle. The SDK turns any
+        // `message` event into the final result regardless of task
+        // state; we still emitted the initial Task event above, but
+        // the message takes precedence in the response.
+        eventBus.publish(
+          AgentEvent.message(
+            this.makeAgentMessage(taskId, contextId, [textPart('Direct message response')])
+          )
+        );
+        return;
+      }
+
+      if (messageId.startsWith('tck-input-required')) {
+        const inputMsg = this.makeAgentMessage(taskId, contextId, [
+          textPart('Please provide input'),
+        ]);
+        this.publishStatus(
+          eventBus,
+          taskId,
+          contextId,
+          TaskState.TASK_STATE_INPUT_REQUIRED,
+          inputMsg
+        );
+        return;
+      }
+
+      if (messageId.startsWith('tck-complete-task')) {
+        const doneMsg = this.makeAgentMessage(taskId, contextId, [textPart('Hello from TCK')]);
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED, doneMsg);
+        return;
+      }
+
+      if (messageId.startsWith('tck-artifact-text')) {
+        this.publishArtifact(eventBus, taskId, contextId, [textPart('Generated text content')]);
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED);
+        return;
+      }
+
+      if (messageId.startsWith('tck-artifact-file')) {
+        this.publishArtifact(eventBus, taskId, contextId, [filePart('output.txt', 'text/plain')]);
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED);
+        return;
+      }
+
+      if (messageId.startsWith('tck-artifact-data')) {
+        this.publishArtifact(eventBus, taskId, contextId, [dataPart({ key: 'value', count: 42 })]);
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED);
+        return;
+      }
+
+      if (messageId.startsWith('tck-reject-task')) {
+        // The reference Python SUT raises an A2AError("rejected") which
+        // the SDK surfaces as a REJECTED terminal state.
+        this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_REJECTED);
+        return;
+      }
+
+      // Default: echo the prefix back in a completion message. Mirrors
+      // the reference SUT's fallthrough so unknown messageIds don't
+      // hang or hard-fail.
+      const echoMsg = this.makeAgentMessage(taskId, contextId, [
+        textPart(`Unhandled messageId prefix: ${messageId}`),
+      ]);
+      this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_COMPLETED, echoMsg);
+    } finally {
+      this.running.delete(taskId);
+    }
+  }
+
+  async cancelTask(taskId: string, eventBus: ExecutionEventBus): Promise<void> {
+    this.running.delete(taskId);
+    eventBus.publish(
+      AgentEvent.statusUpdate({
+        taskId,
+        contextId: '',
         status: {
-          state: TaskState.TASK_STATE_SUBMITTED,
-          timestamp: new Date().toISOString(),
+          state: TaskState.TASK_STATE_CANCELED,
           message: undefined,
+          timestamp: new Date().toISOString(),
         },
-        artifacts: [],
-        history: [userMessage], // Start history with the current user message
-        metadata: userMessage.metadata, // Carry over metadata from message if any
-      };
-      eventBus.publish(AgentEvent.task(initialTask));
-    }
+        metadata: undefined,
+      })
+    );
+  }
 
-    // 2. Publish "working" status update
-    const workingStatusUpdate: TaskStatusUpdateEvent = {
-      taskId: taskId,
-      contextId: contextId,
+  // ---------------------------------------------------------------------
+  // Event publishing helpers
+  // ---------------------------------------------------------------------
+
+  private publishTask(
+    eventBus: ExecutionEventBus,
+    taskId: string,
+    contextId: string,
+    userMessage: Message | undefined
+  ): void {
+    const initial: Task = {
+      id: taskId,
+      contextId,
       status: {
-        state: TaskState.TASK_STATE_WORKING,
-        message: {
-          role: Role.ROLE_AGENT,
-          messageId: uuidv4(),
-          parts: [
-            {
-              content: { $case: 'text', value: 'Processing your question' },
-              metadata: undefined,
-              filename: '',
-              mediaType: 'text/plain',
-            },
-          ],
-          taskId: taskId,
-          contextId: contextId,
-          extensions: [],
-          metadata: {},
-          referenceTaskIds: [],
-        },
+        state: TaskState.TASK_STATE_SUBMITTED,
+        message: undefined,
         timestamp: new Date().toISOString(),
       },
-      metadata: {},
+      artifacts: [],
+      history: userMessage ? [userMessage] : [],
+      metadata: userMessage?.metadata,
     };
-    eventBus.publish(AgentEvent.statusUpdate(workingStatusUpdate));
+    eventBus.publish(AgentEvent.task(initial));
+  }
 
-    // 3. Publish final task status update
-    const agentReplyText = this.parseInputMessage(userMessage);
-    await new Promise((resolve) => setTimeout(resolve, 3000)); // Simulate processing delay
-    if (!this.runningTask.has(taskId)) {
-      console.log(
-        `[SUTAgentExecutor] Task ${taskId} was cancelled before processing could complete.`
-      );
-      return;
-    }
-    console.info(`[SUTAgentExecutor] Prompt response: ${agentReplyText}`);
+  private publishWorking(eventBus: ExecutionEventBus, taskId: string, contextId: string): void {
+    this.publishStatus(eventBus, taskId, contextId, TaskState.TASK_STATE_WORKING);
+  }
 
-    const agentMessage: Message = {
-      role: Role.ROLE_AGENT,
-      messageId: uuidv4(),
-      parts: [
-        {
-          content: { $case: 'text', value: agentReplyText },
-          metadata: undefined,
-          filename: '',
-          mediaType: 'text/plain',
-        },
-      ],
-      taskId: taskId,
-      contextId: contextId,
+  private publishStatus(
+    eventBus: ExecutionEventBus,
+    taskId: string,
+    contextId: string,
+    state: TaskState,
+    message?: Message
+  ): void {
+    const evt: TaskStatusUpdateEvent = {
+      taskId,
+      contextId,
+      status: {
+        state,
+        message,
+        timestamp: new Date().toISOString(),
+      },
+      metadata: undefined,
+    };
+    eventBus.publish(AgentEvent.statusUpdate(evt));
+  }
+
+  private publishArtifact(
+    eventBus: ExecutionEventBus,
+    taskId: string,
+    contextId: string,
+    parts: Part[],
+    options: { append?: boolean; lastChunk?: boolean } = {}
+  ): void {
+    const artifact: Artifact = {
+      artifactId: uuidv4(),
+      name: '',
+      description: '',
+      parts,
+      metadata: undefined,
       extensions: [],
-      metadata: {},
+    };
+    const evt: TaskArtifactUpdateEvent = {
+      taskId,
+      contextId,
+      artifact,
+      append: options.append ?? false,
+      lastChunk: options.lastChunk ?? false,
+      metadata: undefined,
+    };
+    eventBus.publish(AgentEvent.artifactUpdate(evt));
+  }
+
+  private makeAgentMessage(taskId: string, contextId: string, parts: Part[]): Message {
+    return {
+      messageId: uuidv4(),
+      contextId,
+      taskId,
+      role: Role.ROLE_AGENT,
+      parts,
+      metadata: undefined,
+      extensions: [],
       referenceTaskIds: [],
     };
+  }
 
-    const finalUpdate: TaskStatusUpdateEvent = {
-      taskId: taskId,
-      contextId: contextId,
-      status: {
-        state: TaskState.TASK_STATE_INPUT_REQUIRED,
-        message: agentMessage,
-        timestamp: new Date().toISOString(),
+  private async sleep(ms: number, taskId: string): Promise<void> {
+    const step = 200;
+    let elapsed = 0;
+    while (elapsed < ms) {
+      if (!this.running.has(taskId)) {
+        return;
+      }
+      const next = Math.min(step, ms - elapsed);
+      await new Promise((resolve) => setTimeout(resolve, next));
+      elapsed += next;
+    }
+  }
+}
+
+// -------------------------------------------------------------------------
+// Part construction helpers (mirror reference SUT shapes).
+// -------------------------------------------------------------------------
+
+function textPart(text: string): Part {
+  return {
+    content: { $case: 'text', value: text },
+    metadata: undefined,
+    filename: '',
+    mediaType: 'text/plain',
+  };
+}
+
+function filePart(filename: string, mediaType: string): Part {
+  return {
+    content: { $case: 'raw', value: Buffer.from('tck') },
+    metadata: undefined,
+    filename,
+    mediaType,
+  };
+}
+
+function fileUrlPart(url: string, filename: string, mediaType: string): Part {
+  return {
+    content: { $case: 'url', value: url },
+    metadata: undefined,
+    filename,
+    mediaType,
+  };
+}
+
+function dataPart(data: unknown): Part {
+  return {
+    content: { $case: 'data', value: data },
+    metadata: undefined,
+    filename: '',
+    mediaType: 'application/json',
+  };
+}
+
+// -------------------------------------------------------------------------
+// Server bootstrap
+// -------------------------------------------------------------------------
+
+function buildAgentCard(httpPort: number, grpcPort: number): AgentCard {
+  const httpHost = `http://localhost:${httpPort}`;
+  return {
+    name: 'A2A JS SDK System Under Test (SUT)',
+    description: 'SUT agent for the a2a-tck conformance suite.',
+    version: '1.0.0',
+    provider: {
+      organization: 'A2A Project',
+      url: 'https://github.com/a2aproject',
+    },
+    documentationUrl: '',
+    iconUrl: '',
+    // The TCK uses `supportedInterfaces[].protocolBinding` to discover
+    // which transports to test. The binding strings MUST be
+    // `JSONRPC`, `HTTP+JSON`, or `GRPC` — the TCK ignores any other
+    // value (see `tck.transport.manager._TRANSPORT_FACTORIES`).
+    supportedInterfaces: [
+      {
+        url: httpHost,
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: '1.0',
       },
-      metadata: {},
-    };
-    eventBus.publish(AgentEvent.statusUpdate(finalUpdate));
-  }
-
-  parseInputMessage(message: Message): string {
-    /** Process the user query and return a response. */
-    const textPart = message.parts.find((part) => part.content?.$case === 'text');
-    const query = textPart?.content?.$case === 'text' ? textPart.content.value.trim() : '';
-
-    if (!query) {
-      return 'Hello! Please provide a message for me to respond to.';
-    }
-
-    // Simple responses based on input
-    const queryLower = query.toLowerCase();
-    if (queryLower.includes('hello') || queryLower.includes('hi')) {
-      return 'Hello World! How are you?';
-    } else if (queryLower.includes('how are you')) {
-      return "I'm doing great! Thanks for asking. How can I help you today?";
-    } else {
-      return `Hello World! You said: '${query}'. Please, send me a new message.`;
-    }
-  }
+      {
+        url: `${httpHost}${REST_PATH}`,
+        protocolBinding: 'HTTP+JSON',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+      {
+        url: `localhost:${grpcPort}`,
+        protocolBinding: 'GRPC',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+    ],
+    securitySchemes: {},
+    securityRequirements: [],
+    signatures: [],
+    capabilities: {
+      streaming: true,
+      pushNotifications: false,
+      extensions: [],
+      extendedAgentCard: false,
+    },
+    defaultInputModes: ['text'],
+    defaultOutputModes: ['text'],
+    skills: [
+      {
+        id: 'tck',
+        name: 'TCK Conformance',
+        description: 'Handles TCK conformance test messages.',
+        tags: ['tck'],
+        examples: [],
+        inputModes: ['text'],
+        outputModes: ['text'],
+        securityRequirements: [],
+      },
+    ],
+  };
 }
 
-// --- Server Setup ---
+async function main(): Promise<void> {
+  const httpPort = Number(process.env.HTTP_PORT ?? 41241);
+  const grpcPort = Number(process.env.GRPC_PORT ?? 41242);
 
-const SUTAgentCard: AgentCard = {
-  name: 'SUT Agent',
-  description: 'A sample agent to be used as SUT against tck tests.',
-  supportedInterfaces: [
-    {
-      url: 'http://localhost:41241/a2a/jsonrpc',
-      protocolBinding: 'JSONRPC',
-      tenant: '',
-      protocolVersion: '0.3.0',
-    },
-    {
-      url: 'http://localhost:41241/a2a/rest',
-      protocolBinding: 'REST',
-      tenant: '',
-      protocolVersion: '0.3.0',
-    },
-    {
-      url: 'http://localhost:41242',
-      protocolBinding: 'GRPC',
-      tenant: '',
-      protocolVersion: '0.3.0',
-    },
-  ],
-  provider: {
-    organization: 'A2A Samples',
-    url: 'https://example.com/a2a-samples',
-  },
-  documentationUrl: 'https://example.com/docs',
-  securitySchemes: {},
-  signatures: [],
-  securityRequirements: [],
-  version: '1.0.0',
-  capabilities: {
-    streaming: true,
-    pushNotifications: false,
-    extensions: [],
-    extendedAgentCard: false,
-  },
-  defaultInputModes: ['text'],
-  defaultOutputModes: ['text', 'task-status'], // task-status is a common output mode
-  skills: [
-    {
-      id: 'sut_agent',
-      name: 'SUT Agent',
-      description: 'Simulate the general flow of a streaming agent.',
-      tags: ['sut'],
-      examples: ['hi', 'hello world', 'how are you', 'goodbye'],
-      inputModes: ['text'], // Explicitly defining for skill
-      outputModes: ['text', 'task-status'], // Explicitly defining for skill
-      securityRequirements: [],
-    },
-  ],
-};
-
-async function main() {
-  // 1. Create TaskStore
   const taskStore: TaskStore = new InMemoryTaskStore();
+  const agentExecutor: AgentExecutor = new TckAgentExecutor();
+  const agentCard = buildAgentCard(httpPort, grpcPort);
+  const requestHandler = new DefaultRequestHandler(agentCard, taskStore, agentExecutor);
 
-  // 2. Create AgentExecutor
-  const agentExecutor: AgentExecutor = new SUTAgentExecutor();
+  const app = express();
 
-  // 3. Create DefaultRequestHandler
-  const requestHandler = new DefaultRequestHandler(SUTAgentCard, taskStore, agentExecutor);
+  // Per §8.2 the agent card MUST be served at `/.well-known/agent-card.json`.
+  app.use(`/${AGENT_CARD_PATH}`, agentCardHandler({ agentCardProvider: requestHandler }));
 
-  // 4. Setup Express app with modular handlers
-  const expressApp = express();
+  // REST under /a2a/rest. The TCK derives `/message:send`, `/tasks/:id`
+  // etc. from this base URL. Mount REST first so its routes are not
+  // shadowed by the root-mounted JSON-RPC handler.
+  app.use(REST_PATH, restHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication }));
 
-  // Register agent card handler at well-known location (shared by all transports)
-  expressApp.use(
-    '/.well-known/agent-card.json',
-    agentCardHandler({ agentCardProvider: requestHandler })
+  // JSON-RPC at the HTTP server root — the TCK `JsonRpcClient` posts
+  // to `/` of the URL declared in the agent card.
+  app.use('/', jsonRpcHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication }));
+
+  app.listen(httpPort, () => {
+    console.log(`[TckSut] HTTP server on http://localhost:${httpPort}`);
+    console.log(`[TckSut] Agent card at http://localhost:${httpPort}/${AGENT_CARD_PATH}`);
+  });
+
+  const grpcServer = new Server();
+  grpcServer.addService(
+    A2AService,
+    grpcService({ requestHandler, userBuilder: UserBuilder.noAuthentication })
   );
-
-  // Register JSON-RPC handler (preferred transport, backward compatible)
-  expressApp.use(
-    '/a2a/jsonrpc',
-    jsonRpcHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication })
-  );
-
-  // Register HTTP+JSON/REST handler (new feature - additional transport)
-  expressApp.use(
-    '/a2a/rest',
-    restHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication })
-  );
-
-  // 5. Start the server
-  const HTTP_PORT = process.env.HTTP_PORT || 41241;
-  expressApp.listen(HTTP_PORT, (err) => {
+  grpcServer.bindAsync(`0.0.0.0:${grpcPort}`, ServerCredentials.createInsecure(), (err) => {
     if (err) {
-      throw err;
+      console.error(`[TckSut] gRPC bind failed: ${err.message}`);
+      return;
     }
-    console.log(`[SUTAgent] HTTP server started on http://localhost:${HTTP_PORT}`);
-    console.log(`[SUTAgent] Agent Card: http://localhost:${HTTP_PORT}/.well-known/agent-card.json`);
-    console.log('[SUTAgent] Press Ctrl+C to stop the server');
-  });
-
-  // 6. Start the gRPC server on a different port
-  const GRPC_PORT = process.env.GRPC_PORT || 41242;
-  const grpcHandlerInstance = grpcService({
-    requestHandler,
-    userBuilder: UserBuilder.noAuthentication,
-  });
-  const server = new Server();
-  server.addService(A2AService, grpcHandlerInstance);
-  server.bindAsync(`localhost:${GRPC_PORT}`, ServerCredentials.createInsecure(), () => {
-    console.log(`[SUTAgent] gRPC server running at localhost:${GRPC_PORT}`);
+    console.log(`[TckSut] gRPC server on localhost:${grpcPort}`);
   });
 }
 
-main().catch(console.error);
+main().catch((err) => {
+  console.error('[TckSut] Fatal:', err);
+  process.exit(1);
+});

--- a/test/server/express/express_app.spec.ts
+++ b/test/server/express/express_app.spec.ts
@@ -262,14 +262,18 @@ describe('A2AExpressApp', () => {
         .send(requestBody)
         .expect(200);
 
-      // Assert SSE headers and error event content
-      assert.include(response.headers['content-type'], 'text/event-stream');
-      assert.equal(response.headers['cache-control'], 'no-cache');
-      assert.equal(response.headers['connection'], 'keep-alive');
+      // When the streaming generator throws BEFORE yielding its first
+      // event (e.g. resubscribe on a terminal task) the handler must
+      // surface a plain JSON-RPC error response rather than a 200 SSE
+      // stream carrying a single error event: the latter looks like a
+      // successful subscription to most clients.
+      assert.include(response.headers['content-type'], 'application/json');
+      assert.notInclude(response.headers['content-type'], 'text/event-stream');
 
-      const responseText = response.text;
-      assert.include(responseText, 'event: error');
-      assert.include(responseText, 'Immediate streaming error');
+      assert.equal(response.body.jsonrpc, '2.0');
+      assert.equal(response.body.id, 'immediate-stream-error-test');
+      assert.exists(response.body.error);
+      assert.include(response.body.error.message, 'Immediate streaming error');
     });
 
     it('should handle general processing error', async () => {

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -933,8 +933,8 @@ describe('restHandler', () => {
     });
   });
 
-  describe('Content-Type: application/a2a+json (§11.1)', () => {
-    it('should return application/a2a+json for successful JSON responses', async () => {
+  describe('Content-Type: application/json', () => {
+    it('should return application/json for successful JSON responses', async () => {
       (mockRequestHandler.getTask as Mock).mockResolvedValue(testTask);
 
       const response = await request(app)
@@ -942,16 +942,18 @@ describe('restHandler', () => {
         .set('A2A-Version', '1.0')
         .expect(200);
 
-      assert.include(response.headers['content-type'], 'application/a2a+json');
+      assert.include(response.headers['content-type'], 'application/json');
+      assert.notInclude(response.headers['content-type'], 'application/a2a+json');
     });
 
-    it('should return application/a2a+json for error responses', async () => {
+    it('should return application/json for error responses', async () => {
       const response = await request(app)
         .get('/tasks/task-1')
         .set('A2A-Version', '9.9')
         .expect(400);
 
-      assert.include(response.headers['content-type'], 'application/a2a+json');
+      assert.include(response.headers['content-type'], 'application/json');
+      assert.notInclude(response.headers['content-type'], 'application/a2a+json');
     });
 
     it('should accept requests with Content-Type application/a2a+json', async () => {
@@ -964,7 +966,7 @@ describe('restHandler', () => {
         .send(JSON.stringify({ message: testMessage }))
         .expect(200);
 
-      assert.include(response.headers['content-type'], 'application/a2a+json');
+      assert.include(response.headers['content-type'], 'application/json');
     });
 
     it('should accept requests with Content-Type application/json', async () => {
@@ -976,10 +978,10 @@ describe('restHandler', () => {
         .set('Content-Type', 'application/json')
         .expect(200);
 
-      assert.include(response.headers['content-type'], 'application/a2a+json');
+      assert.include(response.headers['content-type'], 'application/json');
     });
 
-    it('should return text/event-stream for SSE responses, not application/a2a+json', async () => {
+    it('should return text/event-stream for SSE responses, not application/json', async () => {
       const streamResponse = (async function* () {
         yield { payload: { $case: 'task' as const, value: testTask } };
       })();
@@ -1209,7 +1211,7 @@ describe('restHandler', () => {
       assert.notInclude(response.headers['content-type'], 'application/a2a+json');
     });
 
-    it('keeps Content-Type application/a2a+json on v1.0 responses', async () => {
+    it('keeps Content-Type application/json on v1.0 responses', async () => {
       (mockRequestHandler.getTask as Mock).mockResolvedValue(testTask);
 
       const response = await request(dualApp)
@@ -1217,7 +1219,10 @@ describe('restHandler', () => {
         .set('A2A-Version', '1.0')
         .expect(200);
 
-      assert.include(response.headers['content-type'], 'application/a2a+json');
+      // Both v1.0 and the legacy v0.3 path emit plain application/json,
+      // so make the assertion specific.
+      assert.include(response.headers['content-type'], 'application/json');
+      assert.notInclude(response.headers['content-type'], 'application/a2a+json');
     });
 
     it('reads and writes back the legacy X-A2A-Extensions header', async () => {


### PR DESCRIPTION
# Description

Replaces the experimental TCK SUT/workflow from bgralewicz/enable_tck_tests with a working setup across all three transports (JSON-RPC, REST/HTTP+JSON, gRPC) on a2a-tck 1.0.0.alpha2, and lands the SDK fixes that the conformance suite exposed.

TCK harness and its consequences:
- tck/agent/index.ts — rewritten as a messageId-prefix-routed SUT executor matching the canonical Gherkin scenarios (scenarios/core_operations.feature, scenarios/streaming.feature) and the reference Python SUT (a2a-tck/sut/a2a-python/sut_agent.py). Serves the agent card at /.well-known/agent-card.json, JSON-RPC at /, REST at /a2a/rest, and gRPC on a separate port — all three declared in supportedInterfaces so the conformance suite probes all bindings against the same agent.
- .github/workflows/run-tck.yaml — pinned to TCK release 1.0.0.alpha2; runs both MUST and SHOULD; uploads compatibility reports as artifacts; triggers on main and epic/**.
- SDK fixes driven by TCK failures

Closes #491  🦕
