### PR TITLE
feat: add compat-v1 client and server samples to demonstrate A2A v0.3 backward compatibility

### DIFF
--- a/.github/workflows/run-itk-nightly.yaml
+++ b/.github/workflows/run-itk-nightly.yaml
@@ -19,6 +19,7 @@ on:
     branches: ["main", "epic/**"]
     paths:
       - 'src/**'
+      - '!src/samples/**'
       - 'itk/**'
       - 'package.json'
       - 'package-lock.json'

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - 'src/**'
+      - '!src/samples/**'
       - 'itk/**'
       - 'package.json'
       - 'package-lock.json'

--- a/src/samples/agents/compat-v1-client/README.md
+++ b/src/samples/agents/compat-v1-client/README.md
@@ -1,0 +1,212 @@
+# Compat v1.0 Client
+
+A v1.0-native A2A client that talks to BOTH modern (v1.0) and legacy (v0.3)
+servers, demonstrating the client side of the `@a2a-js/sdk` v0.3 compat layer.
+
+This is the client half of a two-part showcase; see
+[`../compat-v1-server/`](../compat-v1-server/) for the server half and
+[`src/compat/v0_3/README.md`](../../../compat/v0_3/README.md) for the
+architecture notes.
+
+## What the sample does
+
+The driver runs five connections back-to-back from a single linear flow:
+
+1. **Compat-aware v1.0 client → compat server (JSON-RPC).** Confirms that
+   opting into `legacyCompat` on the client does NOT downgrade the wire to
+   v0.3 when the server speaks v1.0 — the hybrid card's embedded
+   `supportedInterfaces[]` is preferred. Expect `JsonRpcTransport` / `1.0`.
+2. **Same client wiring → in-process pure-v0.3 server (JSON-RPC).** The
+   legacy card has no embedded v1.0 interfaces; the resolver detects v0.3 by
+   response shape, stamps `protocolVersion: '0.3'` on every synthesized
+   interface, and the factory dispatches to `LegacyJsonRpcTransport`. Expect
+   `LegacyJsonRpcTransport` / `0.3`.
+3. **Compat-aware v1.0 client → compat server over gRPC.** Same
+   compat-dispatch logic on a different transport. Expect `GrpcTransport` /
+   `1.0`.
+4. **v1.0 push notification → compat server.** Registers a webhook via the
+   v1.0 JSON-RPC transport. The server's
+   `createLegacyAwarePushNotificationSender` picks the
+   `V1PushNotificationSerializer` because the registration context carries
+   `requestedVersion: '1.0'`. The in-process webhook receiver shows
+   `Content-Type: application/a2a+json` and bodies wrapped in
+   `StreamResponse{<key>}` envelopes.
+5. **v0.3 push notification → SAME compat server.** Forces the v0.3 wire
+   path by handing the factory a synthetic v0.3-only `AgentCard` pointing at
+   the compat server's URL (the `JsonRpcTransportFactory` sees
+   `protocolVersion: '0.3'` on the matched interface and dispatches to
+   `LegacyJsonRpcTransport`). The same sender on the same server, with the
+   same store, now picks the `V03PushNotificationSerializer` for this
+   webhook because the registration context carries `requestedVersion: '0.3'`.
+   The receiver shows `Content-Type: application/json` and bare v0.3 events
+   with `kind: '...'` inner discriminators.
+
+Each connection runs a real `sendMessageStream` (steps 1-3) or `sendMessage`
++ webhook capture (steps 4-5) round-trip so the wire path is exercised
+end-to-end, not just the wiring.
+
+## Running
+
+In one terminal, start the compat server:
+
+```bash
+npm run agents:compat-v1-server
+```
+
+In another terminal, run the client driver:
+
+```bash
+npm run agents:compat-v1-client
+```
+
+The driver spawns its own in-process pure-v0.3 server (port `41253`) and
+webhook receiver (port `42424`), so no extra setup is needed.
+
+Expected output (abbreviated):
+
+```
+[Client] Compat server:    http://localhost:41251 (HTTP) / localhost:41252 (gRPC)
+[Client] Pure-v0.3 server: http://localhost:41253 (in-process)
+[Client] Webhook receiver: http://localhost:42424/webhook/task-updates (in-process)
+
+[Client] === Connecting to compat server over HTTP (JSON-RPC) ===
+[Client] compat-aware → compat server: transport=JsonRpcTransport version=1.0
+[Client] task           id=... state=TASK_STATE_SUBMITTED
+...
+[Client] statusUpdate   task=... state=TASK_STATE_COMPLETED
+
+[Client] === Connecting to pure-v0.3 server over HTTP (JSON-RPC) ===
+[Client] compat-aware → pure-v0.3 server: transport=LegacyJsonRpcTransport version=0.3
+...
+
+[Client] === Connecting to compat server over gRPC ===
+[Client] compat-aware → compat server (gRPC): transport=GrpcTransport version=1.0
+...
+
+[Client] === v1.0 push notification → compat server ===
+[Client] v1.0 push → compat server: transport=JsonRpcTransport version=1.0
+[Client] sendMessage returned task id=... state=TASK_STATE_COMPLETED
+[Webhook] Captured 4 webhook(s) for task ...:
+[Webhook]   Content-Type: application/a2a+json ✓
+[Webhook]   Body summary: v1.0 StreamResponse{task}
+[Webhook]   Content-Type: application/a2a+json ✓
+[Webhook]   Body summary: v1.0 StreamResponse{statusUpdate}
+[Webhook]   Content-Type: application/a2a+json ✓
+[Webhook]   Body summary: v1.0 StreamResponse{artifactUpdate}
+[Webhook]   Content-Type: application/a2a+json ✓
+[Webhook]   Body summary: v1.0 StreamResponse{statusUpdate}
+
+[Client] === v0.3 push notification → compat server (same server!) ===
+[Client] v0.3 push → compat server: transport=LegacyJsonRpcTransport version=0.3
+[Client] sendMessage returned task id=... state=TASK_STATE_COMPLETED
+[Webhook] Captured 4 webhook(s) for task ...:
+[Webhook]   Content-Type: application/json ✓
+[Webhook]   Body summary: v0.3 bare event{kind: 'task'}
+[Webhook]   Content-Type: application/json ✓
+[Webhook]   Body summary: v0.3 bare event{kind: 'status-update'}
+[Webhook]   Content-Type: application/json ✓
+[Webhook]   Body summary: v0.3 bare event{kind: 'artifact-update'}
+[Webhook]   Content-Type: application/json ✓
+[Webhook]   Body summary: v0.3 bare event{kind: 'status-update'}
+
+[Client] Done.
+```
+
+## How it's wired
+
+### Client side: per-factory `legacyCompat` opt-in
+
+The factory used for the first three connections sets
+`legacyCompat: { enabled: true }` on EVERY transport factory AND on the card
+resolver:
+
+```ts
+const factory = new ClientFactory(
+  ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+    cardResolver: new DefaultAgentCardResolver({ legacyCompat: { enabled: true } }),
+    transports: [
+      new JsonRpcTransportFactory({ legacyCompat: { enabled: true } }),
+      new RestTransportFactory({   legacyCompat: { enabled: true } }),
+      new GrpcTransportFactory({   legacyCompat: { enabled: true } }),
+    ],
+  })
+);
+```
+
+Note that `ClientFactory` itself doesn't take a `legacyCompat` option — the
+opt-in is per transport factory and per resolver. This mirrors the server
+side, where each Express handler (`jsonRpcHandler`, `restHandler`,
+`agentCardHandler`) takes its own `legacyCompat` opt-in.
+
+When `legacyCompat: { enabled: true }` is set:
+
+1. The `DefaultAgentCardResolver` inspects every fetched card. If the response
+   shape matches v0.3 (top-level `url` without `supportedInterfaces`,
+   `preferredTransport`, `additionalInterfaces`, or `protocolVersion` in the
+   `[0.3, 1.0)` range), it translates the card to a v1.0 representation with
+   `protocolVersion: '0.3'` stamped on every synthesized `AgentInterface`.
+
+   A "hybrid" card (one with BOTH v0.3 top-level fields AND an embedded v1.0
+   `supportedInterfaces[]`) is treated as v1.0 — that's the override that
+   prevents the downgrade dance in the first connection.
+
+2. Each transport factory's `create()` method inspects the matched
+   `AgentInterface.protocolVersion`. If it falls in `[0.3, 1.0)`, the factory
+   produces the v0.3 compat transport (`LegacyJsonRpcTransport`,
+   `LegacyRestTransport`, or `LegacyGrpcTransport`) instead of the native
+   v1.0 transport. Otherwise it produces the v1.0 transport as usual.
+
+3. The v0.3 compat module is lazy-loaded — it's never reached on the dispatch
+   path when `legacyCompat` is not enabled.
+
+### Forcing the v0.3 wire path against a v1.0-primary server (step 5)
+
+The compat server's well-known card lists v1.0 interfaces first, so the
+resolver normally picks v1.0. To exercise the v0.3 push-notification path
+against the SAME server, the driver bypasses discovery and hands the factory
+a synthetic v0.3-only `AgentCard`:
+
+```ts
+const v03Card: AgentCard = {
+  ...,
+  supportedInterfaces: [
+    {
+      url: 'http://localhost:41251/a2a/jsonrpc',
+      protocolBinding: 'JSONRPC',
+      protocolVersion: A2A_LEGACY_PROTOCOL_VERSION,  // '0.3'
+    },
+  ],
+};
+const client = await factory.createFromAgentCard(v03Card);
+// client.transport is LegacyJsonRpcTransport, client.protocolVersion is '0.3'
+```
+
+This is a useful pattern in its own right — anywhere you need to force a
+specific transport-version pair against a multi-version server.
+
+### Server side: one sender, two serializers
+
+The compat server uses `createLegacyAwarePushNotificationSender` from
+`@a2a-js/sdk/compat/v0_3/server`, which returns a canonical
+`DefaultPushNotificationSender` pre-registered with:
+
+- `V1PushNotificationSerializer` for `'1.0'` → `application/a2a+json` body,
+  v1.0 `StreamResponse` envelope (`{ task: {...} }` / `{ statusUpdate: {...} }` / ...).
+- `V03PushNotificationSerializer` for `'0.3'` → `application/json` body,
+  bare v0.3 event (`{ kind: 'task', id: '...', ... }` etc.).
+
+The `InMemoryPushNotificationStore` captures `context.requestedVersion` at
+registration time. When the sender later dispatches a webhook for a task,
+it looks up the wire version that was active when the webhook was registered
+and routes through the matching serializer. That's why webhooks registered
+over v0.3 keep receiving v0.3-shaped bodies even when later events on the
+same task are triggered by v1.0 requests — and vice versa.
+
+## Configuration
+
+| Variable           | Default | Description                                  |
+| ------------------ | ------- | -------------------------------------------- |
+| `COMPAT_HTTP_PORT` | `41251` | HTTP port of the compat server               |
+| `COMPAT_GRPC_PORT` | `41252` | gRPC port of the compat server               |
+| `V03_ONLY_PORT`    | `41253` | Port for the in-process pure-v0.3 fixture    |
+| `WEBHOOK_PORT`     | `42424` | Port for the in-process webhook receiver     |

--- a/src/samples/agents/compat-v1-client/README.md
+++ b/src/samples/agents/compat-v1-client/README.md
@@ -1,7 +1,10 @@
 # Compat v1.0 Client
 
 A v1.0-native A2A client that talks to BOTH modern (v1.0) and legacy (v0.3)
-servers, demonstrating the client side of the `@a2a-js/sdk` v0.3 compat layer.
+servers using the SDK's standard public API. The only "compat" thing about
+the client is `legacyCompat: { enabled: true }` set on each transport factory
+and on the card resolver — everything else is plain `ClientFactory` /
+`Client` / `sendMessageStream` / `sendMessage`.
 
 This is the client half of a two-part showcase; see
 [`../compat-v1-server/`](../compat-v1-server/) for the server half and
@@ -10,40 +13,41 @@ architecture notes.
 
 ## What the sample does
 
-The driver runs five connections back-to-back from a single linear flow:
+Five connections back-to-back from a single linear flow:
 
-1. **Compat-aware v1.0 client → compat server (JSON-RPC).** Confirms that
-   opting into `legacyCompat` on the client does NOT downgrade the wire to
-   v0.3 when the server speaks v1.0 — the hybrid card's embedded
-   `supportedInterfaces[]` is preferred. Expect `JsonRpcTransport` / `1.0`.
-2. **Same client wiring → in-process pure-v0.3 server (JSON-RPC).** The
-   legacy card has no embedded v1.0 interfaces; the resolver detects v0.3 by
-   response shape, stamps `protocolVersion: '0.3'` on every synthesized
-   interface, and the factory dispatches to `LegacyJsonRpcTransport`. Expect
-   `LegacyJsonRpcTransport` / `0.3`.
-3. **Compat-aware v1.0 client → compat server over gRPC.** Same
-   compat-dispatch logic on a different transport. Expect `GrpcTransport` /
-   `1.0`.
-4. **v1.0 push notification → compat server.** Registers a webhook via the
-   v1.0 JSON-RPC transport. The server's
-   `createLegacyAwarePushNotificationSender` picks the
-   `V1PushNotificationSerializer` because the registration context carries
-   `requestedVersion: '1.0'`. The in-process webhook receiver shows
-   `Content-Type: application/a2a+json` and bodies wrapped in
-   `StreamResponse{<key>}` envelopes.
-5. **v0.3 push notification → SAME compat server.** Forces the v0.3 wire
-   path by handing the factory a synthetic v0.3-only `AgentCard` pointing at
-   the compat server's URL (the `JsonRpcTransportFactory` sees
-   `protocolVersion: '0.3'` on the matched interface and dispatches to
-   `LegacyJsonRpcTransport`). The same sender on the same server, with the
-   same store, now picks the `V03PushNotificationSerializer` for this
-   webhook because the registration context carries `requestedVersion: '0.3'`.
-   The receiver shows `Content-Type: application/json` and bare v0.3 events
-   with `kind: '...'` inner discriminators.
+1. **v1.0+compat server, JSON-RPC.** Expect `JsonRpcTransport` / `1.0`. The
+   server's hybrid card carries `supportedInterfaces[]`, so the resolver
+   picks v1.0 even though `legacyCompat` is enabled — no downgrade dance.
+2. **Mock v0.3 server, JSON-RPC.** Expect `LegacyJsonRpcTransport` / `0.3`.
+   The mock's card is pure v0.3 (no `supportedInterfaces[]`); the resolver
+   detects v0.3 by response shape and the `JsonRpcTransportFactory`
+   dispatches to its v0.3 transport automatically.
+3. **v1.0+compat server, gRPC.** Expect `GrpcTransport` / `1.0`.
+4. **Push notification → v1.0+compat server.** Webhook body is the v1.0
+   `StreamResponse` envelope, `Content-Type: application/a2a+json`.
+5. **Push notification → mock v0.3 server.** Webhook body is a bare v0.3
+   event with inner `kind:` discriminator, `Content-Type: application/json`.
+   Same client API as step 4; the wire-shape difference comes from the peer.
 
-Each connection runs a real `sendMessageStream` (steps 1-3) or `sendMessage`
-+ webhook capture (steps 4-5) round-trip so the wire path is exercised
-end-to-end, not just the wiring.
+## About the mock v0.3 server
+
+The driver spins up an in-process mock v0.3 server (`_mock-v0_3-server.ts`)
+purely so this demo runs without needing an external v0.3 peer.
+
+**The mock is hand-rolled.** Every wire response is a literal JSON template
+following the v0.3 spec verbatim. It does **not** import anything from
+`@a2a-js/sdk/compat/v0_3/server` — those modules exist exclusively to teach
+the SDK's v1.0 server how to TOLERATE v0.3 traffic, and are NOT the public
+API for building a v0.3 server.
+
+Read the file to see exactly what v0.3 wire bytes look like, side-by-side
+with the client's logged output. **Do not** copy it as a "v0.3 server
+template" — it implements only the few JSON-RPC methods this demo needs and
+only the happy-path branches. A real v0.3 server should be built either by
+implementing the spec directly (https://a2a-protocol.org/v0_3/specification/)
+or by using the SDK's v1.0 server with `legacyCompat: { enabled: true }`
+on each handler (see [`../compat-v1-server/`](../compat-v1-server/)) — which
+gives production-grade v0.3 support for free.
 
 ## Running
 
@@ -53,72 +57,48 @@ In one terminal, start the compat server:
 npm run agents:compat-v1-server
 ```
 
-In another terminal, run the client driver:
+In another terminal, run the client:
 
 ```bash
 npm run agents:compat-v1-client
 ```
 
-The driver spawns its own in-process pure-v0.3 server (port `41253`) and
+The driver spawns its own in-process mock v0.3 server (port `41253`) and
 webhook receiver (port `42424`), so no extra setup is needed.
 
 Expected output (abbreviated):
 
 ```
-[Client] Compat server:    http://localhost:41251 (HTTP) / localhost:41252 (gRPC)
-[Client] Pure-v0.3 server: http://localhost:41253 (in-process)
-[Client] Webhook receiver: http://localhost:42424/webhook/task-updates (in-process)
-
-[Client] === Connecting to compat server over HTTP (JSON-RPC) ===
-[Client] compat-aware → compat server: transport=JsonRpcTransport version=1.0
-[Client] task           id=... state=TASK_STATE_SUBMITTED
-...
-[Client] statusUpdate   task=... state=TASK_STATE_COMPLETED
-
-[Client] === Connecting to pure-v0.3 server over HTTP (JSON-RPC) ===
-[Client] compat-aware → pure-v0.3 server: transport=LegacyJsonRpcTransport version=0.3
+[Client] === v1.0+compat server, JSON-RPC ===
+[Client] compat-aware → v1.0 server: transport=JsonRpcTransport version=1.0
 ...
 
-[Client] === Connecting to compat server over gRPC ===
-[Client] compat-aware → compat server (gRPC): transport=GrpcTransport version=1.0
+[Client] === Mock v0.3 server, JSON-RPC ===
+[Client] compat-aware → mock v0.3 server: transport=LegacyJsonRpcTransport version=0.3
 ...
 
-[Client] === v1.0 push notification → compat server ===
-[Client] v1.0 push → compat server: transport=JsonRpcTransport version=1.0
-[Client] sendMessage returned task id=... state=TASK_STATE_COMPLETED
+[Client] === v1.0+compat server, gRPC ===
+[Client] compat-aware → v1.0 server (gRPC): transport=GrpcTransport version=1.0
+...
+
+[Client] === Push notification → v1.0+compat server ===
 [Webhook] Captured 4 webhook(s) for task ...:
 [Webhook]   Content-Type: application/a2a+json ✓
 [Webhook]   Body summary: v1.0 StreamResponse{task}
-[Webhook]   Content-Type: application/a2a+json ✓
-[Webhook]   Body summary: v1.0 StreamResponse{statusUpdate}
-[Webhook]   Content-Type: application/a2a+json ✓
-[Webhook]   Body summary: v1.0 StreamResponse{artifactUpdate}
-[Webhook]   Content-Type: application/a2a+json ✓
-[Webhook]   Body summary: v1.0 StreamResponse{statusUpdate}
+...
 
-[Client] === v0.3 push notification → compat server (same server!) ===
-[Client] v0.3 push → compat server: transport=LegacyJsonRpcTransport version=0.3
-[Client] sendMessage returned task id=... state=TASK_STATE_COMPLETED
+[Client] === Push notification → mock v0.3 server ===
 [Webhook] Captured 4 webhook(s) for task ...:
 [Webhook]   Content-Type: application/json ✓
 [Webhook]   Body summary: v0.3 bare event{kind: 'task'}
-[Webhook]   Content-Type: application/json ✓
-[Webhook]   Body summary: v0.3 bare event{kind: 'status-update'}
-[Webhook]   Content-Type: application/json ✓
-[Webhook]   Body summary: v0.3 bare event{kind: 'artifact-update'}
-[Webhook]   Content-Type: application/json ✓
-[Webhook]   Body summary: v0.3 bare event{kind: 'status-update'}
+...
 
 [Client] Done.
 ```
 
 ## How it's wired
 
-### Client side: per-factory `legacyCompat` opt-in
-
-The factory used for the first three connections sets
-`legacyCompat: { enabled: true }` on EVERY transport factory AND on the card
-resolver:
+Every connection uses the same factory:
 
 ```ts
 const factory = new ClientFactory(
@@ -131,82 +111,47 @@ const factory = new ClientFactory(
     ],
   })
 );
+
+const client = await factory.createFromUrl(serverUrl);
+// → talks v1.0 to v1.0 peers, v0.3 to v0.3 peers, automatically
 ```
 
-Note that `ClientFactory` itself doesn't take a `legacyCompat` option — the
-opt-in is per transport factory and per resolver. This mirrors the server
-side, where each Express handler (`jsonRpcHandler`, `restHandler`,
-`agentCardHandler`) takes its own `legacyCompat` opt-in.
+`ClientFactory` itself doesn't take a `legacyCompat` option — the opt-in is
+per transport factory and per resolver. This mirrors the server side, where
+each Express handler (`jsonRpcHandler`, `restHandler`, `agentCardHandler`)
+takes its own `legacyCompat` opt-in.
 
 When `legacyCompat: { enabled: true }` is set:
 
-1. The `DefaultAgentCardResolver` inspects every fetched card. If the response
-   shape matches v0.3 (top-level `url` without `supportedInterfaces`,
-   `preferredTransport`, `additionalInterfaces`, or `protocolVersion` in the
-   `[0.3, 1.0)` range), it translates the card to a v1.0 representation with
-   `protocolVersion: '0.3'` stamped on every synthesized `AgentInterface`.
-
-   A "hybrid" card (one with BOTH v0.3 top-level fields AND an embedded v1.0
-   `supportedInterfaces[]`) is treated as v1.0 — that's the override that
-   prevents the downgrade dance in the first connection.
+1. **`DefaultAgentCardResolver`** inspects every fetched card. If the
+   response shape matches v0.3 (top-level `url` without
+   `supportedInterfaces`, `preferredTransport`, `additionalInterfaces`, or a
+   `protocolVersion` in the `[0.3, 1.0)` range), it translates the card to a
+   v1.0 representation with `protocolVersion: '0.3'` stamped on every
+   synthesized `AgentInterface`. A "hybrid" card with BOTH v0.3 top-level
+   fields AND v1.0 `supportedInterfaces[]` is treated as v1.0 — that's the
+   override that prevents the downgrade dance in step 1.
 
 2. Each transport factory's `create()` method inspects the matched
-   `AgentInterface.protocolVersion`. If it falls in `[0.3, 1.0)`, the factory
-   produces the v0.3 compat transport (`LegacyJsonRpcTransport`,
-   `LegacyRestTransport`, or `LegacyGrpcTransport`) instead of the native
-   v1.0 transport. Otherwise it produces the v1.0 transport as usual.
+   `AgentInterface.protocolVersion`. If it falls in `[0.3, 1.0)`, the
+   factory produces the v0.3 compat transport instead of the native v1.0
+   transport.
 
-3. The v0.3 compat module is lazy-loaded — it's never reached on the dispatch
-   path when `legacyCompat` is not enabled.
+3. The v0.3 compat module is lazy-loaded — it's never reached on the
+   dispatch path when `legacyCompat` is not enabled.
 
-### Forcing the v0.3 wire path against a v1.0-primary server (step 5)
-
-The compat server's well-known card lists v1.0 interfaces first, so the
-resolver normally picks v1.0. To exercise the v0.3 push-notification path
-against the SAME server, the driver bypasses discovery and hands the factory
-a synthetic v0.3-only `AgentCard`:
-
-```ts
-const v03Card: AgentCard = {
-  ...,
-  supportedInterfaces: [
-    {
-      url: 'http://localhost:41251/a2a/jsonrpc',
-      protocolBinding: 'JSONRPC',
-      protocolVersion: A2A_LEGACY_PROTOCOL_VERSION,  // '0.3'
-    },
-  ],
-};
-const client = await factory.createFromAgentCard(v03Card);
-// client.transport is LegacyJsonRpcTransport, client.protocolVersion is '0.3'
-```
-
-This is a useful pattern in its own right — anywhere you need to force a
-specific transport-version pair against a multi-version server.
-
-### Server side: one sender, two serializers
-
-The compat server uses `createLegacyAwarePushNotificationSender` from
-`@a2a-js/sdk/compat/v0_3/server`, which returns a canonical
-`DefaultPushNotificationSender` pre-registered with:
-
-- `V1PushNotificationSerializer` for `'1.0'` → `application/a2a+json` body,
-  v1.0 `StreamResponse` envelope (`{ task: {...} }` / `{ statusUpdate: {...} }` / ...).
-- `V03PushNotificationSerializer` for `'0.3'` → `application/json` body,
-  bare v0.3 event (`{ kind: 'task', id: '...', ... }` etc.).
-
-The `InMemoryPushNotificationStore` captures `context.requestedVersion` at
-registration time. When the sender later dispatches a webhook for a task,
-it looks up the wire version that was active when the webhook was registered
-and routes through the matching serializer. That's why webhooks registered
-over v0.3 keep receiving v0.3-shaped bodies even when later events on the
-same task are triggered by v1.0 requests — and vice versa.
+For push notifications, the v1.0+compat server uses
+`createLegacyAwarePushNotificationSender`, which pre-registers BOTH the
+v1.0 and v0.3 serializers and dispatches per-webhook based on the
+`requestedVersion` captured at registration time. Steps 4 and 5 show this
+working: v1.0 webhooks get v1.0 wire bodies, v0.3 webhooks get v0.3 wire
+bodies — same server, same store, same sender.
 
 ## Configuration
 
 | Variable           | Default | Description                                  |
 | ------------------ | ------- | -------------------------------------------- |
-| `COMPAT_HTTP_PORT` | `41251` | HTTP port of the compat server               |
-| `COMPAT_GRPC_PORT` | `41252` | gRPC port of the compat server               |
-| `V03_ONLY_PORT`    | `41253` | Port for the in-process pure-v0.3 fixture    |
+| `COMPAT_HTTP_PORT` | `41251` | HTTP port of the v1.0+compat server          |
+| `COMPAT_GRPC_PORT` | `41252` | gRPC port of the v1.0+compat server          |
+| `MOCK_V03_PORT`    | `41253` | Port for the in-process mock v0.3 server     |
 | `WEBHOOK_PORT`     | `42424` | Port for the in-process webhook receiver     |

--- a/src/samples/agents/compat-v1-client/_mock-v0_3-server.ts
+++ b/src/samples/agents/compat-v1-client/_mock-v0_3-server.ts
@@ -212,12 +212,12 @@ function* handleMessageStream(params: {
  * so this method is included for completeness but not strictly
  * exercised.)
  */
-function handlePushNotificationConfigSet(params: {
+function handlePushNotificationConfigSet(params?: {
   taskId?: string;
   pushNotificationConfig?: { url?: string; token?: string };
 }) {
-  const taskId = params.taskId ?? '';
-  if (!taskId || !params.pushNotificationConfig?.url) {
+  const taskId = params?.taskId ?? '';
+  if (!taskId || !params?.pushNotificationConfig?.url) {
     return null;
   }
   const list = pushConfigsByTask.get(taskId) ?? [];
@@ -356,13 +356,14 @@ export async function startMockV03Server(options: MockV03ServerOptions): Promise
   });
 
   await new Promise<void>((resolve, reject) => {
-    app.listen(options.port, (err) => {
-      if (err) {
-        reject(err);
-        return;
-      }
+    // Express's `app.listen` does NOT pass an error to its callback —
+    // the callback is registered for the `'listening'` event and takes
+    // no arguments. Startup errors (e.g. `EADDRINUSE`) are emitted on
+    // the returned server instance via the `'error'` event.
+    const server = app.listen(options.port, () => {
       console.log(`[MockV03Server] In-process mock v0.3 server on ${baseUrl}`);
       resolve();
     });
+    server.on('error', reject);
   });
 }

--- a/src/samples/agents/compat-v1-client/_mock-v0_3-server.ts
+++ b/src/samples/agents/compat-v1-client/_mock-v0_3-server.ts
@@ -1,0 +1,368 @@
+/**
+ * MOCK v0.3 server fixture — for the compat-v1-client demo ONLY.
+ *
+ * This file exists so the demo can run end-to-end without the user
+ * having to start a real v0.3 server somewhere. It is INTENTIONALLY
+ * hand-rolled — every wire response below is a literal JSON template
+ * matching the v0.3 JSON-RPC spec verbatim. It does NOT import or use
+ * the SDK's `@a2a-js/sdk/compat/v0_3/server` modules
+ * (`LegacyJsonRpcTransportHandler`, `legacyAgentCardRouter`,
+ * `legacyRestRouter`, etc.) — those exist exclusively to teach the
+ * SDK's v1.0 server how to handle incoming v0.3 traffic.
+ */
+
+import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+import { AGENT_CARD_PATH } from '../../../index.js';
+
+const LEGACY_JSON_CONTENT_TYPE = 'application/json';
+
+// =============================================================================
+// v0.3 wire-shape helpers
+// =============================================================================
+
+/**
+ * v0.3 `AgentCard` — top-level `url`, `preferredTransport`,
+ * `protocolVersion`, no `supportedInterfaces[]`. Per the v0.3 spec
+ * (https://a2a-protocol.org/v0_3/specification/#5-agent-discovery-the-agent-card).
+ */
+function buildLegacyAgentCard(baseUrl: string) {
+  return {
+    name: 'Mock v0.3 Server',
+    description:
+      'Hand-rolled v0.3 demo fixture for compat-v1-client. NOT a real v0.3 ' +
+      'server template — see the header comment in _mock-v0_3-server.ts.',
+    url: `${baseUrl}/a2a/jsonrpc`,
+    preferredTransport: 'JSONRPC',
+    protocolVersion: '0.3',
+    version: '0.3.0',
+    provider: { organization: 'A2A Samples', url: 'https://example.com/a2a-samples' },
+    capabilities: {
+      streaming: true,
+      pushNotifications: true,
+    },
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [
+      {
+        id: 'sample_skill',
+        name: 'Sample Skill',
+        description: 'Echoes a greeting and publishes a few task status updates.',
+        tags: ['demo'],
+      },
+    ],
+  };
+}
+
+/**
+ * v0.3 `Task` — top-level `id`, `contextId`, `status.state` strings
+ * like `'submitted' | 'working' | 'completed'`, parts with `kind:`
+ * inner discriminator.
+ */
+function buildLegacyTask(taskId: string, contextId: string, userText: string) {
+  return {
+    kind: 'task' as const,
+    id: taskId,
+    contextId,
+    status: {
+      state: 'submitted',
+      timestamp: new Date().toISOString(),
+    },
+    history: [
+      {
+        kind: 'message' as const,
+        messageId: uuidv4(),
+        role: 'user',
+        parts: [{ kind: 'text' as const, text: userText }],
+        taskId,
+        contextId,
+      },
+    ],
+    artifacts: [] as object[],
+  };
+}
+
+function buildLegacyStatusUpdate(
+  taskId: string,
+  contextId: string,
+  state: 'working' | 'completed',
+  agentText?: string,
+  final: boolean = false
+) {
+  return {
+    kind: 'status-update' as const,
+    taskId,
+    contextId,
+    status: {
+      state,
+      timestamp: new Date().toISOString(),
+      ...(agentText
+        ? {
+            message: {
+              kind: 'message' as const,
+              messageId: uuidv4(),
+              role: 'agent',
+              parts: [{ kind: 'text' as const, text: agentText }],
+              taskId,
+              contextId,
+            },
+          }
+        : {}),
+    },
+    final,
+  };
+}
+
+function buildLegacyArtifactUpdate(taskId: string, contextId: string, agentText: string) {
+  return {
+    kind: 'artifact-update' as const,
+    taskId,
+    contextId,
+    artifact: {
+      artifactId: uuidv4(),
+      name: 'Result',
+      parts: [{ kind: 'text' as const, text: agentText }],
+    },
+    lastChunk: true,
+    append: false,
+  };
+}
+
+/**
+ * Compute the agent's reply text. Mirrors `SampleAgentExecutor` so the
+ * compat-v1-client's output is comparable across v1.0 and v0.3 paths.
+ */
+function replyText(userText: string): string {
+  const lower = userText.toLowerCase();
+  if (lower.includes('hello') || lower.includes('hi')) return 'Hello World! Nice to meet you!';
+  if (lower.includes('how are you'))
+    return "I'm doing great! Thanks for asking. How can I help you today?";
+  return `Hello World! You said: '${userText}'. Thanks for your message!`;
+}
+
+// =============================================================================
+// In-memory state
+// =============================================================================
+
+interface PushConfig {
+  url: string;
+  token?: string;
+}
+
+/** Map of taskId → list of push notification webhook configs registered for it. */
+const pushConfigsByTask = new Map<string, PushConfig[]>();
+
+/**
+ * Fire-and-forget POST to every webhook registered for `taskId`. Webhook
+ * bodies are bare v0.3 events (no envelope) with `Content-Type:
+ * application/json` per the v0.3 spec.
+ */
+function dispatchWebhooks(taskId: string, event: unknown): void {
+  const configs = pushConfigsByTask.get(taskId) ?? [];
+  for (const config of configs) {
+    const headers: Record<string, string> = { 'Content-Type': LEGACY_JSON_CONTENT_TYPE };
+    if (config.token) {
+      headers['X-A2A-Notification-Token'] = config.token;
+    }
+    void fetch(config.url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(event),
+    }).catch((err) => {
+      console.error(`[MockV03Server] webhook delivery failed: ${(err as Error).message}`);
+    });
+  }
+}
+
+// =============================================================================
+// JSON-RPC method handlers
+// =============================================================================
+
+/**
+ * `message/stream` — streaming send. v0.3 spec §6.6. Yields a sequence
+ * of v0.3 events; the Express handler wraps each one in an SSE
+ * `data:` line.
+ *
+ * The non-streaming counterpart, `message/send` (v0.3 spec §6.5), is
+ * handled inline in the Express dispatcher below so it can register
+ * the inline `configuration.pushNotificationConfig` BEFORE dispatching
+ * webhooks. Extracting it would force a less-obvious two-pass shape.
+ */
+function* handleMessageStream(params: {
+  message: { messageId: string; parts: { kind?: string; text?: string }[] };
+}): Generator<object> {
+  const userText = params.message.parts.find((p) => p.kind === 'text')?.text ?? '(no text)';
+  const taskId = uuidv4();
+  const contextId = uuidv4();
+  const reply = replyText(userText);
+
+  yield buildLegacyTask(taskId, contextId, userText);
+  yield buildLegacyStatusUpdate(taskId, contextId, 'working', 'Processing your question');
+  yield buildLegacyArtifactUpdate(taskId, contextId, reply);
+  yield buildLegacyStatusUpdate(taskId, contextId, 'completed', undefined, true);
+}
+
+/**
+ * `tasks/pushNotificationConfig/set` — v0.3 spec §6.10. Registers a
+ * webhook for the given task. We accept the bare config and remember
+ * it; future `message/send` calls for that task will POST to it. (For
+ * this demo, the client registers the webhook in the same
+ * `message/send` request via `configuration.pushNotificationConfig`,
+ * so this method is included for completeness but not strictly
+ * exercised.)
+ */
+function handlePushNotificationConfigSet(params: {
+  taskId?: string;
+  pushNotificationConfig?: { url?: string; token?: string };
+}) {
+  const taskId = params.taskId ?? '';
+  if (!taskId || !params.pushNotificationConfig?.url) {
+    return null;
+  }
+  const list = pushConfigsByTask.get(taskId) ?? [];
+  list.push({
+    url: params.pushNotificationConfig.url,
+    token: params.pushNotificationConfig.token,
+  });
+  pushConfigsByTask.set(taskId, list);
+  return {
+    taskId,
+    pushNotificationConfig: params.pushNotificationConfig,
+  };
+}
+
+// =============================================================================
+// Express app
+// =============================================================================
+
+export interface MockV03ServerOptions {
+  port: number;
+}
+
+export async function startMockV03Server(options: MockV03ServerOptions): Promise<void> {
+  const baseUrl = `http://localhost:${options.port}`;
+  const app = express();
+  app.use(express.json({ type: LEGACY_JSON_CONTENT_TYPE, limit: '1mb' }));
+
+  // Well-known agent card — v0.3 wire shape, served unconditionally.
+  app.get(`/${AGENT_CARD_PATH}`, (_req, res) => {
+    res.setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE);
+    res.status(200).send(JSON.stringify(buildLegacyAgentCard(baseUrl)));
+  });
+
+  // JSON-RPC endpoint — speaks only v0.3 method names.
+  app.post('/a2a/jsonrpc', async (req, res) => {
+    const body = (req.body ?? {}) as {
+      jsonrpc?: string;
+      id?: string | number | null;
+      method?: string;
+      params?: unknown;
+    };
+    const id = body.id ?? null;
+    try {
+      switch (body.method) {
+        case 'message/send': {
+          // Register inline pushNotificationConfig from
+          // `configuration.pushNotificationConfig`. v0.3 carried it under
+          // that exact key, attached to the `MessageSendParams`.
+          const params = (body.params ?? {}) as {
+            message: { messageId: string; parts: { kind?: string; text?: string }[] };
+            configuration?: {
+              pushNotificationConfig?: { url?: string; token?: string };
+            };
+          };
+          // We'll compute the taskId before handleMessageSend so we can
+          // register the webhook against it.
+          const taskId = uuidv4();
+          const contextId = uuidv4();
+          if (params.configuration?.pushNotificationConfig?.url) {
+            pushConfigsByTask.set(taskId, [
+              {
+                url: params.configuration.pushNotificationConfig.url,
+                token: params.configuration.pushNotificationConfig.token,
+              },
+            ]);
+          }
+          const userText = params.message.parts.find((p) => p.kind === 'text')?.text ?? '(no text)';
+          const reply = replyText(userText);
+          const initialTask = buildLegacyTask(taskId, contextId, userText);
+          dispatchWebhooks(taskId, initialTask);
+          dispatchWebhooks(
+            taskId,
+            buildLegacyStatusUpdate(taskId, contextId, 'working', 'Processing your question')
+          );
+          dispatchWebhooks(taskId, buildLegacyArtifactUpdate(taskId, contextId, reply));
+          dispatchWebhooks(
+            taskId,
+            buildLegacyStatusUpdate(taskId, contextId, 'completed', undefined, true)
+          );
+
+          const finalTask = {
+            ...initialTask,
+            status: { state: 'completed', timestamp: new Date().toISOString() },
+            artifacts: [
+              {
+                artifactId: uuidv4(),
+                name: 'Result',
+                parts: [{ kind: 'text', text: reply }],
+              },
+            ],
+          };
+          res.setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE);
+          res.status(200).json({ jsonrpc: '2.0', id, result: finalTask });
+          return;
+        }
+        case 'message/stream': {
+          const params = (body.params ?? {}) as {
+            message: { messageId: string; parts: { kind?: string; text?: string }[] };
+          };
+          res.setHeader('Content-Type', 'text/event-stream');
+          res.setHeader('Cache-Control', 'no-cache');
+          res.setHeader('Connection', 'keep-alive');
+          res.flushHeaders();
+          for (const event of handleMessageStream(params)) {
+            res.write(`data: ${JSON.stringify({ jsonrpc: '2.0', id, result: event })}\n\n`);
+          }
+          res.end();
+          return;
+        }
+        case 'tasks/pushNotificationConfig/set': {
+          const result = handlePushNotificationConfigSet(
+            body.params as {
+              taskId?: string;
+              pushNotificationConfig?: { url?: string; token?: string };
+            }
+          );
+          res.setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE);
+          res.status(200).json({ jsonrpc: '2.0', id, result });
+          return;
+        }
+        default:
+          res.setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE);
+          res.status(200).json({
+            jsonrpc: '2.0',
+            id,
+            error: { code: -32601, message: `Method not found: ${body.method}` },
+          });
+          return;
+      }
+    } catch (err) {
+      res.setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE);
+      res
+        .status(500)
+        .json({ jsonrpc: '2.0', id, error: { code: -32603, message: (err as Error).message } });
+    }
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    app.listen(options.port, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      console.log(`[MockV03Server] In-process mock v0.3 server on ${baseUrl}`);
+      resolve();
+    });
+  });
+}

--- a/src/samples/agents/compat-v1-client/index.ts
+++ b/src/samples/agents/compat-v1-client/index.ts
@@ -1,53 +1,38 @@
 /**
  * Sample: v1.0-native A2A client driver showcasing the v0.3 compat layer.
  *
- * Pairs with `../compat-v1-server/` (the dual-version A2A server). See
- * `src/compat/v0_3/README.md` for the underlying architecture.
+ * Pairs with `../compat-v1-server/` (the v1.0-native server with
+ * `legacyCompat: { enabled: true }` opted into every handler). The
+ * driver also spins up a hand-rolled MOCK v0.3 server in-process (see
+ * `_mock-v0_3-server.ts`) so the "v1.0+compat client → real v0.3 peer"
+ * scenario can be demonstrated end-to-end without external setup.
+ *
+ * Everything in THIS file uses only the SDK's public client API
+ * (`ClientFactory`, `DefaultAgentCardResolver`, the per-transport
+ * factories, all with `legacyCompat: { enabled: true }`). The
+ * compat-aware client never needs to know which of its peers is v1.0
+ * vs. v0.3 — that's the whole point.
  *
  * Flow:
- *   1. Spin up an in-process pure-v0.3 server so the second half of the
- *      driver has something legacy to talk to.
- *   2. Spin up an in-process webhook receiver that accepts BOTH the v1.0
- *      `application/a2a+json` `StreamResponse` envelope AND the v0.3
- *      `application/json` bare-event body, then prints what it received
- *      so the wire-shape difference is visible at runtime.
- *   3. Open a "compat-aware" v1.0 client (with `legacyCompat: { enabled:
- *      true }` opted in on every transport factory and on the card
- *      resolver) against the dual-version compat server. Confirm that
- *      it Just Works without downgrading the wire to v0.3, then run a
- *      streaming send-message round-trip.
- *   4. Reuse the SAME factory wiring against the pure-v0.3 server.
- *      Confirm the resolver detected the v0.3-shaped card by response
- *      shape, the factory dispatched to `LegacyJsonRpcTransport`, and
- *      run another streaming send-message round-trip to prove the
- *      v0.3 wire path is exercised end-to-end.
- *   5. Switch to a gRPC-only factory against the compat server's
- *      gRPC endpoint, to demonstrate the same compat-dispatch logic on
- *      a different transport.
- *   6. Register a v1.0 webhook against the compat server (via
- *      `JsonRpcTransport`). The server's
- *      `createLegacyAwarePushNotificationSender` picks the
- *      `V1PushNotificationSerializer` because the registration context
- *      carries `requestedVersion: '1.0'`. The webhook receiver shows
+ *   1. Compat-aware client → v1.0+compat server (HTTP/JSON-RPC):
+ *      hybrid card resolves to v1.0, no downgrade dance.
+ *   2. Same client wiring → mock v0.3 server: card-shape detection
+ *      flips the JsonRpcTransportFactory over to the legacy transport
+ *      automatically.
+ *   3. Compat-aware client → v1.0+compat server over gRPC.
+ *   4. v1.0 push notification: client → v1.0+compat server with a
+ *      webhook config. The in-process receiver sees
  *      `application/a2a+json` `StreamResponse` envelopes.
- *   7. Register a v0.3 webhook against the SAME compat server (via
- *      `LegacyJsonRpcTransport`, by handing the factory a synthetic
- *      v0.3-only card pointing at the compat server's URL). The
- *      registration context carries `requestedVersion: '0.3'`, so the
- *      same sender picks the `V03PushNotificationSerializer` for THIS
- *      webhook. The webhook receiver shows `application/json` bare
- *      v0.3 events on the same server.
- *
- * Each step prints the resolved transport class + protocol version so
- * the dispatch decisions are visible in the output.
+ *   5. v0.3 push notification: client → mock v0.3 server with a
+ *      webhook config. The receiver sees `application/json` bare-event
+ *      bodies. Same compat-aware client API; the wire-shape
+ *      difference comes from the peer.
  */
 
 import express from 'express';
 import { v4 as uuidv4 } from 'uuid';
 
 import {
-  AGENT_CARD_PATH,
-  AgentCard,
   Message,
   Part,
   SendMessageRequest,
@@ -65,205 +50,43 @@ import {
   RestTransportFactory,
 } from '../../../client/index.js';
 import { GrpcTransportFactory } from '../../../client/transports/grpc/grpc_transport.js';
-import {
-  DefaultRequestHandler,
-  InMemoryTaskStore,
-  ServerCallContext,
-  UnauthenticatedUser,
-} from '../../../server/index.js';
-import { toCompatAgentCard } from '../../../compat/v0_3/translate/agent_card.js';
-import { LegacyJsonRpcTransportHandler } from '../../../compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.js';
-import {
-  A2A_LEGACY_PROTOCOL_VERSION,
-  LEGACY_JSON_CONTENT_TYPE,
-} from '../../../compat/v0_3/constants.js';
-import { A2A_CONTENT_TYPE } from '../../../constants.js';
-import { SSE_HEADERS, formatSSEEvent, formatSSEErrorEvent } from '../../../sse_utils.js';
-import { SampleAgentExecutor } from '../sample-agent/agent_executor.js';
+import { startMockV03Server } from './_mock-v0_3-server.js';
 
 // --- Server endpoints ---
-//
-// Default to the compat server defined in `../compat-v1-server/index.ts`.
-// Override via env if you've moved it.
+
 const COMPAT_HTTP_PORT = Number(process.env.COMPAT_HTTP_PORT || 41251);
 const COMPAT_GRPC_PORT = Number(process.env.COMPAT_GRPC_PORT || 41252);
 const COMPAT_BASE_URL = `http://localhost:${COMPAT_HTTP_PORT}`;
 const COMPAT_GRPC_TARGET = `localhost:${COMPAT_GRPC_PORT}`;
-const COMPAT_JSON_RPC_URL = `${COMPAT_BASE_URL}/a2a/jsonrpc`;
 
-// In-process pure-v0.3 server so the showcase is self-contained.
-const V03_ONLY_PORT = Number(process.env.V03_ONLY_PORT || 41253);
-const V03_ONLY_BASE_URL = `http://localhost:${V03_ONLY_PORT}`;
+const MOCK_V03_PORT = Number(process.env.MOCK_V03_PORT || 41253);
+const MOCK_V03_BASE_URL = `http://localhost:${MOCK_V03_PORT}`;
 
-// In-process webhook receiver for the push-notification half of the demo.
 const WEBHOOK_PORT = Number(process.env.WEBHOOK_PORT || 42424);
 const WEBHOOK_URL = `http://localhost:${WEBHOOK_PORT}/webhook/task-updates`;
 const WEBHOOK_TOKEN = 'compat-demo-token';
 
-// =============================================================================
-// Pure v0.3 in-process server (used by step 4).
-// =============================================================================
-
-/**
- * Spawns a deliberately-pure v0.3 server: only the legacy JSON-RPC
- * handler and a single well-known card endpoint that serves a
- * v0.3-shaped body unconditionally. This is the "legacy server in the
- * wild" fixture that a v1.0 client with compat opted in is supposed to
- * interoperate with transparently.
- */
-async function startPureV03Server(): Promise<void> {
-  const card: AgentCard = {
-    name: 'Pure v0.3 Server',
-    description: 'A deliberately pure v0.3 server used by the compat client showcase.',
-    supportedInterfaces: [
-      {
-        url: `${V03_ONLY_BASE_URL}/a2a/jsonrpc`,
-        protocolBinding: 'JSONRPC',
-        tenant: '',
-        // The source card declares v0.3 — that's what makes this a "pure
-        // v0.3 server". `toCompatAgentCard` below relies on a legacy
-        // interface being present to pick the primary URL for the v0.3
-        // card it emits on the wire.
-        protocolVersion: A2A_LEGACY_PROTOCOL_VERSION,
-      },
-    ],
-    provider: { organization: 'A2A Samples', url: 'https://example.com/a2a-samples' },
-    // `version` here is the AGENT implementation version (free-form),
-    // not the A2A protocol version — protocol version lives on each
-    // `supportedInterfaces[]` entry above. Pinning it to `0.3.0` keeps
-    // the "pure v0.3" story consistent for human readers, even though
-    // the SDK never inspects this value.
-    version: '0.3.0',
-    capabilities: {
-      streaming: true,
-      pushNotifications: false,
-      extensions: [],
-      extendedAgentCard: false,
-    },
-    securitySchemes: {},
-    securityRequirements: [],
-    defaultInputModes: ['text'],
-    defaultOutputModes: ['text', 'task-status'],
-    skills: [
-      {
-        id: 'sample_agent',
-        name: 'Sample Agent',
-        description: 'Reuses the SampleAgentExecutor over the v0.3 wire.',
-        tags: ['sample', 'v0.3'],
-        examples: ['hi'],
-        inputModes: ['text'],
-        outputModes: ['text', 'task-status'],
-        securityRequirements: [],
-      },
-    ],
-    documentationUrl: '',
-    signatures: [],
-  };
-
-  const requestHandler = new DefaultRequestHandler(
-    card,
-    new InMemoryTaskStore(),
-    new SampleAgentExecutor()
-  );
-
-  const app = express();
-
-  // Pre-translated v0.3 card, served unconditionally. We bypass the
-  // SDK's `legacyAgentCardRouter` here because that router only emits a
-  // v0.3 body for legacy-range `A2A-Version` headers, and the SDK's
-  // `DefaultAgentCardResolver` always sends `A2A-Version: 1.0` on the
-  // discovery request to avoid a downgrade dance — detection is
-  // response-shape based by design.
-  const legacyCard = toCompatAgentCard(await requestHandler.getAgentCard());
-  app.get(`/${AGENT_CARD_PATH}`, (_req, res) => {
-    res.setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE);
-    res.status(200).send(JSON.stringify(legacyCard));
-  });
-
-  const legacyJsonRpc = new LegacyJsonRpcTransportHandler(requestHandler);
-  app.post(
-    '/a2a/jsonrpc',
-    express.json({ type: LEGACY_JSON_CONTENT_TYPE, strict: false }),
-    async (req, res) => {
-      try {
-        const context = new ServerCallContext({
-          requestedExtensions: [],
-          user: new UnauthenticatedUser(),
-          requestedVersion: '0.3',
-        });
-        const result = await legacyJsonRpc.handle(req.body, context);
-        if (
-          result &&
-          typeof (result as AsyncIterable<unknown>)[Symbol.asyncIterator] === 'function'
-        ) {
-          // Streaming method: pump v0.3 envelopes back as SSE — one
-          // JSON-RPC envelope per `data:` line, mirroring what
-          // `LegacyJsonRpcTransport._sendStreamingRequest` parses on
-          // the client side.
-          for (const [key, value] of Object.entries(SSE_HEADERS)) {
-            res.setHeader(key, value);
-          }
-          res.flushHeaders();
-          try {
-            for await (const event of result as AsyncIterable<unknown>) {
-              res.write(formatSSEEvent(event));
-            }
-          } catch (streamErr) {
-            res.write(formatSSEErrorEvent({ code: -32603, message: (streamErr as Error).message }));
-          } finally {
-            res.end();
-          }
-          return;
-        }
-        res.setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE);
-        res.status(200).json(result);
-      } catch (err: unknown) {
-        res
-          .status(500)
-          .json({ jsonrpc: '2.0', error: { code: -32603, message: (err as Error).message } });
-      }
-    }
-  );
-
-  await new Promise<void>((resolve, reject) => {
-    app.listen(V03_ONLY_PORT, (err) => {
-      if (err) {
-        reject(err);
-        return;
-      }
-      console.log(`[V03Server] In-process pure-v0.3 server on ${V03_ONLY_BASE_URL}`);
-      resolve();
-    });
-  });
-}
+// Content types we want to print and compare side-by-side. Defined
+// inline (rather than imported from `@a2a-js/sdk/compat/v0_3/constants`)
+// so this driver's only SDK dependency is the public client API.
+const V1_CONTENT_TYPE = 'application/a2a+json';
+const V03_CONTENT_TYPE = 'application/json';
 
 // =============================================================================
-// Webhook receiver (used by steps 6 and 7).
+// In-process webhook receiver
 // =============================================================================
 
-/**
- * A single received webhook POST, captured for printing.
- */
 interface ReceivedWebhook {
   contentType: string;
   body: unknown;
 }
 
-/**
- * All webhook deliveries captured so far, bucketed by taskId. The
- * webhook handler appends to this map for every accepted POST,
- * regardless of whether anyone is "watching" the task yet — this avoids
- * the race where the v1.0 `sendMessage` (which blocks until the task
- * reaches a terminal state) returns AFTER the server has already
- * dispatched several webhooks. Callers query the map by taskId AFTER
- * the round-trip completes.
- */
 const capturedWebhooks = new Map<string, ReceivedWebhook[]>();
 
 function eventTaskId(body: unknown): string | undefined {
   if (!body || typeof body !== 'object') return undefined;
   const b = body as Record<string, unknown>;
-  // v1.0 StreamResponse envelope: `{ task: {...} }` / `{ statusUpdate: {...} }` etc.
+  // v1.0 StreamResponse envelope.
   for (const key of ['task', 'statusUpdate', 'artifactUpdate', 'message']) {
     const inner = b[key];
     if (inner && typeof inner === 'object') {
@@ -272,7 +95,7 @@ function eventTaskId(body: unknown): string | undefined {
       if (typeof ib['taskId'] === 'string') return ib['taskId'] as string;
     }
   }
-  // v0.3 bare event: `kind` lives on the body itself.
+  // v0.3 bare event.
   if (typeof b['id'] === 'string' && b['kind'] === 'task') return b['id'] as string;
   if (typeof b['taskId'] === 'string') return b['taskId'] as string;
   return undefined;
@@ -280,17 +103,12 @@ function eventTaskId(body: unknown): string | undefined {
 
 async function startWebhookReceiver(): Promise<void> {
   const app = express();
-
-  // Accept BOTH content types: v0.3 sends `application/json`, v1.0 sends
-  // `application/a2a+json`. Without explicitly allow-listing both,
-  // `express.json()` parses only `application/json`.
   app.use(
     express.json({
       limit: '1mb',
-      type: [LEGACY_JSON_CONTENT_TYPE, A2A_CONTENT_TYPE],
+      type: [V03_CONTENT_TYPE, V1_CONTENT_TYPE],
     })
   );
-
   app.post('/webhook/task-updates', (req, res) => {
     const token = req.header('X-A2A-Notification-Token');
     if (token !== WEBHOOK_TOKEN) {
@@ -299,17 +117,14 @@ async function startWebhookReceiver(): Promise<void> {
     }
     const contentType = req.header('Content-Type') ?? '(missing)';
     const body = req.body ?? {};
-
     const taskId = eventTaskId(body);
     if (taskId) {
       const bucket = capturedWebhooks.get(taskId) ?? [];
       bucket.push({ contentType, body });
       capturedWebhooks.set(taskId, bucket);
     }
-
     res.status(200).json({ received: true });
   });
-
   await new Promise<void>((resolve, reject) => {
     app.listen(WEBHOOK_PORT, (err) => {
       if (err) {
@@ -322,47 +137,43 @@ async function startWebhookReceiver(): Promise<void> {
   });
 }
 
-function printReceivedWebhooks(taskId: string, expectedContentType: string): void {
-  const events = capturedWebhooks.get(taskId) ?? [];
-  console.log(`[Webhook] Captured ${events.length} webhook(s) for task ${taskId}:`);
-  for (const event of events) {
-    const match = event.contentType === expectedContentType ? '✓' : '?';
-    console.log(`[Webhook]   Content-Type: ${event.contentType} ${match}`);
-    // Print a one-line summary that's distinctive per wire shape.
-    const summary = summarizeWebhookBody(event.body);
-    console.log(`[Webhook]   Body summary: ${summary}`);
-  }
-}
-
 function summarizeWebhookBody(body: unknown): string {
   if (!body || typeof body !== 'object') return String(body);
   const b = body as Record<string, unknown>;
-  // v1.0 outer-discriminator
   for (const key of ['task', 'statusUpdate', 'artifactUpdate', 'message']) {
     if (b[key]) {
       return `v1.0 StreamResponse{${key}}`;
     }
   }
-  // v0.3 inner-discriminator
   if (typeof b['kind'] === 'string') {
     return `v0.3 bare event{kind: '${b['kind']}'}`;
   }
   return JSON.stringify(body).slice(0, 80);
 }
 
+function printReceivedWebhooks(taskId: string, expectedContentType: string): void {
+  const events = capturedWebhooks.get(taskId) ?? [];
+  console.log(`[Webhook] Captured ${events.length} webhook(s) for task ${taskId}:`);
+  for (const event of events) {
+    const match = event.contentType === expectedContentType ? '✓' : '?';
+    console.log(`[Webhook]   Content-Type: ${event.contentType} ${match}`);
+    console.log(`[Webhook]   Body summary: ${summarizeWebhookBody(event.body)}`);
+  }
+}
+
 // =============================================================================
-// Helpers
+// Compat-aware client factory
 // =============================================================================
 
 /**
  * Builds a "compat-aware" v1.0 client factory: every transport factory
  * AND the card resolver have `legacyCompat: { enabled: true }` set, so
- * the same factory can talk to both v1.0 servers and v0.3 servers.
+ * the same factory can talk to both v1.0 and v0.3 servers.
  *
- * Note that `ClientFactory` itself doesn't take a `legacyCompat`
- * option — the opt-in is per transport factory and per resolver. This
- * mirrors the server side, where each handler (jsonRpcHandler,
- * restHandler, agentCardHandler) takes its own `legacyCompat` opt-in.
+ * `ClientFactory` itself doesn't take a `legacyCompat` option — the
+ * opt-in is per transport factory and per resolver. This mirrors the
+ * server side, where each Express handler takes its own `legacyCompat`
+ * opt-in.
  */
 function makeCompatAwareFactory(): ClientFactory {
   return new ClientFactory(
@@ -381,6 +192,10 @@ function describeClient(client: Client, label: string): void {
   const transportClass = Object.getPrototypeOf(client.transport).constructor.name;
   console.log(`[Client] ${label}: transport=${transportClass} version=${client.protocolVersion}`);
 }
+
+// =============================================================================
+// Message helpers
+// =============================================================================
 
 function buildSendMessageRequest(
   text: string,
@@ -491,15 +306,6 @@ function printPart(part: Part): void {
   }
 }
 
-// =============================================================================
-// Push-notification helpers
-// =============================================================================
-
-/**
- * Sends a non-streaming message with a webhook config and waits until
- * the in-process receiver observes a terminal status event for the new
- * task. Returns the taskId so the caller can print the captured events.
- */
 async function sendWithPushAndWait(client: Client): Promise<string> {
   const params = buildSendMessageRequest('long-running task with push notification', {
     url: WEBHOOK_URL,
@@ -513,10 +319,9 @@ async function sendWithPushAndWait(client: Client): Promise<string> {
   console.log(
     `[Client] sendMessage returned task id=${taskId} state=${taskStateToJSON(result.status!.state)}`
   );
-  // `sendMessage` (default `returnImmediately: false`) returns once the
-  // task reaches a terminal state, but the server-side push dispatch
-  // happens in a fire-and-forget code path. Give the receiver a short
-  // grace window to absorb any in-flight webhooks before we print.
+  // `sendMessage` returns once the task reaches a terminal state, but
+  // the server-side push dispatch is fire-and-forget. Small grace
+  // window so all webhooks land before we print.
   await sleep(500);
   return taskId;
 }
@@ -525,137 +330,85 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-/**
- * Builds a v0.3-only synthetic AgentCard pointing at the compat
- * server's JSON-RPC URL. Handed to a compat-aware `ClientFactory`, the
- * factory's `JsonRpcTransportFactory` will see `protocolVersion: '0.3'`
- * on the matched interface and dispatch to `LegacyJsonRpcTransport`.
- * This is how we coerce a v0.3 wire path against a server whose primary
- * card is v1.0.
- */
-function makeV03OnlyCardForCompatServer(): AgentCard {
-  return {
-    name: 'Compat Server (v0.3 facade)',
-    description:
-      'Synthetic card used by the client driver to force the v0.3 wire path ' +
-      'against the compat server (whose well-known card is v1.0-primary).',
-    supportedInterfaces: [
-      {
-        url: COMPAT_JSON_RPC_URL,
-        protocolBinding: 'JSONRPC',
-        tenant: '',
-        protocolVersion: A2A_LEGACY_PROTOCOL_VERSION,
-      },
-    ],
-    provider: { organization: 'A2A Samples', url: 'https://example.com/a2a-samples' },
-    version: '0.3.0',
-    capabilities: {
-      streaming: true,
-      pushNotifications: true,
-      extensions: [],
-      extendedAgentCard: false,
-    },
-    securitySchemes: {},
-    securityRequirements: [],
-    defaultInputModes: ['text'],
-    defaultOutputModes: ['text', 'task-status'],
-    skills: [],
-    documentationUrl: '',
-    signatures: [],
-  };
-}
-
 // =============================================================================
 // Main
 // =============================================================================
 
 async function main(): Promise<void> {
   console.log(
-    `[Client] Compat server:    ${COMPAT_BASE_URL} (HTTP) / ${COMPAT_GRPC_TARGET} (gRPC)`
+    `[Client] v1.0+compat server: ${COMPAT_BASE_URL} (HTTP) / ${COMPAT_GRPC_TARGET} (gRPC)`
   );
-  console.log(`[Client] Pure-v0.3 server: ${V03_ONLY_BASE_URL} (in-process)`);
-  console.log(`[Client] Webhook receiver: ${WEBHOOK_URL} (in-process)`);
+  console.log(`[Client] Mock v0.3 server:   ${MOCK_V03_BASE_URL} (in-process)`);
+  console.log(`[Client] Webhook receiver:   ${WEBHOOK_URL} (in-process)`);
   console.log(`[Client] Make sure the compat server is running: npm run agents:compat-v1-server`);
 
-  // Spin up the in-process pure-v0.3 server and webhook receiver.
-  await Promise.all([startPureV03Server(), startWebhookReceiver()]);
+  await Promise.all([startMockV03Server({ port: MOCK_V03_PORT }), startWebhookReceiver()]);
 
   // ---------------------------------------------------------------------------
-  // Compat-aware v1.0 client against the dual-version compat server.
-  // The hybrid card carries an embedded v1.0 `supportedInterfaces[]`, so the
-  // resolver picks the v1.0 representation: no downgrade dance even though
-  // `legacyCompat` is on.
+  // 1. Compat-aware v1.0 client → v1.0+compat server (JSON-RPC).
+  //    The server's hybrid card carries v1.0 `supportedInterfaces[]`,
+  //    so the resolver picks v1.0 even though `legacyCompat` is on
+  //    (no downgrade dance).
   // ---------------------------------------------------------------------------
-  console.log(`\n[Client] === Connecting to compat server over HTTP (JSON-RPC) ===`);
+  console.log(`\n[Client] === v1.0+compat server, JSON-RPC ===`);
   const compatHttpClient = await makeCompatAwareFactory().createFromUrl(COMPAT_BASE_URL);
-  describeClient(compatHttpClient, 'compat-aware → compat server');
-  await runRoundTrip(compatHttpClient, 'hello from compat-aware client to compat server');
+  describeClient(compatHttpClient, 'compat-aware → v1.0 server');
+  await runRoundTrip(compatHttpClient, 'hello v1.0 server');
 
   // ---------------------------------------------------------------------------
-  // Same factory wiring against the pure-v0.3 server.
-  // The legacy card has no embedded `supportedInterfaces`; the resolver
-  // translates it, every synthesized interface carries `protocolVersion: '0.3'`,
-  // and the `JsonRpcTransportFactory` dispatches to `LegacyJsonRpcTransport`.
+  // 2. Same compat-aware factory → mock v0.3 server.
+  //    The server's card has no `supportedInterfaces[]`; the resolver
+  //    detects v0.3 by response shape, and the
+  //    `JsonRpcTransportFactory` dispatches to its v0.3 transport
+  //    automatically.
   // ---------------------------------------------------------------------------
-  console.log(`\n[Client] === Connecting to pure-v0.3 server over HTTP (JSON-RPC) ===`);
-  const v03Client = await makeCompatAwareFactory().createFromUrl(V03_ONLY_BASE_URL);
-  describeClient(v03Client, 'compat-aware → pure-v0.3 server');
-  await runRoundTrip(v03Client, 'hello from compat-aware client to pure-v0.3 server');
+  console.log(`\n[Client] === Mock v0.3 server, JSON-RPC ===`);
+  const mockV03Client = await makeCompatAwareFactory().createFromUrl(MOCK_V03_BASE_URL);
+  describeClient(mockV03Client, 'compat-aware → mock v0.3 server');
+  await runRoundTrip(mockV03Client, 'hello v0.3 server');
 
   // ---------------------------------------------------------------------------
-  // gRPC-only factory against the compat server, to show the same
-  // compat-dispatch logic on a different transport.
+  // 3. Compat-aware factory → v1.0+compat server over gRPC.
   // ---------------------------------------------------------------------------
-  console.log(`\n[Client] === Connecting to compat server over gRPC ===`);
+  console.log(`\n[Client] === v1.0+compat server, gRPC ===`);
   const grpcFactory = new ClientFactory(
     ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
       cardResolver: new DefaultAgentCardResolver({ legacyCompat: { enabled: true } }),
       transports: [new GrpcTransportFactory({ legacyCompat: { enabled: true } })],
-      // Force gRPC even though the card lists JSONRPC first.
       preferredTransports: ['GRPC'],
     })
   );
   const grpcClient = await grpcFactory.createFromUrl(COMPAT_BASE_URL);
-  describeClient(grpcClient, 'compat-aware → compat server (gRPC)');
-  await runRoundTrip(grpcClient, 'hello from compat-aware client to compat server over gRPC');
+  describeClient(grpcClient, 'compat-aware → v1.0 server (gRPC)');
+  await runRoundTrip(grpcClient, 'hello v1.0 server over gRPC');
 
   // ---------------------------------------------------------------------------
-  // Push-notification round-trip: v1.0 client → compat server.
-  // The compat server uses `createLegacyAwarePushNotificationSender`,
-  // which picks the V1PushNotificationSerializer because the
-  // registration context carries `requestedVersion: '1.0'`. The webhook
-  // body is the v1.0 `StreamResponse` envelope with
-  // `Content-Type: application/a2a+json`.
+  // 4. v1.0 push notification: client → v1.0+compat server.
+  //    Webhook body: v1.0 `StreamResponse` envelopes, `application/a2a+json`.
   // ---------------------------------------------------------------------------
-  console.log(`\n[Client] === v1.0 push notification → compat server ===`);
+  console.log(`\n[Client] === Push notification → v1.0+compat server ===`);
   const v1PushClient = await makeCompatAwareFactory().createFromUrl(COMPAT_BASE_URL);
-  describeClient(v1PushClient, 'v1.0 push → compat server');
+  describeClient(v1PushClient, 'push → v1.0 server');
   const v1TaskId = await sendWithPushAndWait(v1PushClient);
-  printReceivedWebhooks(v1TaskId, A2A_CONTENT_TYPE);
+  printReceivedWebhooks(v1TaskId, V1_CONTENT_TYPE);
 
   // ---------------------------------------------------------------------------
-  // Push-notification round-trip: v0.3 client → SAME compat server.
-  // We force the v0.3 wire path by handing the factory a synthetic
-  // v0.3-only card; the compat-aware JsonRpcTransportFactory dispatches
-  // to LegacyJsonRpcTransport. On the server side, the registration
-  // context carries `requestedVersion: '0.3'`, so the same
-  // (legacy-aware) sender picks V03PushNotificationSerializer for THIS
-  // webhook. The webhook body is a bare v0.3 event with
-  // `Content-Type: application/json`.
+  // 5. v0.3 push notification: client → mock v0.3 server.
+  //    Webhook body: bare v0.3 events with inner `kind` discriminator,
+  //    `application/json`. Same compat-aware client code as step 4;
+  //    the wire-shape difference comes entirely from the peer.
   // ---------------------------------------------------------------------------
-  console.log(`\n[Client] === v0.3 push notification → compat server (same server!) ===`);
-  const v03PushClient = await makeCompatAwareFactory().createFromAgentCard(
-    makeV03OnlyCardForCompatServer()
-  );
-  describeClient(v03PushClient, 'v0.3 push → compat server');
+  console.log(`\n[Client] === Push notification → mock v0.3 server ===`);
+  const v03PushClient = await makeCompatAwareFactory().createFromUrl(MOCK_V03_BASE_URL);
+  describeClient(v03PushClient, 'push → mock v0.3 server');
   const v03TaskId = await sendWithPushAndWait(v03PushClient);
-  printReceivedWebhooks(v03TaskId, LEGACY_JSON_CONTENT_TYPE);
+  printReceivedWebhooks(v03TaskId, V03_CONTENT_TYPE);
 
   console.log(`\n[Client] Done.`);
 
   // The in-process fixtures, webhook receiver, and gRPC transport own
-  // native resources; an explicit exit avoids leaving the process
-  // hanging on Node's event loop.
+  // native resources; an explicit exit avoids hanging on Node's event
+  // loop.
   process.exit(0);
 }
 

--- a/src/samples/agents/compat-v1-client/index.ts
+++ b/src/samples/agents/compat-v1-client/index.ts
@@ -126,14 +126,15 @@ async function startWebhookReceiver(): Promise<void> {
     res.status(200).json({ received: true });
   });
   await new Promise<void>((resolve, reject) => {
-    app.listen(WEBHOOK_PORT, (err) => {
-      if (err) {
-        reject(err);
-        return;
-      }
+    // Express's `app.listen` does NOT pass an error to its callback —
+    // the callback is registered for the `'listening'` event and takes
+    // no arguments. Startup errors (e.g. `EADDRINUSE`) are emitted on
+    // the returned server instance via the `'error'` event.
+    const server = app.listen(WEBHOOK_PORT, () => {
       console.log(`[Webhook] In-process receiver on ${WEBHOOK_URL}`);
       resolve();
     });
+    server.on('error', reject);
   });
 }
 
@@ -251,21 +252,21 @@ function printStreamEvent(event: StreamResponse): void {
   const payload = event.payload;
   if (!payload) return;
   switch (payload.$case) {
-    case 'task':
-      console.log(
-        `[Client] task           id=${payload.value.id} state=${taskStateToJSON(payload.value.status!.state)}`
-      );
+    case 'task': {
+      // `status` is optional on the proto `Task`; guard against a peer
+      // that emits a task without one.
+      const state = payload.value.status ? taskStateToJSON(payload.value.status.state) : 'UNKNOWN';
+      console.log(`[Client] task           id=${payload.value.id} state=${state}`);
       break;
-    case 'statusUpdate':
-      console.log(
-        `[Client] statusUpdate   task=${payload.value.taskId} state=${taskStateToJSON(
-          payload.value.status!.state
-        )}`
-      );
+    }
+    case 'statusUpdate': {
+      const state = payload.value.status ? taskStateToJSON(payload.value.status.state) : 'UNKNOWN';
+      console.log(`[Client] statusUpdate   task=${payload.value.taskId} state=${state}`);
       if (payload.value.status?.message) {
         printMessage(payload.value.status.message);
       }
       break;
+    }
     case 'artifactUpdate':
       console.log(
         `[Client] artifactUpdate task=${payload.value.taskId} artifact=${payload.value.artifact?.name ?? '(unnamed)'}`
@@ -316,9 +317,8 @@ async function sendWithPushAndWait(client: Client): Promise<string> {
     throw new Error('Expected a Task in the sendMessage response');
   }
   const taskId = result.id;
-  console.log(
-    `[Client] sendMessage returned task id=${taskId} state=${taskStateToJSON(result.status!.state)}`
-  );
+  const state = result.status ? taskStateToJSON(result.status.state) : 'UNKNOWN';
+  console.log(`[Client] sendMessage returned task id=${taskId} state=${state}`);
   // `sendMessage` returns once the task reaches a terminal state, but
   // the server-side push dispatch is fire-and-forget. Small grace
   // window so all webhooks land before we print.

--- a/src/samples/agents/compat-v1-client/index.ts
+++ b/src/samples/agents/compat-v1-client/index.ts
@@ -1,0 +1,665 @@
+/**
+ * Sample: v1.0-native A2A client driver showcasing the v0.3 compat layer.
+ *
+ * Pairs with `../compat-v1-server/` (the dual-version A2A server). See
+ * `src/compat/v0_3/README.md` for the underlying architecture.
+ *
+ * Flow:
+ *   1. Spin up an in-process pure-v0.3 server so the second half of the
+ *      driver has something legacy to talk to.
+ *   2. Spin up an in-process webhook receiver that accepts BOTH the v1.0
+ *      `application/a2a+json` `StreamResponse` envelope AND the v0.3
+ *      `application/json` bare-event body, then prints what it received
+ *      so the wire-shape difference is visible at runtime.
+ *   3. Open a "compat-aware" v1.0 client (with `legacyCompat: { enabled:
+ *      true }` opted in on every transport factory and on the card
+ *      resolver) against the dual-version compat server. Confirm that
+ *      it Just Works without downgrading the wire to v0.3, then run a
+ *      streaming send-message round-trip.
+ *   4. Reuse the SAME factory wiring against the pure-v0.3 server.
+ *      Confirm the resolver detected the v0.3-shaped card by response
+ *      shape, the factory dispatched to `LegacyJsonRpcTransport`, and
+ *      run another streaming send-message round-trip to prove the
+ *      v0.3 wire path is exercised end-to-end.
+ *   5. Switch to a gRPC-only factory against the compat server's
+ *      gRPC endpoint, to demonstrate the same compat-dispatch logic on
+ *      a different transport.
+ *   6. Register a v1.0 webhook against the compat server (via
+ *      `JsonRpcTransport`). The server's
+ *      `createLegacyAwarePushNotificationSender` picks the
+ *      `V1PushNotificationSerializer` because the registration context
+ *      carries `requestedVersion: '1.0'`. The webhook receiver shows
+ *      `application/a2a+json` `StreamResponse` envelopes.
+ *   7. Register a v0.3 webhook against the SAME compat server (via
+ *      `LegacyJsonRpcTransport`, by handing the factory a synthetic
+ *      v0.3-only card pointing at the compat server's URL). The
+ *      registration context carries `requestedVersion: '0.3'`, so the
+ *      same sender picks the `V03PushNotificationSerializer` for THIS
+ *      webhook. The webhook receiver shows `application/json` bare
+ *      v0.3 events on the same server.
+ *
+ * Each step prints the resolved transport class + protocol version so
+ * the dispatch decisions are visible in the output.
+ */
+
+import express from 'express';
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  AGENT_CARD_PATH,
+  AgentCard,
+  Message,
+  Part,
+  SendMessageRequest,
+  StreamResponse,
+  TaskPushNotificationConfig,
+  taskStateToJSON,
+} from '../../../index.js';
+import { Role } from '../../../types/pb/a2a.js';
+import {
+  Client,
+  ClientFactory,
+  ClientFactoryOptions,
+  DefaultAgentCardResolver,
+  JsonRpcTransportFactory,
+  RestTransportFactory,
+} from '../../../client/index.js';
+import { GrpcTransportFactory } from '../../../client/transports/grpc/grpc_transport.js';
+import {
+  DefaultRequestHandler,
+  InMemoryTaskStore,
+  ServerCallContext,
+  UnauthenticatedUser,
+} from '../../../server/index.js';
+import { toCompatAgentCard } from '../../../compat/v0_3/translate/agent_card.js';
+import { LegacyJsonRpcTransportHandler } from '../../../compat/v0_3/server/transports/jsonrpc/jsonrpc_transport_handler.js';
+import {
+  A2A_LEGACY_PROTOCOL_VERSION,
+  LEGACY_JSON_CONTENT_TYPE,
+} from '../../../compat/v0_3/constants.js';
+import { A2A_CONTENT_TYPE } from '../../../constants.js';
+import { SSE_HEADERS, formatSSEEvent, formatSSEErrorEvent } from '../../../sse_utils.js';
+import { SampleAgentExecutor } from '../sample-agent/agent_executor.js';
+
+// --- Server endpoints ---
+//
+// Default to the compat server defined in `../compat-v1-server/index.ts`.
+// Override via env if you've moved it.
+const COMPAT_HTTP_PORT = Number(process.env.COMPAT_HTTP_PORT || 41251);
+const COMPAT_GRPC_PORT = Number(process.env.COMPAT_GRPC_PORT || 41252);
+const COMPAT_BASE_URL = `http://localhost:${COMPAT_HTTP_PORT}`;
+const COMPAT_GRPC_TARGET = `localhost:${COMPAT_GRPC_PORT}`;
+const COMPAT_JSON_RPC_URL = `${COMPAT_BASE_URL}/a2a/jsonrpc`;
+
+// In-process pure-v0.3 server so the showcase is self-contained.
+const V03_ONLY_PORT = Number(process.env.V03_ONLY_PORT || 41253);
+const V03_ONLY_BASE_URL = `http://localhost:${V03_ONLY_PORT}`;
+
+// In-process webhook receiver for the push-notification half of the demo.
+const WEBHOOK_PORT = Number(process.env.WEBHOOK_PORT || 42424);
+const WEBHOOK_URL = `http://localhost:${WEBHOOK_PORT}/webhook/task-updates`;
+const WEBHOOK_TOKEN = 'compat-demo-token';
+
+// =============================================================================
+// Pure v0.3 in-process server (used by step 4).
+// =============================================================================
+
+/**
+ * Spawns a deliberately-pure v0.3 server: only the legacy JSON-RPC
+ * handler and a single well-known card endpoint that serves a
+ * v0.3-shaped body unconditionally. This is the "legacy server in the
+ * wild" fixture that a v1.0 client with compat opted in is supposed to
+ * interoperate with transparently.
+ */
+async function startPureV03Server(): Promise<void> {
+  const card: AgentCard = {
+    name: 'Pure v0.3 Server',
+    description: 'A deliberately pure v0.3 server used by the compat client showcase.',
+    supportedInterfaces: [
+      {
+        url: `${V03_ONLY_BASE_URL}/a2a/jsonrpc`,
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        // The source card declares v0.3 — that's what makes this a "pure
+        // v0.3 server". `toCompatAgentCard` below relies on a legacy
+        // interface being present to pick the primary URL for the v0.3
+        // card it emits on the wire.
+        protocolVersion: A2A_LEGACY_PROTOCOL_VERSION,
+      },
+    ],
+    provider: { organization: 'A2A Samples', url: 'https://example.com/a2a-samples' },
+    // `version` here is the AGENT implementation version (free-form),
+    // not the A2A protocol version — protocol version lives on each
+    // `supportedInterfaces[]` entry above. Pinning it to `0.3.0` keeps
+    // the "pure v0.3" story consistent for human readers, even though
+    // the SDK never inspects this value.
+    version: '0.3.0',
+    capabilities: {
+      streaming: true,
+      pushNotifications: false,
+      extensions: [],
+      extendedAgentCard: false,
+    },
+    securitySchemes: {},
+    securityRequirements: [],
+    defaultInputModes: ['text'],
+    defaultOutputModes: ['text', 'task-status'],
+    skills: [
+      {
+        id: 'sample_agent',
+        name: 'Sample Agent',
+        description: 'Reuses the SampleAgentExecutor over the v0.3 wire.',
+        tags: ['sample', 'v0.3'],
+        examples: ['hi'],
+        inputModes: ['text'],
+        outputModes: ['text', 'task-status'],
+        securityRequirements: [],
+      },
+    ],
+    documentationUrl: '',
+    signatures: [],
+  };
+
+  const requestHandler = new DefaultRequestHandler(
+    card,
+    new InMemoryTaskStore(),
+    new SampleAgentExecutor()
+  );
+
+  const app = express();
+
+  // Pre-translated v0.3 card, served unconditionally. We bypass the
+  // SDK's `legacyAgentCardRouter` here because that router only emits a
+  // v0.3 body for legacy-range `A2A-Version` headers, and the SDK's
+  // `DefaultAgentCardResolver` always sends `A2A-Version: 1.0` on the
+  // discovery request to avoid a downgrade dance — detection is
+  // response-shape based by design.
+  const legacyCard = toCompatAgentCard(await requestHandler.getAgentCard());
+  app.get(`/${AGENT_CARD_PATH}`, (_req, res) => {
+    res.setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE);
+    res.status(200).send(JSON.stringify(legacyCard));
+  });
+
+  const legacyJsonRpc = new LegacyJsonRpcTransportHandler(requestHandler);
+  app.post(
+    '/a2a/jsonrpc',
+    express.json({ type: LEGACY_JSON_CONTENT_TYPE, strict: false }),
+    async (req, res) => {
+      try {
+        const context = new ServerCallContext({
+          requestedExtensions: [],
+          user: new UnauthenticatedUser(),
+          requestedVersion: '0.3',
+        });
+        const result = await legacyJsonRpc.handle(req.body, context);
+        if (
+          result &&
+          typeof (result as AsyncIterable<unknown>)[Symbol.asyncIterator] === 'function'
+        ) {
+          // Streaming method: pump v0.3 envelopes back as SSE — one
+          // JSON-RPC envelope per `data:` line, mirroring what
+          // `LegacyJsonRpcTransport._sendStreamingRequest` parses on
+          // the client side.
+          for (const [key, value] of Object.entries(SSE_HEADERS)) {
+            res.setHeader(key, value);
+          }
+          res.flushHeaders();
+          try {
+            for await (const event of result as AsyncIterable<unknown>) {
+              res.write(formatSSEEvent(event));
+            }
+          } catch (streamErr) {
+            res.write(formatSSEErrorEvent({ code: -32603, message: (streamErr as Error).message }));
+          } finally {
+            res.end();
+          }
+          return;
+        }
+        res.setHeader('Content-Type', LEGACY_JSON_CONTENT_TYPE);
+        res.status(200).json(result);
+      } catch (err: unknown) {
+        res
+          .status(500)
+          .json({ jsonrpc: '2.0', error: { code: -32603, message: (err as Error).message } });
+      }
+    }
+  );
+
+  await new Promise<void>((resolve, reject) => {
+    app.listen(V03_ONLY_PORT, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      console.log(`[V03Server] In-process pure-v0.3 server on ${V03_ONLY_BASE_URL}`);
+      resolve();
+    });
+  });
+}
+
+// =============================================================================
+// Webhook receiver (used by steps 6 and 7).
+// =============================================================================
+
+/**
+ * A single received webhook POST, captured for printing.
+ */
+interface ReceivedWebhook {
+  contentType: string;
+  body: unknown;
+}
+
+/**
+ * All webhook deliveries captured so far, bucketed by taskId. The
+ * webhook handler appends to this map for every accepted POST,
+ * regardless of whether anyone is "watching" the task yet — this avoids
+ * the race where the v1.0 `sendMessage` (which blocks until the task
+ * reaches a terminal state) returns AFTER the server has already
+ * dispatched several webhooks. Callers query the map by taskId AFTER
+ * the round-trip completes.
+ */
+const capturedWebhooks = new Map<string, ReceivedWebhook[]>();
+
+function eventTaskId(body: unknown): string | undefined {
+  if (!body || typeof body !== 'object') return undefined;
+  const b = body as Record<string, unknown>;
+  // v1.0 StreamResponse envelope: `{ task: {...} }` / `{ statusUpdate: {...} }` etc.
+  for (const key of ['task', 'statusUpdate', 'artifactUpdate', 'message']) {
+    const inner = b[key];
+    if (inner && typeof inner === 'object') {
+      const ib = inner as Record<string, unknown>;
+      if (typeof ib['id'] === 'string') return ib['id'] as string;
+      if (typeof ib['taskId'] === 'string') return ib['taskId'] as string;
+    }
+  }
+  // v0.3 bare event: `kind` lives on the body itself.
+  if (typeof b['id'] === 'string' && b['kind'] === 'task') return b['id'] as string;
+  if (typeof b['taskId'] === 'string') return b['taskId'] as string;
+  return undefined;
+}
+
+async function startWebhookReceiver(): Promise<void> {
+  const app = express();
+
+  // Accept BOTH content types: v0.3 sends `application/json`, v1.0 sends
+  // `application/a2a+json`. Without explicitly allow-listing both,
+  // `express.json()` parses only `application/json`.
+  app.use(
+    express.json({
+      limit: '1mb',
+      type: [LEGACY_JSON_CONTENT_TYPE, A2A_CONTENT_TYPE],
+    })
+  );
+
+  app.post('/webhook/task-updates', (req, res) => {
+    const token = req.header('X-A2A-Notification-Token');
+    if (token !== WEBHOOK_TOKEN) {
+      res.status(401).json({ error: 'Unauthorized' });
+      return;
+    }
+    const contentType = req.header('Content-Type') ?? '(missing)';
+    const body = req.body ?? {};
+
+    const taskId = eventTaskId(body);
+    if (taskId) {
+      const bucket = capturedWebhooks.get(taskId) ?? [];
+      bucket.push({ contentType, body });
+      capturedWebhooks.set(taskId, bucket);
+    }
+
+    res.status(200).json({ received: true });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    app.listen(WEBHOOK_PORT, (err) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      console.log(`[Webhook] In-process receiver on ${WEBHOOK_URL}`);
+      resolve();
+    });
+  });
+}
+
+function printReceivedWebhooks(taskId: string, expectedContentType: string): void {
+  const events = capturedWebhooks.get(taskId) ?? [];
+  console.log(`[Webhook] Captured ${events.length} webhook(s) for task ${taskId}:`);
+  for (const event of events) {
+    const match = event.contentType === expectedContentType ? '✓' : '?';
+    console.log(`[Webhook]   Content-Type: ${event.contentType} ${match}`);
+    // Print a one-line summary that's distinctive per wire shape.
+    const summary = summarizeWebhookBody(event.body);
+    console.log(`[Webhook]   Body summary: ${summary}`);
+  }
+}
+
+function summarizeWebhookBody(body: unknown): string {
+  if (!body || typeof body !== 'object') return String(body);
+  const b = body as Record<string, unknown>;
+  // v1.0 outer-discriminator
+  for (const key of ['task', 'statusUpdate', 'artifactUpdate', 'message']) {
+    if (b[key]) {
+      return `v1.0 StreamResponse{${key}}`;
+    }
+  }
+  // v0.3 inner-discriminator
+  if (typeof b['kind'] === 'string') {
+    return `v0.3 bare event{kind: '${b['kind']}'}`;
+  }
+  return JSON.stringify(body).slice(0, 80);
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Builds a "compat-aware" v1.0 client factory: every transport factory
+ * AND the card resolver have `legacyCompat: { enabled: true }` set, so
+ * the same factory can talk to both v1.0 servers and v0.3 servers.
+ *
+ * Note that `ClientFactory` itself doesn't take a `legacyCompat`
+ * option — the opt-in is per transport factory and per resolver. This
+ * mirrors the server side, where each handler (jsonRpcHandler,
+ * restHandler, agentCardHandler) takes its own `legacyCompat` opt-in.
+ */
+function makeCompatAwareFactory(): ClientFactory {
+  return new ClientFactory(
+    ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+      cardResolver: new DefaultAgentCardResolver({ legacyCompat: { enabled: true } }),
+      transports: [
+        new JsonRpcTransportFactory({ legacyCompat: { enabled: true } }),
+        new RestTransportFactory({ legacyCompat: { enabled: true } }),
+        new GrpcTransportFactory({ legacyCompat: { enabled: true } }),
+      ],
+    })
+  );
+}
+
+function describeClient(client: Client, label: string): void {
+  const transportClass = Object.getPrototypeOf(client.transport).constructor.name;
+  console.log(`[Client] ${label}: transport=${transportClass} version=${client.protocolVersion}`);
+}
+
+function buildSendMessageRequest(
+  text: string,
+  push?: { url: string; token: string }
+): SendMessageRequest {
+  const taskPushNotificationConfig: TaskPushNotificationConfig | undefined = push
+    ? {
+        id: '',
+        taskId: '',
+        tenant: '',
+        url: push.url,
+        token: push.token,
+        authentication: undefined,
+      }
+    : undefined;
+  return {
+    tenant: '',
+    metadata: {},
+    message: {
+      messageId: uuidv4(),
+      role: Role.ROLE_USER,
+      parts: [
+        {
+          content: { $case: 'text', value: text },
+          metadata: undefined,
+          filename: '',
+          mediaType: 'text/plain',
+        },
+      ],
+      taskId: '',
+      contextId: '',
+      extensions: [],
+      metadata: {},
+      referenceTaskIds: [],
+    },
+    configuration: push
+      ? {
+          acceptedOutputModes: ['text/plain'],
+          taskPushNotificationConfig,
+          returnImmediately: false,
+        }
+      : undefined,
+  };
+}
+
+async function runRoundTrip(client: Client, text: string): Promise<void> {
+  for await (const event of client.sendMessageStream(buildSendMessageRequest(text))) {
+    printStreamEvent(event);
+  }
+}
+
+function printStreamEvent(event: StreamResponse): void {
+  const payload = event.payload;
+  if (!payload) return;
+  switch (payload.$case) {
+    case 'task':
+      console.log(
+        `[Client] task           id=${payload.value.id} state=${taskStateToJSON(payload.value.status!.state)}`
+      );
+      break;
+    case 'statusUpdate':
+      console.log(
+        `[Client] statusUpdate   task=${payload.value.taskId} state=${taskStateToJSON(
+          payload.value.status!.state
+        )}`
+      );
+      if (payload.value.status?.message) {
+        printMessage(payload.value.status.message);
+      }
+      break;
+    case 'artifactUpdate':
+      console.log(
+        `[Client] artifactUpdate task=${payload.value.taskId} artifact=${payload.value.artifact?.name ?? '(unnamed)'}`
+      );
+      for (const part of payload.value.artifact?.parts ?? []) {
+        printPart(part);
+      }
+      break;
+    case 'message':
+      console.log(`[Client] message        messageId=${payload.value.messageId}`);
+      printMessage(payload.value);
+      break;
+  }
+}
+
+function printMessage(message: Message): void {
+  for (const part of message.parts) {
+    printPart(part);
+  }
+}
+
+function printPart(part: Part): void {
+  const c = part.content;
+  if (!c) return;
+  switch (c.$case) {
+    case 'text':
+      console.log(`[Client]   text: ${c.value}`);
+      break;
+    case 'data':
+      console.log(`[Client]   data: ${JSON.stringify(c.value)}`);
+      break;
+    case 'url':
+      console.log(`[Client]   url:  ${c.value}`);
+      break;
+    case 'raw':
+      console.log(`[Client]   raw:  (${c.value.length} bytes)`);
+      break;
+  }
+}
+
+// =============================================================================
+// Push-notification helpers
+// =============================================================================
+
+/**
+ * Sends a non-streaming message with a webhook config and waits until
+ * the in-process receiver observes a terminal status event for the new
+ * task. Returns the taskId so the caller can print the captured events.
+ */
+async function sendWithPushAndWait(client: Client): Promise<string> {
+  const params = buildSendMessageRequest('long-running task with push notification', {
+    url: WEBHOOK_URL,
+    token: WEBHOOK_TOKEN,
+  });
+  const result = await client.sendMessage(params);
+  if (!('id' in result)) {
+    throw new Error('Expected a Task in the sendMessage response');
+  }
+  const taskId = result.id;
+  console.log(
+    `[Client] sendMessage returned task id=${taskId} state=${taskStateToJSON(result.status!.state)}`
+  );
+  // `sendMessage` (default `returnImmediately: false`) returns once the
+  // task reaches a terminal state, but the server-side push dispatch
+  // happens in a fire-and-forget code path. Give the receiver a short
+  // grace window to absorb any in-flight webhooks before we print.
+  await sleep(500);
+  return taskId;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Builds a v0.3-only synthetic AgentCard pointing at the compat
+ * server's JSON-RPC URL. Handed to a compat-aware `ClientFactory`, the
+ * factory's `JsonRpcTransportFactory` will see `protocolVersion: '0.3'`
+ * on the matched interface and dispatch to `LegacyJsonRpcTransport`.
+ * This is how we coerce a v0.3 wire path against a server whose primary
+ * card is v1.0.
+ */
+function makeV03OnlyCardForCompatServer(): AgentCard {
+  return {
+    name: 'Compat Server (v0.3 facade)',
+    description:
+      'Synthetic card used by the client driver to force the v0.3 wire path ' +
+      'against the compat server (whose well-known card is v1.0-primary).',
+    supportedInterfaces: [
+      {
+        url: COMPAT_JSON_RPC_URL,
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: A2A_LEGACY_PROTOCOL_VERSION,
+      },
+    ],
+    provider: { organization: 'A2A Samples', url: 'https://example.com/a2a-samples' },
+    version: '0.3.0',
+    capabilities: {
+      streaming: true,
+      pushNotifications: true,
+      extensions: [],
+      extendedAgentCard: false,
+    },
+    securitySchemes: {},
+    securityRequirements: [],
+    defaultInputModes: ['text'],
+    defaultOutputModes: ['text', 'task-status'],
+    skills: [],
+    documentationUrl: '',
+    signatures: [],
+  };
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+async function main(): Promise<void> {
+  console.log(
+    `[Client] Compat server:    ${COMPAT_BASE_URL} (HTTP) / ${COMPAT_GRPC_TARGET} (gRPC)`
+  );
+  console.log(`[Client] Pure-v0.3 server: ${V03_ONLY_BASE_URL} (in-process)`);
+  console.log(`[Client] Webhook receiver: ${WEBHOOK_URL} (in-process)`);
+  console.log(`[Client] Make sure the compat server is running: npm run agents:compat-v1-server`);
+
+  // Spin up the in-process pure-v0.3 server and webhook receiver.
+  await Promise.all([startPureV03Server(), startWebhookReceiver()]);
+
+  // ---------------------------------------------------------------------------
+  // Compat-aware v1.0 client against the dual-version compat server.
+  // The hybrid card carries an embedded v1.0 `supportedInterfaces[]`, so the
+  // resolver picks the v1.0 representation: no downgrade dance even though
+  // `legacyCompat` is on.
+  // ---------------------------------------------------------------------------
+  console.log(`\n[Client] === Connecting to compat server over HTTP (JSON-RPC) ===`);
+  const compatHttpClient = await makeCompatAwareFactory().createFromUrl(COMPAT_BASE_URL);
+  describeClient(compatHttpClient, 'compat-aware → compat server');
+  await runRoundTrip(compatHttpClient, 'hello from compat-aware client to compat server');
+
+  // ---------------------------------------------------------------------------
+  // Same factory wiring against the pure-v0.3 server.
+  // The legacy card has no embedded `supportedInterfaces`; the resolver
+  // translates it, every synthesized interface carries `protocolVersion: '0.3'`,
+  // and the `JsonRpcTransportFactory` dispatches to `LegacyJsonRpcTransport`.
+  // ---------------------------------------------------------------------------
+  console.log(`\n[Client] === Connecting to pure-v0.3 server over HTTP (JSON-RPC) ===`);
+  const v03Client = await makeCompatAwareFactory().createFromUrl(V03_ONLY_BASE_URL);
+  describeClient(v03Client, 'compat-aware → pure-v0.3 server');
+  await runRoundTrip(v03Client, 'hello from compat-aware client to pure-v0.3 server');
+
+  // ---------------------------------------------------------------------------
+  // gRPC-only factory against the compat server, to show the same
+  // compat-dispatch logic on a different transport.
+  // ---------------------------------------------------------------------------
+  console.log(`\n[Client] === Connecting to compat server over gRPC ===`);
+  const grpcFactory = new ClientFactory(
+    ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+      cardResolver: new DefaultAgentCardResolver({ legacyCompat: { enabled: true } }),
+      transports: [new GrpcTransportFactory({ legacyCompat: { enabled: true } })],
+      // Force gRPC even though the card lists JSONRPC first.
+      preferredTransports: ['GRPC'],
+    })
+  );
+  const grpcClient = await grpcFactory.createFromUrl(COMPAT_BASE_URL);
+  describeClient(grpcClient, 'compat-aware → compat server (gRPC)');
+  await runRoundTrip(grpcClient, 'hello from compat-aware client to compat server over gRPC');
+
+  // ---------------------------------------------------------------------------
+  // Push-notification round-trip: v1.0 client → compat server.
+  // The compat server uses `createLegacyAwarePushNotificationSender`,
+  // which picks the V1PushNotificationSerializer because the
+  // registration context carries `requestedVersion: '1.0'`. The webhook
+  // body is the v1.0 `StreamResponse` envelope with
+  // `Content-Type: application/a2a+json`.
+  // ---------------------------------------------------------------------------
+  console.log(`\n[Client] === v1.0 push notification → compat server ===`);
+  const v1PushClient = await makeCompatAwareFactory().createFromUrl(COMPAT_BASE_URL);
+  describeClient(v1PushClient, 'v1.0 push → compat server');
+  const v1TaskId = await sendWithPushAndWait(v1PushClient);
+  printReceivedWebhooks(v1TaskId, A2A_CONTENT_TYPE);
+
+  // ---------------------------------------------------------------------------
+  // Push-notification round-trip: v0.3 client → SAME compat server.
+  // We force the v0.3 wire path by handing the factory a synthetic
+  // v0.3-only card; the compat-aware JsonRpcTransportFactory dispatches
+  // to LegacyJsonRpcTransport. On the server side, the registration
+  // context carries `requestedVersion: '0.3'`, so the same
+  // (legacy-aware) sender picks V03PushNotificationSerializer for THIS
+  // webhook. The webhook body is a bare v0.3 event with
+  // `Content-Type: application/json`.
+  // ---------------------------------------------------------------------------
+  console.log(`\n[Client] === v0.3 push notification → compat server (same server!) ===`);
+  const v03PushClient = await makeCompatAwareFactory().createFromAgentCard(
+    makeV03OnlyCardForCompatServer()
+  );
+  describeClient(v03PushClient, 'v0.3 push → compat server');
+  const v03TaskId = await sendWithPushAndWait(v03PushClient);
+  printReceivedWebhooks(v03TaskId, LEGACY_JSON_CONTENT_TYPE);
+
+  console.log(`\n[Client] Done.`);
+
+  // The in-process fixtures, webhook receiver, and gRPC transport own
+  // native resources; an explicit exit avoids leaving the process
+  // hanging on Node's event loop.
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('[Client] Error:', err);
+  process.exit(1);
+});

--- a/src/samples/agents/compat-v1-server/README.md
+++ b/src/samples/agents/compat-v1-server/README.md
@@ -1,0 +1,183 @@
+# Compat v1.0 Server
+
+A v1.0-native A2A server that accepts BOTH modern (v1.0) and legacy (v0.3) clients
+on the **same URLs**, across **all three transports**, without duplicating any
+`supportedInterfaces` entries.
+
+This is the server half of a two-part showcase of the `@a2a-js/sdk` v0.3 compat
+layer; the client half lives next to it under
+[`../compat-v1-client/`](../compat-v1-client/). See
+[`src/compat/v0_3/README.md`](../../../compat/v0_3/README.md) for the underlying
+architecture (translators, header dispatch, hybrid agent card synthesis).
+
+## What the sample demonstrates
+
+| Surface             | URL                                                     | Accepts v1.0?      | Accepts v0.3?                              |
+| ------------------- | ------------------------------------------------------- | ------------------ | ------------------------------------------ |
+| Agent card          | `http://localhost:41251/.well-known/agent-card.json`    | yes (modern shape) | yes (hybrid shape, default when no header) |
+| JSON-RPC            | `http://localhost:41251/a2a/jsonrpc`                    | yes                | yes (body-shape detection)                 |
+| REST (v1.0)         | `http://localhost:41251/a2a/rest/<operation>`           | yes                | n/a (different paths)                      |
+| REST (v0.3)         | `http://localhost:41251/a2a/rest/v1/<operation>`        | n/a (404)          | yes                                        |
+| gRPC                | `localhost:41252`                                       | yes (`A2AService`) | yes (`LegacyA2AService`)                   |
+| Push notifications  | Per-webhook (registered via any of the above)           | yes (`application/a2a+json` `StreamResponse`) | yes (`application/json` bare event) |
+
+A single `DefaultRequestHandler` backs every transport AND every version — the
+business logic only ever sees v1.0 types; the compat layer translates v0.3 wire
+shapes to v1.0 (and back) transparently.
+
+For push notifications, the server wires `createLegacyAwarePushNotificationSender`
+from `@a2a-js/sdk/compat/v0_3/server`, which pre-registers a
+`V03PushNotificationSerializer` alongside the built-in `V1PushNotificationSerializer`.
+The `InMemoryPushNotificationStore` captures `context.requestedVersion` at
+registration time, so each webhook keeps receiving the wire shape it was
+originally registered with — v0.3 and v1.0 webhooks coexist on the SAME task.
+
+## Running
+
+```bash
+npm run agents:compat-v1-server
+```
+
+You should see:
+
+```
+[CompatServer] HTTP server started on http://localhost:41251
+  JSON-RPC : http://localhost:41251/a2a/jsonrpc  (v1.0 + v0.3)
+  REST v1.0: http://localhost:41251/a2a/rest/message:send  (and other `/<operation>` routes)
+  REST v0.3: http://localhost:41251/a2a/rest/v1/message:send  (and other `/v1/...` routes)
+  Card     : http://localhost:41251/.well-known/agent-card.json  (hybrid: shape depends on A2A-Version header)
+  Push     : v1.0 webhooks receive application/a2a+json StreamResponse envelopes
+             v0.3 webhooks receive application/json     bare-event bodies
+[CompatServer] gRPC server started on localhost:41252  (v1.0 + v0.3)
+```
+
+## Talking to the server
+
+### Agent card: hybrid response
+
+```bash
+# v0.3 client (or any client that omits `A2A-Version`, which §3.6.2 defaults to '0.3'):
+curl -sS http://localhost:41251/.well-known/agent-card.json | jq
+
+# Response includes v0.3 top-level fields (`url`, `preferredTransport`,
+# `additionalInterfaces`, `protocolVersion: "0.3"`) AND the original v1.0
+# `supportedInterfaces[]` array (the hybrid embedding). Either kind of
+# resolver can discover the same agent without operator-side duplication.
+```
+
+```bash
+# v1.0 client: receives the modern proto-JSON card unchanged.
+curl -sS -H 'A2A-Version: 1.0' http://localhost:41251/.well-known/agent-card.json | jq
+```
+
+`Vary: A2A-Version` is set on every response so shared HTTP caches keep separate
+entries per version.
+
+### JSON-RPC: same endpoint, both wire shapes
+
+```bash
+# v0.3 (legacy) JSON-RPC: method names are kebab-style, parts use the `kind` discriminator.
+curl -sS -X POST http://localhost:41251/a2a/jsonrpc \
+  -H 'Content-Type: application/json' \
+  -H 'A2A-Version: 0.3' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "messageId": "demo-v03",
+        "role": "user",
+        "parts": [{ "kind": "text", "text": "hello" }]
+      }
+    }
+  }'
+```
+
+```bash
+# v1.0 JSON-RPC: method names are PascalCase, parts use the `oneof content` shape.
+curl -sS -X POST http://localhost:41251/a2a/jsonrpc \
+  -H 'Content-Type: application/json' \
+  -H 'A2A-Version: 1.0' \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "SendMessage",
+    "params": {
+      "message": {
+        "messageId": "demo-v10",
+        "role": "ROLE_USER",
+        "parts": [{ "text": "hello", "mediaType": "text/plain" }]
+      }
+    }
+  }'
+```
+
+### REST: disjoint paths
+
+The v0.3 reference REST surface (`/v1/...`) and the v1.0 REST surface
+(`/<operation>` per spec §11.3) coexist under the same mount point.
+
+```bash
+# v0.3 REST: per the v0.3 a2a.proto google.api.http annotations.
+curl -sS -X POST http://localhost:41251/a2a/rest/v1/message:send \
+  -H 'Content-Type: application/json' \
+  -H 'A2A-Version: 0.3' \
+  -d '{
+    "request": {
+      "message": {
+        "messageId": "demo-rest-v03",
+        "role": "user",
+        "parts": [{ "kind": "text", "text": "hello" }]
+      }
+    }
+  }'
+```
+
+```bash
+# v1.0 REST: bare proto-JSON `SendMessageRequest`, no JSON-RPC envelope.
+curl -sS -X POST http://localhost:41251/a2a/rest/message:send \
+  -H 'Content-Type: application/json' \
+  -H 'A2A-Version: 1.0' \
+  -d '{
+    "message": {
+      "messageId": "demo-rest-v10",
+      "role": "ROLE_USER",
+      "parts": [{ "text": "hello", "mediaType": "text/plain" }]
+    }
+  }'
+```
+
+### gRPC: two services on one port
+
+Use `grpcurl` (or any v0.3 / v1.0 gRPC client) against `localhost:41252`. The
+v1.0 service is named `a2a.v1.A2AService`; the v0.3 service is named
+`a2a.v1.A2AService` in its own descriptor (the proto-package names overlap by
+spec — they're discriminated by descriptor, not by name). The companion
+[`../compat-v1-client/`](../compat-v1-client/) sample exercises both via the
+SDK's gRPC transport factory.
+
+## Talking to the server with the bundled CLI
+
+The CLI at `samples/cli.ts` is a v1.0-native client. It Just Works against this
+server because the v1.0 surface is unchanged:
+
+```bash
+# Auto-discovers from the agent card and picks the first matching transport.
+npm run a2a:cli http://localhost:41251
+
+# Force a specific transport:
+npm run a2a:cli http://localhost:41251 -- --transport=HTTP+JSON
+npm run a2a:cli http://localhost:41251 -- --transport=GRPC
+```
+
+To drive the legacy paths from a real SDK client, run the companion
+[`compat-v1-client`](../compat-v1-client/) sample, which uses
+`legacyCompat: { enabled: true }` on every transport factory.
+
+## Configuration
+
+| Variable    | Default | Description                 |
+| ----------- | ------- | --------------------------- |
+| `HTTP_PORT` | `41251` | JSON-RPC + REST + AgentCard |
+| `GRPC_PORT` | `41252` | gRPC service                |

--- a/src/samples/agents/compat-v1-server/README.md
+++ b/src/samples/agents/compat-v1-server/README.md
@@ -118,8 +118,27 @@ curl -sS -X POST http://localhost:41251/a2a/jsonrpc \
 The v0.3 reference REST surface (`/v1/...`) and the v1.0 REST surface
 (`/<operation>` per spec §11.3) coexist under the same mount point.
 
+**Both** REST surfaces speak **proto-JSON** of their respective proto types
+(per each version's `google.api.http` annotations), NOT the JSON-Schema-style
+bodies with `kind:` discriminators that you'd send over v0.3 JSON-RPC. This
+matches the cross-SDK convention. The v0.3 and v1.0 REST bodies look very similar
+on the wire — the differences are field renames and the response `Content-Type` header:
+
+| Aspect              | v0.3 REST                     | v1.0 REST                     |
+| ------------------- | ----------------------------- | ----------------------------- |
+| Path prefix         | `/v1/<operation>`             | `/<operation>` (no `/v1/`)    |
+| Request field name  | `request` (a `Message`)       | `message` (a `Message`)       |
+| `Message` payload   | `content[]`                   | `parts[]`                     |
+| `role` encoding     | proto enum (`ROLE_USER`)      | proto enum (`ROLE_USER`)      |
+| Response shape      | proto-JSON `SendMessageResponse` (`{task: {...}}` or `{msg: {...}}` oneof) | proto-JSON `SendMessageResponse` (same shape) |
+| Response `Content-Type` | `application/json`        | `application/a2a+json`        |
+| Response `state` enum | `TASK_STATE_COMPLETED`      | `TASK_STATE_COMPLETED`        |
+
 ```bash
 # v0.3 REST: per the v0.3 a2a.proto google.api.http annotations.
+# Body is proto-JSON `SendMessageRequest` (the v0.3 proto's Message has
+# `content[]` instead of v1.0's `parts[]`, and the outer field is
+# `request` instead of `message`).
 curl -sS -X POST http://localhost:41251/a2a/rest/v1/message:send \
   -H 'Content-Type: application/json' \
   -H 'A2A-Version: 0.3' \
@@ -131,6 +150,25 @@ curl -sS -X POST http://localhost:41251/a2a/rest/v1/message:send \
     }
   }'
 ```
+
+```bash
+# v1.0 REST: bare proto-JSON `SendMessageRequest`, no JSON-RPC envelope.
+curl -sS -X POST http://localhost:41251/a2a/rest/message:send \
+  -H 'Content-Type: application/json' \
+  -H 'A2A-Version: 1.0' \
+  -d '{
+    "message": {
+      "messageId": "demo-rest-v10",
+      "role": "ROLE_USER",
+      "parts": [{ "text": "hello", "mediaType": "text/plain" }]
+    }
+  }'
+```
+
+If you want a v0.3 wire shape with JSON-Schema-style `{kind: 'task', state:
+'completed', parts: [{kind: 'text', ...}]}` envelopes, use the v0.3 JSON-RPC
+endpoint (`/a2a/jsonrpc` above) — that's the surface that emits and accepts
+the JSON-Schema spec types verbatim.
 
 ```bash
 # v1.0 REST: bare proto-JSON `SendMessageRequest`, no JSON-RPC envelope.

--- a/src/samples/agents/compat-v1-server/README.md
+++ b/src/samples/agents/compat-v1-server/README.md
@@ -125,11 +125,9 @@ curl -sS -X POST http://localhost:41251/a2a/rest/v1/message:send \
   -H 'A2A-Version: 0.3' \
   -d '{
     "request": {
-      "message": {
-        "messageId": "demo-rest-v03",
-        "role": "user",
-        "parts": [{ "kind": "text", "text": "hello" }]
-      }
+      "messageId": "demo-rest-v03",
+      "role": "ROLE_USER",
+      "content": [{ "text": "hello", "mediaType": "text/plain" }]
     }
   }'
 ```

--- a/src/samples/agents/compat-v1-server/index.ts
+++ b/src/samples/agents/compat-v1-server/index.ts
@@ -213,10 +213,12 @@ async function main() {
     })
   );
 
-  app.listen(HTTP_PORT, (err) => {
-    if (err) {
-      throw err;
-    }
+  // Express's `app.listen` does NOT pass an error to its callback —
+  // the callback is registered for the `'listening'` event and takes no
+  // arguments. Startup errors (e.g. `EADDRINUSE`) are emitted on the
+  // returned server instance via the `'error'` event, so we listen for
+  // both explicitly.
+  const httpServer = app.listen(HTTP_PORT, () => {
     console.log(`[CompatServer] HTTP server started on http://localhost:${HTTP_PORT}`);
     console.log(`  JSON-RPC : http://localhost:${HTTP_PORT}/a2a/jsonrpc  (v1.0 + v0.3)`);
     console.log(
@@ -233,6 +235,10 @@ async function main() {
     );
     console.log(`  Push     : v1.0 webhooks receive application/a2a+json StreamResponse envelopes`);
     console.log(`             v0.3 webhooks receive application/json     bare-event bodies`);
+  });
+  httpServer.on('error', (err) => {
+    console.error('[CompatServer] HTTP server failed to start:', err);
+    process.exit(1);
   });
 
   // 3. gRPC server: register BOTH the v1.0 and v0.3 services on the

--- a/src/samples/agents/compat-v1-server/index.ts
+++ b/src/samples/agents/compat-v1-server/index.ts
@@ -1,0 +1,264 @@
+/**
+ * Sample: v1.0-native A2A server with v0.3 compatibility enabled across
+ * every transport, INCLUDING push notifications.
+ *
+ * This sample is the server side of a two-part showcase of the
+ * `@a2a-js/sdk` v0.3 compat layer (see `src/compat/v0_3/README.md`). It
+ * runs ONE shared `DefaultRequestHandler` behind:
+ *
+ *   - JSON-RPC over HTTP, with `legacyCompat: { enabled: true }` so the
+ *     same endpoint accepts both v1.0 and v0.3 JSON-RPC bodies.
+ *   - HTTP+JSON/REST, with `legacyCompat: { enabled: true }` so the same
+ *     mount point serves both the v1.0 `POST /message:send` style routes
+ *     AND the v0.3 reference `POST /v1/message:send` style routes.
+ *   - gRPC, with the v1.0 `A2AService` AND the v0.3 `LegacyA2AService`
+ *     registered side by side on a single gRPC `Server` (per the compat
+ *     README §"Version negotiation under legacyCompat" — the v1.0 gRPC
+ *     factory deliberately has no `legacyCompat` flag).
+ *   - The well-known agent-card endpoint, with `legacyCompat: { enabled:
+ *     true }` so the response shape adapts to the requester's
+ *     `A2A-Version` header (defaulting to `'0.3'` when absent per
+ *     §3.6.2).
+ *   - Push notifications, wired through
+ *     `createLegacyAwarePushNotificationSender`, which pre-registers a
+ *     `V03PushNotificationSerializer` alongside the built-in
+ *     `V1PushNotificationSerializer`. Webhooks registered over a v0.3
+ *     transport receive v0.3-shaped bodies (`application/json`, bare
+ *     event); webhooks registered over a v1.0 transport receive
+ *     `application/a2a+json` `StreamResponse` envelopes — on the SAME
+ *     task, on the same server.
+ *
+ * The agent card declared below intentionally contains ONLY v1.0
+ * `supportedInterfaces` entries. The compat layer synthesizes the v0.3
+ * surface automatically — no operator duplication required — which is
+ * the whole point of opting into `legacyCompat`.
+ */
+
+import express from 'express';
+import { Server, ServerCredentials } from '@grpc/grpc-js';
+
+import { A2A_PROTOCOL_VERSION, AGENT_CARD_PATH, AgentCard } from '../../../index.js';
+import {
+  AgentExecutor,
+  DefaultRequestHandler,
+  InMemoryPushNotificationStore,
+  InMemoryTaskStore,
+  TaskStore,
+} from '../../../server/index.js';
+import {
+  agentCardHandler,
+  jsonRpcHandler,
+  restHandler,
+  UserBuilder,
+} from '../../../server/express/index.js';
+import {
+  A2AService,
+  LegacyA2AService,
+  grpcService,
+  legacyGrpcService,
+} from '../../../server/grpc/index.js';
+import { createLegacyAwarePushNotificationSender } from '../../../compat/v0_3/server/index.js';
+import { SampleAgentExecutor } from '../sample-agent/agent_executor.js';
+
+// --- Configuration ---
+
+const HTTP_PORT = Number(process.env.HTTP_PORT || 41251);
+const GRPC_PORT = Number(process.env.GRPC_PORT || 41252);
+
+// --- Agent Card ---
+//
+// NOTE: only v1.0 (`A2A_PROTOCOL_VERSION`) interfaces are declared. With
+// `legacyCompat: { enabled: true }` set on the well-known agent-card
+// handler, requests carrying `A2A-Version: 0.3` (or no header at all,
+// which §3.6.2 defaults to `'0.3'`) receive a HYBRID card synthesized
+// by the compat layer: the same interface URLs are re-presented under
+// the v0.3 protocol version at the card's top level (`url` /
+// `preferredTransport` / `additionalInterfaces`), AND the v1.0
+// `supportedInterfaces[]` array is left intact. See
+// `src/compat/v0_3/server/express/agent_card_handler.ts`.
+
+const compatServerCard: AgentCard = {
+  name: 'Compat v1.0 Server',
+  description:
+    'A v1.0-native A2A server that opts into the v0.3 compat layer on every ' +
+    'transport (including push notifications). Accepts both modern ' +
+    '(A2A-Version: 1.0) and legacy (A2A-Version: 0.3 or absent) clients on ' +
+    'the SAME URLs without any duplication of `supportedInterfaces` entries.',
+  supportedInterfaces: [
+    {
+      url: `http://localhost:${HTTP_PORT}/a2a/jsonrpc`,
+      protocolBinding: 'JSONRPC',
+      tenant: '',
+      protocolVersion: A2A_PROTOCOL_VERSION,
+    },
+    {
+      url: `http://localhost:${HTTP_PORT}/a2a/rest`,
+      protocolBinding: 'HTTP+JSON',
+      tenant: '',
+      protocolVersion: A2A_PROTOCOL_VERSION,
+    },
+    {
+      url: `localhost:${GRPC_PORT}`,
+      protocolBinding: 'GRPC',
+      tenant: '',
+      protocolVersion: A2A_PROTOCOL_VERSION,
+    },
+  ],
+  provider: {
+    organization: 'A2A Samples',
+    url: 'https://example.com/a2a-samples',
+  },
+  version: '1.0.0',
+  capabilities: {
+    streaming: true,
+    // Required to opt into push notification support. Without this flag,
+    // `DefaultRequestHandler` short-circuits every webhook registration
+    // and never invokes the sender (see §4.3 of the spec).
+    pushNotifications: true,
+    extensions: [],
+    extendedAgentCard: false,
+  },
+  securitySchemes: {},
+  securityRequirements: [],
+  defaultInputModes: ['text'],
+  defaultOutputModes: ['text', 'task-status'],
+  skills: [
+    {
+      id: 'sample_agent',
+      name: 'Sample Agent',
+      description:
+        'Reuses the SampleAgentExecutor across all transports and across ' +
+        'both protocol versions. Publishes task / working / artifact / ' +
+        'completed events — enough to exercise the push notification path.',
+      tags: ['sample', 'compat', 'v0.3', 'push-notification'],
+      examples: ['hi', 'hello', 'how are you'],
+      inputModes: ['text'],
+      outputModes: ['text', 'task-status'],
+      securityRequirements: [],
+    },
+  ],
+  documentationUrl: '',
+  signatures: [],
+};
+
+async function main() {
+  // 1. One TaskStore, one AgentExecutor, one PushNotificationStore, one
+  //    sender — shared across every transport AND every protocol
+  //    version. The compat layer translates v0.3 ↔ v1.0 on the wire;
+  //    the business logic only ever sees v1.0 types.
+  const taskStore: TaskStore = new InMemoryTaskStore();
+  const agentExecutor: AgentExecutor = new SampleAgentExecutor();
+
+  // Push notifications: `createLegacyAwarePushNotificationSender`
+  // returns a canonical `DefaultPushNotificationSender` seeded with
+  // `V1PushNotificationSerializer` for the `'1.0'` wire version AND
+  // `V03PushNotificationSerializer` for the `'0.3'` wire version. The
+  // store captures `context.requestedVersion` at registration time, so
+  // every webhook keeps receiving the wire shape it was originally
+  // registered with — even when later events on the same task are
+  // triggered by requests on the other transport.
+  const pushNotificationStore = new InMemoryPushNotificationStore();
+  const pushNotificationSender = createLegacyAwarePushNotificationSender(pushNotificationStore, {
+    timeout: 5000,
+    tokenHeaderName: 'X-A2A-Notification-Token',
+  });
+
+  const requestHandler = new DefaultRequestHandler(
+    compatServerCard,
+    taskStore,
+    agentExecutor,
+    undefined, // eventBusManager (use default)
+    pushNotificationStore,
+    pushNotificationSender
+  );
+
+  // 2. Express app: JSON-RPC + REST + AgentCard, every handler with
+  //    `legacyCompat: { enabled: true }`.
+  const app = express();
+
+  // Agent card: serves a v1.0 card to v1.0 clients and a HYBRID
+  // (v0.3 top-level fields + embedded v1.0 `supportedInterfaces`) card
+  // to v0.3 clients. `Vary: A2A-Version` ensures HTTP caches keep
+  // separate entries per version.
+  app.use(
+    `/${AGENT_CARD_PATH}`,
+    agentCardHandler({
+      agentCardProvider: requestHandler,
+      legacyCompat: { enabled: true },
+    })
+  );
+
+  // JSON-RPC: inspects every incoming body and routes v0.3-shaped
+  // requests through `LegacyJsonRpcTransportHandler`, v1.0-shaped
+  // requests through the modern handler. Both paths share `requestHandler`.
+  app.use(
+    '/a2a/jsonrpc',
+    jsonRpcHandler({
+      requestHandler,
+      userBuilder: UserBuilder.noAuthentication,
+      legacyCompat: { enabled: true },
+    })
+  );
+
+  // REST: mounts the v0.3 `/v1/...` route set (per the v0.3 reference
+  // proto's `google.api.http` annotations) at the SAME mount point as
+  // the v1.0 routes. Express's path matcher disambiguates by prefix:
+  // `POST /a2a/rest/v1/message:send` → legacy; `POST /a2a/rest/message:send` → v1.0.
+  app.use(
+    '/a2a/rest',
+    restHandler({
+      requestHandler,
+      userBuilder: UserBuilder.noAuthentication,
+      legacyCompat: { enabled: true },
+    })
+  );
+
+  app.listen(HTTP_PORT, (err) => {
+    if (err) {
+      throw err;
+    }
+    console.log(`[CompatServer] HTTP server started on http://localhost:${HTTP_PORT}`);
+    console.log(`  JSON-RPC : http://localhost:${HTTP_PORT}/a2a/jsonrpc  (v1.0 + v0.3)`);
+    console.log(
+      `  REST v1.0: http://localhost:${HTTP_PORT}/a2a/rest/message:send  (and other ` +
+        `${'`/<operation>`'} routes)`
+    );
+    console.log(
+      `  REST v0.3: http://localhost:${HTTP_PORT}/a2a/rest/v1/message:send  (and other ` +
+        `${'`/v1/...`'} routes)`
+    );
+    console.log(
+      `  Card     : http://localhost:${HTTP_PORT}/${AGENT_CARD_PATH}  ` +
+        `(hybrid: shape depends on A2A-Version header)`
+    );
+    console.log(`  Push     : v1.0 webhooks receive application/a2a+json StreamResponse envelopes`);
+    console.log(`             v0.3 webhooks receive application/json     bare-event bodies`);
+  });
+
+  // 3. gRPC server: register BOTH the v1.0 and v0.3 services on the
+  //    same `grpc.Server` instance. The v1.0 gRPC factory intentionally
+  //    has no `legacyCompat` opt-in (it would be ambiguous over gRPC,
+  //    where the service descriptor itself is the version) — the
+  //    canonical way to support v0.3 gRPC clients is to register
+  //    `legacyGrpcService` alongside `grpcService`.
+  const grpcServer = new Server();
+  grpcServer.addService(
+    A2AService,
+    grpcService({ requestHandler, userBuilder: UserBuilder.noAuthentication })
+  );
+  grpcServer.addService(
+    LegacyA2AService,
+    legacyGrpcService({ requestHandler, userBuilder: UserBuilder.noAuthentication })
+  );
+  grpcServer.bindAsync(`localhost:${GRPC_PORT}`, ServerCredentials.createInsecure(), (err) => {
+    if (err) {
+      console.error('[CompatServer] gRPC bind failed:', err);
+      return;
+    }
+    console.log(`[CompatServer] gRPC server started on localhost:${GRPC_PORT}  (v1.0 + v0.3)`);
+  });
+
+  console.log('[CompatServer] Press Ctrl+C to stop the server');
+}
+
+main().catch(console.error);

--- a/src/samples/package.json
+++ b/src/samples/package.json
@@ -14,6 +14,8 @@
     "agents:multi-transport-agent": "tsx agents/multi-transport-agent/index.ts",
     "agents:cancellable-agent": "tsx agents/cancellable-agent/index.ts",
     "agents:cancellable-client": "tsx agents/cancellable-agent/client.ts",
+    "agents:compat-v1-server": "tsx agents/compat-v1-server/index.ts",
+    "agents:compat-v1-client": "tsx agents/compat-v1-client/index.ts",
     "client:interceptors": "tsx client/interceptors/index.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description

Add an end-to-end demo of the new legacyCompat opt-in for v0.3 ↔ v1.0 interoperability under src/samples/agents/:

`compat-v1-server/index.ts` — v1.0-native A2A server with legacyCompat: { enabled: true } on every Express handler (agentCardHandler, jsonRpcHandler, restHandler) and the v0.3 LegacyA2AService registered side-by-side with v1.0 A2AService on one gRPC server. Push notifications wired via createLegacyAwarePushNotificationSender + InMemoryPushNotificationStore. The agent card declares v1.0 interfaces only; v0.3 is synthesized by the compat layer. One DefaultRequestHandler + SampleAgentExecutor backs every transport and both protocol versions.

`compat-v1-client/index.ts` — v1.0-native driver using only the public client API (ClientFactory + DefaultAgentCardResolver + per-transport factories, all with legacyCompat: { enabled: true }). Runs five back-to-back connections that exercise the full compat surface from a single uniform client: v1.0+compat server over JSON-RPC (no downgrade), mock v0.3 server over JSON-RPC (auto-dispatch to LegacyJsonRpcTransport), v1.0+compat server over gRPC, v1.0 push notification (webhook receives application/a2a+json StreamResponse envelopes), and v0.3 push notification (webhook receives application/json bare events).

`compat-v1-client/_mock-v0_3-server.ts` — hand-rolled in-process v0.3 fixture so the demo is self-contained. Every wire response is a literal JSON template matching the v0.3 spec verbatim; deliberately imports nothing from @a2a-js/sdk/compat/v0_3/server and carries a header comment warning readers not to copy it as a v0.3 server template.

Closes #492  🦕
