### PR TITLE
fix(server): handle AUTH_REQUIRED lifecycle per spec

### DIFF
--- a/src/server/events/execution_event_queue.ts
+++ b/src/server/events/execution_event_queue.ts
@@ -1,5 +1,5 @@
 import { ExecutionEventBus, AgentExecutionEvent } from './execution_event_bus.js';
-import { INTERRUPTED_STATE_LIST, TERMINAL_STATE_LIST } from '../utils.js';
+import { INPUT_REQUIRED_STATE_LIST, TERMINAL_STATE_LIST } from '../utils.js';
 
 /**
  * An async queue that subscribes to an ExecutionEventBus for events
@@ -43,17 +43,26 @@ export class ExecutionEventQueue {
         //   * a Message (the only event a stateless agent ever produces);
         //   * a terminal Task status (COMPLETED / FAILED / CANCELED /
         //     REJECTED) — the task can never produce further events;
-        //   * an interrupted Task status (INPUT_REQUIRED / AUTH_REQUIRED)
-        //     — the executor has returned and is awaiting a fresh
-        //     message, so blocking consumers must stop iterating; the
-        //     underlying bus stays alive in `DefaultRequestHandler` so
-        //     resubscribers and follow-up sends can still attach.
+        //   * INPUT_REQUIRED — the executor has returned and is
+        //     awaiting a fresh client message, so blocking consumers
+        //     must stop iterating; the underlying bus stays alive in
+        //     `DefaultRequestHandler` so resubscribers and follow-up
+        //     sends can still attach.
+        //
+        // AUTH_REQUIRED is deliberately NOT in the stop set per spec
+        // §7.6.1: the agent is expected to keep publishing on the same
+        // bus immediately after the out-of-band credential injection,
+        // so the queue must stay drainable. A blocking caller in
+        // `DefaultRequestHandler` returns a snapshot at the
+        // AUTH_REQUIRED status update via a separate code path and a
+        // background consumer continues draining this queue until a
+        // terminal state is reached.
         if (
           event.kind === 'message' ||
           (event.kind === 'statusUpdate' &&
             event.data.status &&
             (TERMINAL_STATE_LIST.includes(event.data.status.state) ||
-              INTERRUPTED_STATE_LIST.includes(event.data.status.state)))
+              INPUT_REQUIRED_STATE_LIST.includes(event.data.status.state)))
         ) {
           this.handleFinished();
           break;

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -56,7 +56,13 @@ import { PushNotificationSender } from '../push_notification/push_notification_s
 import { DefaultPushNotificationSender } from '../push_notification/default_push_notification_sender.js';
 import { ServerCallContext } from '../context.js';
 import { DEFAULT_PAGE_SIZE } from '../../constants.js';
-import { INTERRUPTED_STATE_LIST, TERMINAL_STATE_LIST, isTask, StreamPattern } from '../utils.js';
+import {
+  AUTH_REQUIRED_STATE_LIST,
+  INTERRUPTED_STATE_LIST,
+  TERMINAL_STATE_LIST,
+  isTask,
+  StreamPattern,
+} from '../utils.js';
 import { AgentCardSignatureGenerator } from '../../signature.js';
 import { extractErrorMessage } from '../../errors.js';
 
@@ -250,9 +256,32 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     options?: {
       firstResultResolver?: (value: Message | Task) => void;
       firstResultRejector?: (reason?: unknown) => void;
+      /**
+       * If provided, fires (at most once) the first time the queue
+       * yields a `statusUpdate` whose state is in
+       * {@link AUTH_REQUIRED_STATE_LIST}. The callback receives a deep
+       * snapshot of the current Task as known to the `ResultManager`
+       * immediately after the AUTH_REQUIRED event has been persisted.
+       *
+       * The drain loop continues iterating after invocation per spec
+       * §7.6.1: AUTH_REQUIRED is not a stream-terminating state, so the
+       * agent may resume publishing on the same bus as soon as the
+       * credential is injected out-of-band.
+       *
+       * Blocking `sendMessage` uses this hook to return a snapshot to
+       * the caller without tearing down the consumer; the
+       * `ExecutionEventQueue` is configured (see
+       * `INPUT_REQUIRED_STATE_LIST` in `events()`) to keep yielding
+       * after AUTH_REQUIRED, so this same `_processEvents` invocation
+       * continues draining in the background as a fire-and-forget
+       * task until a terminal state — or INPUT_REQUIRED, the other
+       * pause state — is reached.
+       */
+      authRequiredSnapshotResolver?: (snapshot: Task) => void;
     }
   ): Promise<void> {
     let firstResultSent = false;
+    let authRequiredSnapshotSent = false;
     try {
       for await (const event of eventQueue.events()) {
         await resultManager.processEvent(event);
@@ -281,6 +310,30 @@ export class DefaultRequestHandler implements A2ARequestHandler {
             firstResultSent = true;
           }
         }
+
+        // §7.6.1 AUTH_REQUIRED snapshot: hand the blocking caller a
+        // copy of the current Task at the moment the executor signals
+        // it needs a credential, but DO NOT break out of the loop —
+        // the queue is configured to keep yielding past AUTH_REQUIRED
+        // so the executor can resume publishing once the credential
+        // arrives out-of-band.
+        if (
+          options?.authRequiredSnapshotResolver &&
+          !authRequiredSnapshotSent &&
+          event.kind === 'statusUpdate' &&
+          event.data.status &&
+          AUTH_REQUIRED_STATE_LIST.includes(event.data.status.state)
+        ) {
+          const currentTask = resultManager.getCurrentTask();
+          if (currentTask) {
+            // Deep-clone so subsequent in-place mutations by the
+            // continuing drain (status updates, artifact merges)
+            // can't leak into the snapshot the caller already
+            // received.
+            options.authRequiredSnapshotResolver(structuredClone(currentTask));
+            authRequiredSnapshotSent = true;
+          }
+        }
       }
       if (options?.firstResultRejector && !firstResultSent) {
         options.firstResultRejector(
@@ -301,6 +354,34 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       // when the executor settles (see `_runExecutor` / `_runStreamExecutor`).
       eventQueue.stop();
     }
+  }
+
+  /**
+   * Background drain helper used by the blocking `sendMessage` path
+   * after an AUTH_REQUIRED snapshot has been returned to the caller.
+   *
+   * The pending `_processEvents` promise continues iterating the
+   * event queue (which, per §7.6.1, is configured to stay open
+   * through AUTH_REQUIRED) so subsequent agent events keep flowing
+   * into the {@link ResultManager} and push-notification sender until
+   * a terminal — or INPUT_REQUIRED — state arrives and the loop
+   * naturally exits.
+   *
+   * Scheduling: detached via `queueMicrotask` so the caller's `await`
+   * resolves immediately and the drain loop runs in its own
+   * microtask context. The promise is otherwise unattended — any
+   * thrown error is logged and swallowed here so it doesn't surface
+   * as a Node `unhandledRejection`.
+   */
+  private _continueDraining(taskId: string, pending: Promise<void>): void {
+    queueMicrotask(() => {
+      pending.catch((error) => {
+        console.error(
+          `Background AUTH_REQUIRED drain failed for task ${taskId}:`,
+          error instanceof Error ? error.message : error
+        );
+      });
+    });
   }
 
   /**
@@ -399,10 +480,27 @@ export class DefaultRequestHandler implements A2ARequestHandler {
    * Settles the event bus once the executor returns.
    *
    * Terminal states (and the bare-Message pattern in §3.1.2) close the
-   * bus immediately. Interrupted states (INPUT_REQUIRED / AUTH_REQUIRED)
-   * keep it alive so a follow-up `message/send` can resume the same
-   * execution via `createOrGetByTaskId`, and `tasks/resubscribe` can
-   * attach in the meantime (§3.4.3).
+   * bus immediately. Interrupted states keep it alive but for two
+   * subtly different reasons:
+   *
+   *   * INPUT_REQUIRED (§3.4.3): the executor has stopped publishing
+   *     and is waiting on a follow-up `message/send` from the client.
+   *     The bus must survive across calls so `createOrGetByTaskId`
+   *     finds the same instance when the client resumes, and so
+   *     `tasks/resubscribe` can attach in the meantime.
+   *
+   *   * AUTH_REQUIRED (§7.6.1): the executor is expected to resume
+   *     publishing on this same bus as soon as the credential is
+   *     injected out-of-band, with no follow-up client message
+   *     required. A blocking `sendMessage` has already returned a
+   *     snapshot to its caller and its `_processEvents` loop is now
+   *     draining in the background (see `_continueDraining`); the
+   *     bus stays alive so those subsequent publishes still flow
+   *     into `ResultManager` and the push-notification sender.
+   *
+   * Both cases share the same `INTERRUPTED_STATE_LIST` early-return
+   * here because the lifecycle decision — "don't close the bus when
+   * `execute()` returns at this state" — is identical.
    */
   private _settleBus(
     taskId: string,
@@ -539,19 +637,51 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     const historyLengthConfig = params.configuration;
 
     if (isBlocking) {
-      // In blocking mode, wait for the full processing to complete.
-      await this._processEvents(taskId, resultManager, eventQueue, context);
-      const finalResult = resultManager.getFinalResult();
-      if (!finalResult) {
-        throw new GenericError(
-          'Agent execution finished without a result, and no task context found.'
-        );
-      }
-
-      if (isTask(finalResult)) {
-        this._applyHistoryLengthSemantics(finalResult, historyLengthConfig ?? {});
-      }
-      return finalResult;
+      // In blocking mode, the call normally resolves after the full
+      // event drain finishes — the final result comes from the
+      // ResultManager once the queue closes on terminal /
+      // INPUT_REQUIRED / Message.
+      //
+      // AUTH_REQUIRED is the §7.6.1 exception: the blocking caller
+      // gets handed a snapshot of the current Task as soon as the
+      // AUTH_REQUIRED status update is observed, and the drain loop
+      // detaches into the background so the executor can keep
+      // publishing on the same bus after the out-of-band credential
+      // injection (and so the ResultManager / push-notification
+      // pipeline continues servicing those events).
+      return new Promise<Message | Task>((resolve, reject) => {
+        const pending = this._processEvents(taskId, resultManager, eventQueue, context, {
+          authRequiredSnapshotResolver: (snapshot) => {
+            this._applyHistoryLengthSemantics(snapshot, historyLengthConfig ?? {});
+            resolve(snapshot);
+            // Drain continues in the background; see
+            // `_continueDraining` for the unhandled-rejection guard.
+            this._continueDraining(taskId, pending);
+          },
+        });
+        pending
+          .then(() => {
+            // If we already resolved with an AUTH_REQUIRED snapshot
+            // above, this resolve() call is a no-op — Promise
+            // resolution is one-shot, and the background drain only
+            // exists to keep ResultManager + push notifications
+            // current beyond the snapshot.
+            const finalResult = resultManager.getFinalResult();
+            if (!finalResult) {
+              reject(
+                new GenericError(
+                  'Agent execution finished without a result, and no task context found.'
+                )
+              );
+              return;
+            }
+            if (isTask(finalResult)) {
+              this._applyHistoryLengthSemantics(finalResult, historyLengthConfig ?? {});
+            }
+            resolve(finalResult);
+          })
+          .catch(reject);
+      });
     } else {
       // In non-blocking mode, return a promise that will be settled by fullProcessing.
       return new Promise<Message | Task>((resolve, reject) => {

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -332,10 +332,32 @@ export class DefaultRequestHandler implements A2ARequestHandler {
             // received.
             options.authRequiredSnapshotResolver(structuredClone(currentTask));
             authRequiredSnapshotSent = true;
+            // The caller has been handed a result (the snapshot); from
+            // `_handleProcessingError`'s perspective this is
+            // indistinguishable from the non-blocking
+            // first-Task-event resolution. Setting `firstResultSent`
+            // routes any subsequent drain error to the
+            // "first result already sent" branch, where the failure
+            // is persisted as a TASK_STATE_FAILED status update via
+            // `ResultManager` instead of being re-thrown into the
+            // unattended background drain.
+            firstResultSent = true;
           }
         }
       }
-      if (options?.firstResultRejector && !firstResultSent) {
+      // Non-blocking contract guard: the caller wired a
+      // `firstResultResolver` and expects the drain to produce at
+      // least one Task / Message event. If the executor returned
+      // without publishing one, surface the protocol violation via
+      // `firstResultRejector`.
+      //
+      // This is intentionally gated on `firstResultResolver` (not
+      // `firstResultRejector`) so the blocking caller — which also
+      // passes `firstResultRejector` to route post-AUTH_REQUIRED
+      // drain errors — doesn't trip this branch on a normal
+      // INPUT_REQUIRED / terminal exit where no first-result tracking
+      // is meaningful.
+      if (options?.firstResultResolver && options?.firstResultRejector && !firstResultSent) {
         options.firstResultRejector(
           new RequestMalformedError('Execution finished before a message or task was produced.')
         );
@@ -367,20 +389,21 @@ export class DefaultRequestHandler implements A2ARequestHandler {
    * a terminal — or INPUT_REQUIRED — state arrives and the loop
    * naturally exits.
    *
-   * Scheduling: detached via `queueMicrotask` so the caller's `await`
-   * resolves immediately and the drain loop runs in its own
-   * microtask context. The promise is otherwise unattended — any
-   * thrown error is logged and swallowed here so it doesn't surface
-   * as a Node `unhandledRejection`.
+   * Attaches a `.catch` so a thrown error in the unattended drain is
+   * logged instead of surfacing as a Node `unhandledRejection`.
+   * Drain errors that happen *after* the AUTH_REQUIRED snapshot are
+   * already routed through `_handleProcessingError`'s
+   * "first result already sent" branch (which persists a FAILED
+   * status update via `ResultManager`), so this handler is the
+   * last-ditch safety net for synchronous throws inside the drain
+   * machinery itself.
    */
   private _continueDraining(taskId: string, pending: Promise<void>): void {
-    queueMicrotask(() => {
-      pending.catch((error) => {
-        console.error(
-          `Background AUTH_REQUIRED drain failed for task ${taskId}:`,
-          error instanceof Error ? error.message : error
-        );
-      });
+    pending.catch((error) => {
+      console.error(
+        `Background AUTH_REQUIRED drain failed for task ${taskId}:`,
+        error instanceof Error ? error.message : error
+      );
     });
   }
 
@@ -658,6 +681,22 @@ export class DefaultRequestHandler implements A2ARequestHandler {
             // `_continueDraining` for the unhandled-rejection guard.
             this._continueDraining(taskId, pending);
           },
+          // Passing `firstResultRejector` keeps the blocking promise
+          // in sync with `_handleProcessingError`'s tri-state contract
+          // (see `_processEvents`):
+          //   * pre-AUTH_REQUIRED drain error → rejects the outer
+          //     promise so the caller's `await sendMessage(...)`
+          //     throws (same as today's blocking behaviour);
+          //   * post-AUTH_REQUIRED drain error → `firstResultSent` is
+          //     true (set alongside the snapshot resolve), so
+          //     `_handleProcessingError` falls into the
+          //     "first result already sent" branch and persists a
+          //     FAILED status update via `ResultManager` instead of
+          //     re-throwing into the unattended background drain.
+          // Calling `reject` after `resolve` is a no-op (Promise
+          // settlement is one-shot), so this is safe even when the
+          // snapshot path already fired.
+          firstResultRejector: reject,
         });
         pending
           .then(() => {

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -11,16 +11,45 @@ const TERMINAL_STATE_LIST: TaskState[] = [
 export { TERMINAL_STATE_LIST };
 
 /**
- * Non-terminal states that pause the executor and require a follow-up
- * message before progress can resume. The agent's `execute()` is
- * expected to return after publishing one of these states, but the
- * underlying task remains live so a client can resubscribe — or send a
- * fresh message with the same `taskId` — to continue the flow. See
- * §3.4.3 (Input Required State) of the A2A specification.
+ * Non-terminal state in which the executor pauses awaiting a fresh
+ * follow-up message from the client (§3.4.3). Both the executor's
+ * `execute()` call AND the blocking consumer's drain loop stop when
+ * this state is published — there is nothing more to drain until a
+ * subsequent `message/send` reuses the same `taskId`.
+ */
+const INPUT_REQUIRED_STATE_LIST: TaskState[] = [TaskState.TASK_STATE_INPUT_REQUIRED];
+export { INPUT_REQUIRED_STATE_LIST };
+
+/**
+ * Non-terminal state in which the executor pauses awaiting an
+ * out-of-band credential injection (§7.6.1). Unlike INPUT_REQUIRED, the
+ * agent is expected to "immediately continue Task processing after
+ * receiving the credential, without a requirement that clients send a
+ * follow-up message." The response stream therefore MUST NOT be closed
+ * on this state, and a blocking caller MUST be returned a snapshot of
+ * the current Task while the event bus keeps draining in the
+ * background until a terminal state is reached.
+ */
+const AUTH_REQUIRED_STATE_LIST: TaskState[] = [TaskState.TASK_STATE_AUTH_REQUIRED];
+export { AUTH_REQUIRED_STATE_LIST };
+
+/**
+ * Union of {@link INPUT_REQUIRED_STATE_LIST} and
+ * {@link AUTH_REQUIRED_STATE_LIST} — the non-terminal states in which
+ * the executor's `execute()` call returns after a single publish (the
+ * agent is paused, waiting on the client or on external credentials).
+ *
+ * Kept as a re-export for the call sites that genuinely need both
+ * states together — typically terminal/snapshot checks where the
+ * distinction between the two pause reasons doesn't matter (e.g. "have
+ * we reached a steady state from which the blocking caller can return
+ * a snapshot to the client?"). Lifecycle decisions that differ between
+ * the two (closing the bus, stopping the drain loop) MUST use the
+ * specific lists above instead.
  */
 const INTERRUPTED_STATE_LIST: TaskState[] = [
-  TaskState.TASK_STATE_INPUT_REQUIRED,
-  TaskState.TASK_STATE_AUTH_REQUIRED,
+  ...INPUT_REQUIRED_STATE_LIST,
+  ...AUTH_REQUIRED_STATE_LIST,
 ];
 export { INTERRUPTED_STATE_LIST };
 

--- a/test/server/events/execution_event_queue.spec.ts
+++ b/test/server/events/execution_event_queue.spec.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+  DefaultExecutionEventBus,
+  AgentEvent,
+  AgentExecutionEvent,
+} from '../../../src/server/events/execution_event_bus.js';
+import { ExecutionEventQueue } from '../../../src/server/events/execution_event_queue.js';
+import { Message, Role, Task, TaskStatusUpdateEvent } from '../../../src/index.js';
+import { TaskState } from '../../../src/types/pb/a2a.js';
+
+/**
+ * Tests for `ExecutionEventQueue.events()` focused on the stop-set
+ * semantics introduced for spec §7.6.1 AUTH_REQUIRED handling.
+ *
+ * The queue must stop iterating on:
+ *   * Message,
+ *   * any terminal state,
+ *   * INPUT_REQUIRED.
+ *
+ * The queue must KEEP iterating past:
+ *   * AUTH_REQUIRED (executor resumes after out-of-band credential),
+ *   * intermediate non-terminal states (SUBMITTED / WORKING / etc.).
+ */
+describe('ExecutionEventQueue stop semantics', () => {
+  let bus: DefaultExecutionEventBus;
+
+  beforeEach(() => {
+    bus = new DefaultExecutionEventBus();
+  });
+
+  const taskId = 'task-eq-1';
+  const contextId = 'ctx-eq-1';
+
+  const statusEvent = (state: TaskState): AgentExecutionEvent =>
+    AgentEvent.statusUpdate({
+      taskId,
+      contextId,
+      status: { state, message: undefined, timestamp: undefined },
+      metadata: {},
+    } as TaskStatusUpdateEvent);
+
+  const taskEvent: AgentExecutionEvent = AgentEvent.task({
+    id: taskId,
+    contextId,
+    status: { state: TaskState.TASK_STATE_SUBMITTED, message: undefined, timestamp: undefined },
+    artifacts: [],
+    history: [],
+    metadata: {},
+  } as Task);
+
+  const messageEvent: AgentExecutionEvent = AgentEvent.message({
+    messageId: 'msg-1',
+    role: Role.ROLE_AGENT,
+    parts: [
+      {
+        content: { $case: 'text', value: 'hi' },
+        filename: '',
+        mediaType: 'text/plain',
+        metadata: {},
+      },
+    ],
+    taskId,
+    contextId,
+    extensions: [],
+    metadata: {},
+    referenceTaskIds: [],
+  } as Message);
+
+  /**
+   * Helper that drives the queue until it stops on its own, returning
+   * the full list of yielded events. Publishes happen via the bus
+   * before the iteration starts so they're already buffered when
+   * `events()` first awaits.
+   */
+  async function drain(queue: ExecutionEventQueue): Promise<AgentExecutionEvent[]> {
+    const seen: AgentExecutionEvent[] = [];
+    for await (const event of queue.events()) {
+      seen.push(event);
+    }
+    return seen;
+  }
+
+  it('stops after a Message event', async () => {
+    const queue = new ExecutionEventQueue(bus);
+    bus.publish(taskEvent);
+    bus.publish(messageEvent);
+    // Subsequent events would not be yielded after a Message; publish
+    // one to prove it.
+    bus.publish(statusEvent(TaskState.TASK_STATE_WORKING));
+
+    const seen = await drain(queue);
+    expect(seen).toHaveLength(2);
+    expect(seen[1].kind).toBe('message');
+  });
+
+  it('stops on terminal COMPLETED status', async () => {
+    const queue = new ExecutionEventQueue(bus);
+    bus.publish(taskEvent);
+    bus.publish(statusEvent(TaskState.TASK_STATE_COMPLETED));
+    // Anything after a terminal should be ignored.
+    bus.publish(statusEvent(TaskState.TASK_STATE_WORKING));
+
+    const seen = await drain(queue);
+    expect(seen).toHaveLength(2);
+    expect(seen[1].kind).toBe('statusUpdate');
+    expect((seen[1].data as TaskStatusUpdateEvent).status?.state).toBe(
+      TaskState.TASK_STATE_COMPLETED
+    );
+  });
+
+  it.each([
+    ['FAILED', TaskState.TASK_STATE_FAILED],
+    ['CANCELED', TaskState.TASK_STATE_CANCELED],
+    ['REJECTED', TaskState.TASK_STATE_REJECTED],
+  ])('stops on terminal %s status', async (_name, state) => {
+    const queue = new ExecutionEventQueue(bus);
+    bus.publish(taskEvent);
+    bus.publish(statusEvent(state));
+    bus.publish(statusEvent(TaskState.TASK_STATE_WORKING));
+
+    const seen = await drain(queue);
+    expect(seen).toHaveLength(2);
+    expect((seen[1].data as TaskStatusUpdateEvent).status?.state).toBe(state);
+  });
+
+  it('stops on INPUT_REQUIRED (executor is paused waiting on follow-up message)', async () => {
+    const queue = new ExecutionEventQueue(bus);
+    bus.publish(taskEvent);
+    bus.publish(statusEvent(TaskState.TASK_STATE_WORKING));
+    bus.publish(statusEvent(TaskState.TASK_STATE_INPUT_REQUIRED));
+    // Anything published after INPUT_REQUIRED on this queue should be
+    // ignored — a fresh queue (attached to the same bus) is the only
+    // path forward.
+    bus.publish(statusEvent(TaskState.TASK_STATE_WORKING));
+
+    const seen = await drain(queue);
+    expect(seen).toHaveLength(3);
+    expect((seen[2].data as TaskStatusUpdateEvent).status?.state).toBe(
+      TaskState.TASK_STATE_INPUT_REQUIRED
+    );
+  });
+
+  it('does NOT stop on AUTH_REQUIRED — keeps draining for the post-credential publishes (§7.6.1)', async () => {
+    const queue = new ExecutionEventQueue(bus);
+    bus.publish(taskEvent);
+    bus.publish(statusEvent(TaskState.TASK_STATE_WORKING));
+    bus.publish(statusEvent(TaskState.TASK_STATE_AUTH_REQUIRED));
+    // Simulate the agent resuming after out-of-band credential
+    // injection — these events MUST flow through the same queue.
+    bus.publish(statusEvent(TaskState.TASK_STATE_WORKING));
+    bus.publish(statusEvent(TaskState.TASK_STATE_COMPLETED));
+
+    const seen = await drain(queue);
+    expect(seen).toHaveLength(5);
+    expect((seen[2].data as TaskStatusUpdateEvent).status?.state).toBe(
+      TaskState.TASK_STATE_AUTH_REQUIRED
+    );
+    expect((seen[3].data as TaskStatusUpdateEvent).status?.state).toBe(
+      TaskState.TASK_STATE_WORKING
+    );
+    expect((seen[4].data as TaskStatusUpdateEvent).status?.state).toBe(
+      TaskState.TASK_STATE_COMPLETED
+    );
+  });
+
+  it('AUTH_REQUIRED followed by INPUT_REQUIRED stops on INPUT_REQUIRED', async () => {
+    // Sanity: even though AUTH_REQUIRED is not in the stop set, the
+    // queue still treats a subsequent INPUT_REQUIRED as the natural
+    // pause point.
+    const queue = new ExecutionEventQueue(bus);
+    bus.publish(taskEvent);
+    bus.publish(statusEvent(TaskState.TASK_STATE_AUTH_REQUIRED));
+    bus.publish(statusEvent(TaskState.TASK_STATE_INPUT_REQUIRED));
+    bus.publish(statusEvent(TaskState.TASK_STATE_WORKING));
+
+    const seen = await drain(queue);
+    expect(seen).toHaveLength(3);
+    expect((seen[2].data as TaskStatusUpdateEvent).status?.state).toBe(
+      TaskState.TASK_STATE_INPUT_REQUIRED
+    );
+  });
+
+  it('AUTH_REQUIRED followed by a terminal state stops on the terminal state', async () => {
+    const queue = new ExecutionEventQueue(bus);
+    bus.publish(taskEvent);
+    bus.publish(statusEvent(TaskState.TASK_STATE_AUTH_REQUIRED));
+    bus.publish(statusEvent(TaskState.TASK_STATE_COMPLETED));
+
+    const seen = await drain(queue);
+    expect(seen).toHaveLength(3);
+    expect((seen[2].data as TaskStatusUpdateEvent).status?.state).toBe(
+      TaskState.TASK_STATE_COMPLETED
+    );
+  });
+
+  it('does not stop on intermediate non-terminal states (SUBMITTED, WORKING)', async () => {
+    const queue = new ExecutionEventQueue(bus);
+    bus.publish(taskEvent);
+    bus.publish(statusEvent(TaskState.TASK_STATE_SUBMITTED));
+    bus.publish(statusEvent(TaskState.TASK_STATE_WORKING));
+    bus.publish(statusEvent(TaskState.TASK_STATE_COMPLETED));
+
+    const seen = await drain(queue);
+    expect(seen).toHaveLength(4);
+  });
+
+  it('stops when the bus emits finished (executor-driven shutdown)', async () => {
+    const queue = new ExecutionEventQueue(bus);
+    bus.publish(taskEvent);
+    bus.publish(statusEvent(TaskState.TASK_STATE_WORKING));
+    bus.finished();
+
+    const seen = await drain(queue);
+    expect(seen).toHaveLength(2);
+  });
+
+  it('keeps draining past AUTH_REQUIRED even when events arrive asynchronously', async () => {
+    // Exercise the async resolvePromise path: queue starts iterating
+    // before all events are published, then events are pushed one by
+    // one with a microtask gap between them.
+    const queue = new ExecutionEventQueue(bus);
+    const collected: AgentExecutionEvent[] = [];
+
+    const drainPromise = (async () => {
+      for await (const e of queue.events()) {
+        collected.push(e);
+      }
+    })();
+
+    // Yield to let the consumer attach to the bus.
+    bus.publish(taskEvent);
+    await Promise.resolve();
+    bus.publish(statusEvent(TaskState.TASK_STATE_AUTH_REQUIRED));
+    await Promise.resolve();
+    // The executor resumes on the same bus after credential injection.
+    bus.publish(statusEvent(TaskState.TASK_STATE_WORKING));
+    await Promise.resolve();
+    bus.publish(statusEvent(TaskState.TASK_STATE_COMPLETED));
+
+    await drainPromise;
+
+    expect(collected).toHaveLength(4);
+    expect((collected[1].data as TaskStatusUpdateEvent).status?.state).toBe(
+      TaskState.TASK_STATE_AUTH_REQUIRED
+    );
+    expect((collected[3].data as TaskStatusUpdateEvent).status?.state).toBe(
+      TaskState.TASK_STATE_COMPLETED
+    );
+  });
+});

--- a/test/server/request_handler/auth_required.spec.ts
+++ b/test/server/request_handler/auth_required.spec.ts
@@ -22,6 +22,7 @@ import { ServerCallContext } from '../../../src/server/context.js';
 import { RequestContext } from '../../../src/server/agent_execution/request_context.js';
 import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
 import { MockPushNotificationSender } from '../mocks/push_notification_sender.mock.js';
+import { MockTaskStore } from '../mocks/task_store.mock.js';
 
 /**
  * End-to-end coverage for the §7.6.1 AUTH_REQUIRED lifecycle through
@@ -586,5 +587,131 @@ describe('DefaultRequestHandler AUTH_REQUIRED lifecycle (§7.6.1)', () => {
     // Bus stays alive for the follow-up `message/send` (§3.4.3) —
     // same pre-existing behaviour.
     expect(eventBusManager.getByTaskId(observedTaskId)).toBeDefined();
+  });
+
+  it('post-AUTH_REQUIRED drain error persists a FAILED status update instead of throwing into the background', async () => {
+    // The caller already has the AUTH_REQUIRED snapshot when the
+    // drain throws. Without `firstResultRejector` wired into the
+    // blocking-mode `_processEvents` call, `_handleProcessingError`
+    // would fall into its "blocking case" branch and `throw error`
+    // inside the unattended background drain — which makes the
+    // failure invisible to the client AND leaves the task stuck at
+    // AUTH_REQUIRED in the store. With the fix, `firstResultSent` is
+    // set alongside the snapshot resolve and `firstResultRejector`
+    // is passed in, routing the error into the "first result already
+    // sent" branch which persists a FAILED status via `ResultManager`.
+    const failingStore = new MockTaskStore();
+    const localBusManager = new DefaultExecutionEventBusManager();
+    const localHandler = new DefaultRequestHandler(
+      agentCard,
+      failingStore,
+      mockExecutor,
+      localBusManager,
+      pushNotificationStore,
+      pushNotificationSender
+    );
+
+    const errorMessage = 'Simulated store failure on COMPLETED save';
+    let savedFailed: Task | undefined;
+    const taskByState = new Map<TaskState, Task>();
+    failingStore.save.mockImplementation(async (task: Task) => {
+      // Inject the failure only on the post-snapshot publish so the
+      // snapshot return path itself is unaffected.
+      if (task.status.state === TaskState.TASK_STATE_COMPLETED) {
+        throw new Error(errorMessage);
+      }
+      if (task.status.state === TaskState.TASK_STATE_FAILED) {
+        savedFailed = task;
+      }
+      taskByState.set(task.status.state, task);
+    });
+    failingStore.load.mockImplementation(async (id: string) => {
+      // Returns the most recently saved version of the task,
+      // regardless of state — used by `ResultManager.ensureTaskLoaded`
+      // and by the handler's task-event-to-stream-response mapping.
+      for (const t of [...taskByState.values()].reverse()) {
+        if (t.id === id) return t;
+      }
+      return undefined;
+    });
+
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((r) => (releaseGate = r));
+    const ids = { taskId: '', contextId: '' };
+
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+      ids.taskId = ctx.taskId;
+      ids.contextId = ctx.contextId;
+      bus.publish(
+        AgentEvent.task({
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        })
+      );
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_AUTH_REQUIRED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+      await gate;
+      // This publish will trigger the rigged store failure inside
+      // the drain loop after the snapshot has already been returned.
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-auth-7', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    // The blocking call resolves with the snapshot — the
+    // post-snapshot failure must not surface here.
+    const snapshot = (await localHandler.sendMessage(params, serverContext)) as Task;
+    expect(snapshot.status.state).toBe(TaskState.TASK_STATE_AUTH_REQUIRED);
+
+    releaseGate();
+    // Let the background drain advance through the throwing publish
+    // and the recovery path that saves the FAILED status.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // The FAILED status must have been persisted via the
+    // "first result already sent" recovery branch.
+    expect(savedFailed).toBeDefined();
+    expect(savedFailed!.id).toBe(ids.taskId);
+    expect(savedFailed!.status.state).toBe(TaskState.TASK_STATE_FAILED);
+    expect(savedFailed!.status.message?.role).toBe(Role.ROLE_AGENT);
+    expect(
+      (savedFailed!.status.message?.parts[0].content as { $case: 'text'; value: string }).value
+    ).toContain(errorMessage);
   });
 });

--- a/test/server/request_handler/auth_required.spec.ts
+++ b/test/server/request_handler/auth_required.spec.ts
@@ -1,0 +1,590 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+
+import {
+  DefaultRequestHandler,
+  ExecutionEventBus,
+  InMemoryTaskStore,
+  InMemoryPushNotificationStore,
+  TaskStore,
+} from '../../../src/server/index.js';
+import {
+  AgentCard,
+  Message,
+  Role,
+  SendMessageRequest,
+  StreamResponse,
+  Task,
+  TaskState,
+} from '../../../src/types/pb/a2a.js';
+import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
+import { AgentEvent } from '../../../src/server/events/execution_event_bus.js';
+import { ServerCallContext } from '../../../src/server/context.js';
+import { RequestContext } from '../../../src/server/agent_execution/request_context.js';
+import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
+import { MockPushNotificationSender } from '../mocks/push_notification_sender.mock.js';
+
+/**
+ * End-to-end coverage for the §7.6.1 AUTH_REQUIRED lifecycle through
+ * {@link DefaultRequestHandler}:
+ *   1. A blocking `sendMessage` returns a snapshot of the current Task
+ *      as soon as the executor publishes AUTH_REQUIRED, without
+ *      closing the underlying event bus.
+ *   2. The handler continues to drain events the executor publishes
+ *      after the snapshot was returned, persisting them into the
+ *      `TaskStore` via the same `ResultManager` and firing push
+ *      notifications.
+ *   3. The bus is closed once the executor finally returns at a
+ *      terminal state (i.e. `_settleBus` runs with a non-interrupted
+ *      `lastState`).
+ *
+ * Mirrors the Python `result_aggregator._continue_consuming` and Go
+ * `taskupdate.Final` parity tests.
+ */
+describe('DefaultRequestHandler AUTH_REQUIRED lifecycle (§7.6.1)', () => {
+  let handler: DefaultRequestHandler;
+  let taskStore: TaskStore;
+  let mockExecutor: MockAgentExecutor;
+  let eventBusManager: DefaultExecutionEventBusManager;
+  let pushNotificationSender: MockPushNotificationSender;
+  let pushNotificationStore: InMemoryPushNotificationStore;
+
+  const agentCard: AgentCard = {
+    name: 'Auth Required Agent',
+    description: 'Test agent for §7.6.1 lifecycle',
+    version: '1.0.0',
+    provider: undefined,
+    documentationUrl: '',
+    supportedInterfaces: [
+      {
+        url: 'http://localhost/a2a',
+        protocolBinding: 'HTTP+JSON',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+    ],
+    capabilities: {
+      extensions: [],
+      streaming: true,
+      pushNotifications: true,
+    },
+    securitySchemes: {},
+    securityRequirements: [],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    signatures: [],
+  };
+
+  const serverContext = new ServerCallContext();
+
+  beforeEach(() => {
+    taskStore = new InMemoryTaskStore();
+    mockExecutor = new MockAgentExecutor();
+    eventBusManager = new DefaultExecutionEventBusManager();
+    pushNotificationStore = new InMemoryPushNotificationStore();
+    pushNotificationSender = new MockPushNotificationSender();
+    handler = new DefaultRequestHandler(
+      agentCard,
+      taskStore,
+      mockExecutor,
+      eventBusManager,
+      pushNotificationStore,
+      pushNotificationSender
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeMessage = (id: string, text: string): Message => ({
+    messageId: id,
+    role: Role.ROLE_USER,
+    parts: [
+      {
+        content: { $case: 'text', value: text },
+        mediaType: 'text/plain',
+        filename: '',
+        metadata: undefined,
+      },
+    ],
+    taskId: '',
+    contextId: '',
+    extensions: [],
+    metadata: {},
+    referenceTaskIds: [],
+  });
+
+  /**
+   * Configures `mockExecutor` to publish a Task + AUTH_REQUIRED
+   * status update, then await an external trigger before invoking
+   * `onCredentials(bus)`. Captures the taskId/contextId the handler
+   * assigns to the in-flight request so individual tests can assert
+   * against them.
+   *
+   * Returns:
+   *   * `release()`: invoke from the test to simulate the
+   *     out-of-band credential arrival.
+   *   * `executed`: resolves once `execute()` has returned. Tests use
+   *     this to know when `.finally(_settleBus)` has run.
+   *   * `ids`: live container, populated once the executor enters.
+   */
+  function mockAuthRequiredFlow(onCredentials: (bus: ExecutionEventBus) => void): {
+    release: () => void;
+    executed: Promise<void>;
+    ids: { taskId: string; contextId: string };
+  } {
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseGate = resolve;
+    });
+    let executedResolve!: () => void;
+    const executed = new Promise<void>((resolve) => {
+      executedResolve = resolve;
+    });
+    const ids = { taskId: '', contextId: '' };
+
+    mockExecutor.execute.mockImplementation(async (ctx: RequestContext, bus: ExecutionEventBus) => {
+      ids.taskId = ctx.taskId;
+      ids.contextId = ctx.contextId;
+      bus.publish(
+        AgentEvent.task({
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        })
+      );
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_AUTH_REQUIRED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+      // Block until the test signals that the credential has
+      // arrived out-of-band.
+      await gate;
+      onCredentials(bus);
+      executedResolve();
+    });
+
+    return { release: releaseGate, executed, ids };
+  }
+
+  it('blocking sendMessage returns a snapshot at AUTH_REQUIRED without closing the bus', async () => {
+    // Executor parks indefinitely on the credential — `release` is
+    // never called inside this test, so `_settleBus` is never reached
+    // and the bus must stay alive.
+    const { ids } = mockAuthRequiredFlow(() => {
+      throw new Error('post-credential code path should not run in this test');
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-auth-1', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+    const snapshot = (await handler.sendMessage(params, serverContext)) as Task;
+
+    expect(snapshot.id).toBe(ids.taskId);
+    expect(snapshot.status.state).toBe(TaskState.TASK_STATE_AUTH_REQUIRED);
+
+    // Bus must still be alive — `_settleBus` was not called because
+    // the executor has not returned.
+    expect(eventBusManager.getByTaskId(ids.taskId)).toBeDefined();
+  });
+
+  it('background consumer persists post-AUTH_REQUIRED events into the task store', async () => {
+    const { release, executed, ids } = mockAuthRequiredFlow((bus) => {
+      // Credential injected — resume publishing.
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ids.taskId,
+          contextId: ids.contextId,
+          status: {
+            state: TaskState.TASK_STATE_WORKING,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+      bus.publish(
+        AgentEvent.artifactUpdate({
+          taskId: ids.taskId,
+          contextId: ids.contextId,
+          artifact: {
+            artifactId: 'artifact-after-auth',
+            name: 'Result',
+            description: 'Generated after credential injection',
+            parts: [
+              {
+                content: { $case: 'text', value: 'authenticated content' },
+                mediaType: 'text/plain',
+                filename: '',
+                metadata: undefined,
+              },
+            ],
+            metadata: {},
+            extensions: [],
+          },
+          append: false,
+          lastChunk: true,
+          metadata: {},
+        })
+      );
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ids.taskId,
+          contextId: ids.contextId,
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-auth-2', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+    const snapshot = (await handler.sendMessage(params, serverContext)) as Task;
+
+    // Caller got the snapshot at AUTH_REQUIRED and nothing more
+    // (artifact / completion events have not been published yet).
+    expect(snapshot.status.state).toBe(TaskState.TASK_STATE_AUTH_REQUIRED);
+    expect(snapshot.artifacts ?? []).toHaveLength(0);
+
+    // Release the agent and let the background drain catch up.
+    release();
+    await executed;
+    // Yield so the background `_processEvents` promise can advance to
+    // and past the COMPLETED status.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // The store reflects what the background consumer drained.
+    const persisted = await taskStore.load(ids.taskId, serverContext);
+    expect(persisted).toBeDefined();
+    expect(persisted!.contextId).toBe(ids.contextId);
+    expect(persisted!.status.state).toBe(TaskState.TASK_STATE_COMPLETED);
+    expect(persisted!.artifacts ?? []).toHaveLength(1);
+    expect(persisted!.artifacts![0].artifactId).toBe('artifact-after-auth');
+
+    // Snapshot returned to the caller MUST NOT have been mutated by
+    // the background drain — `_processEvents` deep-clones via
+    // `structuredClone` before resolving the snapshot.
+    expect(snapshot.status.state).toBe(TaskState.TASK_STATE_AUTH_REQUIRED);
+    expect(snapshot.artifacts ?? []).toHaveLength(0);
+  });
+
+  it('push notifications fire for events published after AUTH_REQUIRED', async () => {
+    // Register a push config for the task BEFORE the message is sent
+    // — `sendMessage` doesn't know the taskId up front, but we can
+    // intercept the executor to grab it and register on the fly.
+    let observedTaskId = '';
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((r) => (releaseGate = r));
+
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+      observedTaskId = ctx.taskId;
+      // Register a push config now that we know the taskId. The
+      // sender mock captures every push call regardless of config.
+      await pushNotificationStore.save(ctx.taskId, serverContext, {
+        tenant: '',
+        taskId: ctx.taskId,
+        id: 'cfg-1',
+        url: 'http://example.com/notify',
+        token: '',
+        authentication: undefined,
+      });
+
+      bus.publish(
+        AgentEvent.task({
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        })
+      );
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_AUTH_REQUIRED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+      await gate;
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-auth-3', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    await handler.sendMessage(params, serverContext);
+    // Snapshot of which sends fired pre-credential.
+    const sendsBeforeRelease = pushNotificationSender.send.mock.calls.length;
+
+    releaseGate();
+    // Let the background drain process the COMPLETED status.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const sendsAfterRelease = pushNotificationSender.send.mock.calls.length;
+    expect(sendsAfterRelease).toBeGreaterThan(sendsBeforeRelease);
+
+    // Find the COMPLETED status update among the calls fired after
+    // the AUTH_REQUIRED snapshot was returned.
+    const completedCalls = pushNotificationSender.send.mock.calls.filter(([response]) => {
+      const r = response as StreamResponse;
+      if (r.payload?.$case !== 'statusUpdate') return false;
+      return r.payload.value.status?.state === TaskState.TASK_STATE_COMPLETED;
+    });
+    expect(completedCalls.length).toBe(1);
+    expect(observedTaskId).not.toBe('');
+  });
+
+  it('bus is closed once the executor reaches a terminal state after credential injection', async () => {
+    const { release, executed, ids } = mockAuthRequiredFlow((bus) => {
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ids.taskId,
+          contextId: ids.contextId,
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-auth-4', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+    const snapshot = (await handler.sendMessage(params, serverContext)) as Task;
+    expect(snapshot.status.state).toBe(TaskState.TASK_STATE_AUTH_REQUIRED);
+    // Bus stays alive while the executor is paused on the credential.
+    expect(eventBusManager.getByTaskId(ids.taskId)).toBeDefined();
+
+    release();
+    await executed;
+    // The executor returns after the COMPLETED publish; its `.finally`
+    // calls `_settleBus`, which closes the bus and cleans up.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(eventBusManager.getByTaskId(ids.taskId)).toBeUndefined();
+  });
+
+  it('AUTH_REQUIRED followed by INPUT_REQUIRED in the same execution: snapshot returned at AUTH_REQUIRED, drain stops at INPUT_REQUIRED (bus stays alive)', async () => {
+    const { release, executed, ids } = mockAuthRequiredFlow((bus) => {
+      // After the credential, the agent decides it needs additional
+      // input from the client. The drain loop must observe and
+      // persist this, then stop. The bus stays alive (interrupted
+      // state) for the follow-up `message/send`.
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ids.taskId,
+          contextId: ids.contextId,
+          status: {
+            state: TaskState.TASK_STATE_INPUT_REQUIRED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-auth-5', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+    const snapshot = (await handler.sendMessage(params, serverContext)) as Task;
+    expect(snapshot.status.state).toBe(TaskState.TASK_STATE_AUTH_REQUIRED);
+
+    release();
+    await executed;
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    const persisted = await taskStore.load(ids.taskId, serverContext);
+    expect(persisted!.status.state).toBe(TaskState.TASK_STATE_INPUT_REQUIRED);
+    // INPUT_REQUIRED is an interrupted state — bus stays alive for
+    // the follow-up `message/send` (existing §3.4.3 semantics).
+    expect(eventBusManager.getByTaskId(ids.taskId)).toBeDefined();
+  });
+
+  it('non-blocking sendMessage is unaffected by AUTH_REQUIRED — returns the initial Task event immediately as before', async () => {
+    // The §7.6.1 snapshot path only applies to blocking calls. The
+    // non-blocking path resolves on the first Task event regardless
+    // of subsequent state transitions; this test pins that contract.
+    let releaseGate!: () => void;
+    const gate = new Promise<void>((r) => (releaseGate = r));
+
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+      bus.publish(
+        AgentEvent.task({
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        })
+      );
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_AUTH_REQUIRED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+      await gate;
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-auth-6', 'kick off'),
+      tenant: '',
+      configuration: {
+        acceptedOutputModes: [],
+        taskPushNotificationConfig: undefined,
+        returnImmediately: true,
+      },
+      metadata: {},
+    };
+
+    const result = (await handler.sendMessage(params, serverContext)) as Task;
+    // Non-blocking resolves on the FIRST Task event — that's still
+    // SUBMITTED, not the AUTH_REQUIRED snapshot the blocking path
+    // would have returned.
+    expect(result.status.state).toBe(TaskState.TASK_STATE_SUBMITTED);
+
+    releaseGate();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  });
+
+  it('plain INPUT_REQUIRED flow is not affected by the new AUTH_REQUIRED handling (regression guard)', async () => {
+    // The new `authRequiredSnapshotResolver` callback must NOT fire
+    // for INPUT_REQUIRED — only the existing terminal-state code
+    // path should run, and the queue must stop normally.
+    let observedTaskId = '';
+
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+      observedTaskId = ctx.taskId;
+      bus.publish(
+        AgentEvent.task({
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        })
+      );
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_INPUT_REQUIRED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-input-1', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const result = (await handler.sendMessage(params, serverContext)) as Task;
+    expect(result.status.state).toBe(TaskState.TASK_STATE_INPUT_REQUIRED);
+
+    // Bus stays alive for the follow-up `message/send` (§3.4.3) —
+    // same pre-existing behaviour.
+    expect(eventBusManager.getByTaskId(observedTaskId)).toBeDefined();
+  });
+});

--- a/test/server/utils.spec.ts
+++ b/test/server/utils.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+
+import { TaskState } from '../../src/types/pb/a2a.js';
+import {
+  AUTH_REQUIRED_STATE_LIST,
+  INPUT_REQUIRED_STATE_LIST,
+  INTERRUPTED_STATE_LIST,
+  TERMINAL_STATE_LIST,
+} from '../../src/server/utils.js';
+
+describe('utils interrupted-state lists', () => {
+  describe('INPUT_REQUIRED_STATE_LIST', () => {
+    it('contains exactly TASK_STATE_INPUT_REQUIRED', () => {
+      expect(INPUT_REQUIRED_STATE_LIST).toEqual([TaskState.TASK_STATE_INPUT_REQUIRED]);
+    });
+
+    it('does not contain TASK_STATE_AUTH_REQUIRED', () => {
+      expect(INPUT_REQUIRED_STATE_LIST).not.toContain(TaskState.TASK_STATE_AUTH_REQUIRED);
+    });
+
+    it('does not contain any terminal state', () => {
+      for (const terminal of TERMINAL_STATE_LIST) {
+        expect(INPUT_REQUIRED_STATE_LIST).not.toContain(terminal);
+      }
+    });
+  });
+
+  describe('AUTH_REQUIRED_STATE_LIST', () => {
+    it('contains exactly TASK_STATE_AUTH_REQUIRED', () => {
+      expect(AUTH_REQUIRED_STATE_LIST).toEqual([TaskState.TASK_STATE_AUTH_REQUIRED]);
+    });
+
+    it('does not contain TASK_STATE_INPUT_REQUIRED', () => {
+      expect(AUTH_REQUIRED_STATE_LIST).not.toContain(TaskState.TASK_STATE_INPUT_REQUIRED);
+    });
+
+    it('does not contain any terminal state', () => {
+      for (const terminal of TERMINAL_STATE_LIST) {
+        expect(AUTH_REQUIRED_STATE_LIST).not.toContain(terminal);
+      }
+    });
+  });
+
+  describe('INTERRUPTED_STATE_LIST', () => {
+    it('is the union of INPUT_REQUIRED_STATE_LIST and AUTH_REQUIRED_STATE_LIST', () => {
+      // Order-independent set equality
+      expect(new Set(INTERRUPTED_STATE_LIST)).toEqual(
+        new Set([...INPUT_REQUIRED_STATE_LIST, ...AUTH_REQUIRED_STATE_LIST])
+      );
+    });
+
+    it('contains both TASK_STATE_INPUT_REQUIRED and TASK_STATE_AUTH_REQUIRED', () => {
+      expect(INTERRUPTED_STATE_LIST).toContain(TaskState.TASK_STATE_INPUT_REQUIRED);
+      expect(INTERRUPTED_STATE_LIST).toContain(TaskState.TASK_STATE_AUTH_REQUIRED);
+    });
+
+    it('has length equal to sum of component lists (no overlap)', () => {
+      expect(INTERRUPTED_STATE_LIST).toHaveLength(
+        INPUT_REQUIRED_STATE_LIST.length + AUTH_REQUIRED_STATE_LIST.length
+      );
+    });
+
+    it('does not contain any terminal state', () => {
+      for (const terminal of TERMINAL_STATE_LIST) {
+        expect(INTERRUPTED_STATE_LIST).not.toContain(terminal);
+      }
+    });
+
+    it('INPUT_REQUIRED_STATE_LIST and AUTH_REQUIRED_STATE_LIST are disjoint', () => {
+      const inputSet = new Set(INPUT_REQUIRED_STATE_LIST);
+      for (const state of AUTH_REQUIRED_STATE_LIST) {
+        expect(inputSet.has(state)).toBe(false);
+      }
+    });
+  });
+});


### PR DESCRIPTION
# Description

## What

Implements proper AUTH_REQUIRED lifecycle per spec §7.6:

- New `INPUT_REQUIRED_STATE_LIST` / `AUTH_REQUIRED_STATE_LIST` constants;
  union `INTERRUPTED_STATE_LIST` kept for backward compat
- `ExecutionEventQueue` only stops on INPUT_REQUIRED, not AUTH_REQUIRED
- Blocking `sendMessage` returns a snapshot on AUTH_REQUIRED without closing
  the event bus; spawns a background consumer that drains events
  (ResultManager + push notifications) until terminal state

## Why

Spec §7.6.1: AUTH_REQUIRED must keep response streams open and allow the
agent to "immediately continue Task processing after receiving the credential,
without a requirement that clients send a follow-up message." JS treated
AUTH_REQUIRED identically to INPUT_REQUIRED — closing streams, ending the
blocking call, with no background drain.
