### PR TITLE
fix(server): merge Task history in ResultManager instead of overwriting

### DIFF
--- a/src/server/result_manager.ts
+++ b/src/server/result_manager.ts
@@ -10,6 +10,49 @@ import { AgentExecutionEvent, assertUnreachableEvent } from './events/execution_
 import { TaskStore } from './store.js';
 
 /**
+ * Per-`taskId` write serializer shared across every `ResultManager`
+ * instance in this process.
+ *
+ * Multiple `ResultManager`s can run concurrently against the same task:
+ * - The AUTH_REQUIRED background drain holds one RM while a follow-up
+ *   `sendMessage` constructs a new one (spec §7.6).
+ * - INPUT_REQUIRED's `createOrGetByTaskId` bus reuse + a follow-up call.
+ * - `cancelTask` overlapping with the background drain.
+ * - Non-blocking `sendMessage` returning early while its drain continues.
+ *
+ * Each `processEvent` performs a load-merge-save sequence on the
+ * `TaskStore`. Without serialization, two RMs racing on the same row
+ * would each read a pre-sibling snapshot, merge against it, and the last
+ * writer would silently overwrite the other's contribution (classic
+ * lost-update). Wholesale-replace was bug-equivalent for both writers;
+ * merge semantics make the race observable as missing history /
+ * artifacts.
+ *
+ * Scope: in-process only. Cross-process serialization belongs in the
+ * `TaskStore` interface (compare-and-swap or transactional `update`) and
+ * is intentionally out of scope here.
+ */
+const taskWriteLocks = new Map<string, Promise<unknown>>();
+
+async function serializeByTaskId<T>(taskId: string, fn: () => Promise<T>): Promise<T> {
+  const prev = taskWriteLocks.get(taskId) ?? Promise.resolve();
+  // `.then(fn, fn)` ensures one RM's rejection doesn't block the chain —
+  // the next queued function still runs.
+  const next = prev.then(fn, fn);
+  taskWriteLocks.set(
+    taskId,
+    next.finally(() => {
+      // Only evict if no newer call has extended the chain. Without this
+      // guard, a fast successor would be orphaned by our cleanup.
+      if (taskWriteLocks.get(taskId) === next) {
+        taskWriteLocks.delete(taskId);
+      }
+    })
+  );
+  return next;
+}
+
+/**
  * Tracks the in-flight task/message state for a single A2A request and
  * persists updates to the {@link TaskStore}.
  *
@@ -20,6 +63,14 @@ import { TaskStore } from './store.js';
  * caller-side mutations of the same event objects (and vice versa). The
  * `TaskStore.load` / `TaskStore.save` boundary clones independently, so
  * this class is safe to combine with stores that share references.
+ *
+ * Concurrency: `processEvent` serializes all store-touching branches
+ * (`task` / `statusUpdate` / `artifactUpdate`) through a per-`taskId`
+ * lock shared across every `ResultManager` instance in the process.
+ * Inside the lock we always invalidate `currentTask` and re-load from
+ * the store, so a sibling RM's write (e.g. the AUTH_REQUIRED background
+ * drain interleaving with a follow-up `sendMessage`) cannot be silently
+ * overwritten by a merge against a stale cached snapshot.
  */
 export class ResultManager {
   private readonly taskStore: TaskStore;
@@ -28,6 +79,13 @@ export class ResultManager {
   private currentTask?: Task;
   private latestUserMessage?: Message; // To add to history if a new task is created
   private finalMessageResult?: Message; // Stores the message if it's the final result
+  /**
+   * The `taskId` from the last event this RM processed under the lock.
+   * Used to surface a warning when an executor publishes events for a
+   * different `taskId` on the same RM mid-stream — that's an executor
+   * bug and not something the per-task lock can paper over.
+   */
+  private lastSeenTaskId?: string;
 
   constructor(taskStore: TaskStore, serverCallContext: ServerCallContext) {
     this.taskStore = taskStore;
@@ -42,11 +100,18 @@ export class ResultManager {
 
   /**
    * Processes an agent execution event and updates the task store.
+   *
+   * Store-touching branches run under `serializeByTaskId(taskId, ...)`
+   * so concurrent RMs on the same task linearize their load-merge-save
+   * sequences. The `message` branch only touches in-memory state and is
+   * intentionally unlocked.
+   *
    * @param event The agent execution event.
    */
   public async processEvent(event: AgentExecutionEvent): Promise<void> {
     switch (event.kind) {
       case 'message': {
+        // In-memory only; no store I/O, so no lock needed.
         // Final-result messages may be returned to callers verbatim, so
         // store a defensive copy.
         this.finalMessageResult = structuredClone(event.data);
@@ -57,88 +122,34 @@ export class ResultManager {
       }
       case 'task': {
         const taskEvent = event.data;
-
-        // Merge with any persisted state instead of wholesale-replacing it.
-        // A fresh Task event published on a follow-up turn (e.g. after
-        // INPUT_REQUIRED) often has empty `history` / `artifacts`; replacing
-        // would drop the entire conversation.
-        //
-        // Unlike status/artifact updates, receiving a Task event with no
-        // prior persisted task is the normal create-flow, so we load
-        // directly rather than going through `ensureTaskLoaded` (which
-        // warns on misses). We also re-load if the in-memory task is for
-        // a different id, otherwise we'd lose the persisted state for the
-        // new task id.
-        if ((!this.currentTask || this.currentTask.id !== taskEvent.id) && taskEvent.id) {
-          const loaded = await this.taskStore.load(taskEvent.id, this.serverCallContext);
-          if (loaded) {
-            this.currentTask = loaded;
-          } else if (this.currentTask && this.currentTask.id !== taskEvent.id) {
-            // The previously-tracked task is unrelated to the incoming
-            // event; drop it so we don't accidentally merge across ids.
-            this.currentTask = undefined;
-          }
+        if (!taskEvent.id) {
+          // No key to serialize on — fall through unlocked. This
+          // shouldn't happen for a valid Task event but defending
+          // against it keeps us crash-free on malformed payloads.
+          await this.processTaskEventLocked(taskEvent);
+          break;
         }
-        const persistedTask =
-          this.currentTask && this.currentTask.id === taskEvent.id ? this.currentTask : undefined;
-
-        // Deep-clone the incoming Task so further executor mutations or
-        // caller-side reuse of the same event object can't leak into our
-        // state.
-        const mergedTask: Task = structuredClone(taskEvent);
-
-        if (persistedTask) {
-          // Preserve persisted history when the incoming Task event omits it.
-          // If the incoming Task event carries its own history, treat it as
-          // authoritative (the executor is responsible for what gets persisted
-          // per §3.7).
-          if ((!mergedTask.history || mergedTask.history.length === 0) && persistedTask.history) {
-            mergedTask.history = structuredClone(persistedTask.history);
-          }
-
-          // Merge artifacts: keep persisted artifacts and overlay any incoming
-          // ones (matched by artifactId). Incoming wins for collisions; new
-          // ones are appended.
-          mergedTask.artifacts = this.mergeArtifacts(persistedTask.artifacts, taskEvent.artifacts);
-
-          // Merge metadata, incoming wins on key collisions. structuredClone
-          // each half so nested values can't be shared with either source.
-          if (persistedTask.metadata || taskEvent.metadata) {
-            mergedTask.metadata = {
-              ...structuredClone(persistedTask.metadata ?? {}),
-              ...structuredClone(taskEvent.metadata ?? {}),
-            };
-          }
-        }
-
-        this.currentTask = mergedTask;
-
-        // Ensure the latest user message is in history if not already present.
-        // `latestUserMessage` was already cloned in `setContext`, but clone
-        // again so the same reference can't end up shared between the
-        // history array and the `latestUserMessage` slot if the same
-        // `ResultManager` is reused for multiple task events.
-        if (this.latestUserMessage) {
-          if (
-            !this.currentTask.history?.find(
-              (msg) => msg.messageId === this.latestUserMessage?.messageId
-            )
-          ) {
-            this.currentTask.history = [
-              structuredClone(this.latestUserMessage),
-              ...(this.currentTask.history || []),
-            ];
-          }
-        }
-        await this.saveCurrentTask();
+        await serializeByTaskId(taskEvent.id, () => this.processTaskEventLocked(taskEvent));
         break;
       }
       case 'statusUpdate': {
-        await this.applyStatusUpdate(event.data);
+        const updateEvent = event.data;
+        if (!updateEvent.taskId) {
+          await this.applyStatusUpdate(updateEvent);
+          break;
+        }
+        await serializeByTaskId(updateEvent.taskId, () => this.applyStatusUpdate(updateEvent));
         break;
       }
       case 'artifactUpdate': {
-        await this.applyArtifactUpdate(event.data);
+        const artifactEvent = event.data;
+        if (!artifactEvent.taskId) {
+          await this.applyArtifactUpdate(artifactEvent);
+          break;
+        }
+        await serializeByTaskId(artifactEvent.taskId, () =>
+          this.applyArtifactUpdate(artifactEvent)
+        );
         break;
       }
       default:
@@ -146,74 +157,178 @@ export class ResultManager {
     }
   }
 
-  private async ensureTaskLoaded(taskId: string | undefined, eventName: string): Promise<void> {
-    if (!this.currentTask && taskId) {
-      const loaded = await this.taskStore.load(taskId, this.serverCallContext);
-      if (loaded) {
-        this.currentTask = loaded;
-      } else {
-        console.warn(`ResultManager: Received ${eventName} for unknown task ${taskId}`);
+  /**
+   * Warns once when the executor publishes an event for a different
+   * `taskId` than the previous event this RM observed. A single RM is
+   * scoped to one request and should only ever see events for one
+   * `taskId`; a mismatch indicates an executor bug.
+   */
+  private notePersistedTaskId(taskId: string | undefined): void {
+    if (!taskId) return;
+    if (this.lastSeenTaskId && this.lastSeenTaskId !== taskId) {
+      console.warn(
+        `ResultManager: event for task ${taskId} arrived after processing ` +
+          `events for ${this.lastSeenTaskId}. This indicates the executor ` +
+          `switched tasks mid-stream, which is not expected in normal operation.`
+      );
+    }
+    this.lastSeenTaskId = taskId;
+  }
+
+  /**
+   * Handles a `task` event under the per-`taskId` write lock.
+   *
+   * Always re-loads from the store (no cached state from prior events)
+   * so a sibling `ResultManager`'s write between our previous event and
+   * this one is observed by our merge (instead of being silently
+   * clobbered by a stale-snapshot merge).
+   */
+  private async processTaskEventLocked(taskEvent: Task): Promise<void> {
+    this.notePersistedTaskId(taskEvent.id);
+
+    // Receiving a Task event with no prior persisted task is the normal
+    // create-flow, so we load directly rather than going through
+    // `loadPersistedTask` (which warns on misses).
+    const persistedTask = taskEvent.id
+      ? await this.taskStore.load(taskEvent.id, this.serverCallContext)
+      : undefined;
+
+    // Deep-clone the incoming Task so further executor mutations or
+    // caller-side reuse of the same event object can't leak into our
+    // state.
+    const mergedTask: Task = structuredClone(taskEvent);
+
+    if (persistedTask && persistedTask.id === taskEvent.id) {
+      // Preserve persisted history when the incoming Task event omits it.
+      // If the incoming Task event carries its own history, treat it as
+      // authoritative (the executor is responsible for what gets persisted
+      // per §3.7).
+      if ((!mergedTask.history || mergedTask.history.length === 0) && persistedTask.history) {
+        mergedTask.history = structuredClone(persistedTask.history);
+      }
+
+      // Merge artifacts: keep persisted artifacts and overlay any incoming
+      // ones (matched by artifactId). Incoming wins for collisions; new
+      // ones are appended.
+      mergedTask.artifacts = this.mergeArtifacts(persistedTask.artifacts, taskEvent.artifacts);
+
+      // Merge metadata, incoming wins on key collisions. structuredClone
+      // each half so nested values can't be shared with either source.
+      if (persistedTask.metadata || taskEvent.metadata) {
+        mergedTask.metadata = {
+          ...structuredClone(persistedTask.metadata ?? {}),
+          ...structuredClone(taskEvent.metadata ?? {}),
+        };
       }
     }
+
+    // Ensure the latest user message is in history if not already present.
+    // `latestUserMessage` was already cloned in `setContext`, but clone
+    // again so the same reference can't end up shared between the
+    // history array and the `latestUserMessage` slot if the same
+    // `ResultManager` is reused for multiple task events.
+    if (this.latestUserMessage) {
+      const latest = this.latestUserMessage;
+      if (!mergedTask.history?.find((msg) => msg.messageId === latest.messageId)) {
+        mergedTask.history = [structuredClone(latest), ...(mergedTask.history || [])];
+      }
+    }
+
+    this.currentTask = mergedTask;
+    await this.saveCurrentTask();
+  }
+
+  /**
+   * Loads the task fresh from the store, warning if it doesn't exist.
+   * Returns the loaded task (or undefined) without mutating
+   * `this.currentTask`, so callers can use the result with TypeScript's
+   * flow-narrowing intact.
+   */
+  private async loadPersistedTask(
+    taskId: string | undefined,
+    eventName: string
+  ): Promise<Task | undefined> {
+    if (!taskId) return undefined;
+    const loaded = await this.taskStore.load(taskId, this.serverCallContext);
+    if (!loaded) {
+      console.warn(`ResultManager: Received ${eventName} for unknown task ${taskId}`);
+    }
+    return loaded;
   }
 
   private async applyStatusUpdate(updateEvent: TaskStatusUpdateEvent): Promise<void> {
-    await this.ensureTaskLoaded(updateEvent.taskId, 'status update');
+    this.notePersistedTaskId(updateEvent.taskId);
 
-    if (this.currentTask && this.currentTask.id === updateEvent.taskId) {
-      // Clone the incoming status (and its nested message) so caller-side
-      // mutation of the original event payload can't drift our state.
-      this.currentTask.status = structuredClone(updateEvent.status);
-      const update = updateEvent.status?.message;
-      if (update) {
-        // Add message to history if not already present
-        if (!this.currentTask.history?.find((msg) => msg.messageId === update.messageId)) {
-          this.currentTask.history = [...(this.currentTask.history || []), structuredClone(update)];
-        }
-      }
-      await this.saveCurrentTask();
+    // Under the per-taskId lock we always re-load fresh persisted state
+    // so a sibling RM's write isn't overwritten by a stale-snapshot
+    // merge.
+    const task = await this.loadPersistedTask(updateEvent.taskId, 'status update');
+    if (!task || task.id !== updateEvent.taskId) {
+      this.currentTask = task;
+      return;
     }
+
+    // Clone the incoming status (and its nested message) so caller-side
+    // mutation of the original event payload can't drift our state.
+    task.status = structuredClone(updateEvent.status);
+    const update = updateEvent.status?.message;
+    if (update) {
+      // Add message to history if not already present.
+      if (!task.history?.find((msg) => msg.messageId === update.messageId)) {
+        task.history = [...(task.history || []), structuredClone(update)];
+      }
+    }
+    this.currentTask = task;
+    await this.saveCurrentTask();
   }
 
   private async applyArtifactUpdate(artifactEvent: TaskArtifactUpdateEvent): Promise<void> {
     const artifact = artifactEvent.artifact;
     if (!artifact) return;
 
-    await this.ensureTaskLoaded(artifactEvent.taskId, 'artifact update');
+    this.notePersistedTaskId(artifactEvent.taskId);
 
-    if (this.currentTask && this.currentTask.id === artifactEvent.taskId) {
-      if (!this.currentTask.artifacts) {
-        this.currentTask.artifacts = [];
-      }
-      const existingArtifactIndex = this.currentTask.artifacts.findIndex(
-        (art) => art.artifactId === artifact.artifactId
-      );
-      if (existingArtifactIndex !== -1) {
-        if (artifactEvent.append) {
-          // Basic append logic, assuming parts are compatible.
-          // Clone incoming parts/metadata so the persisted artifact owns
-          // its own deep copies and the event payload can be reused
-          // safely by the executor.
-          const existingArtifact = this.currentTask.artifacts[existingArtifactIndex];
-          existingArtifact.parts = [
-            ...(existingArtifact.parts || []),
-            ...structuredClone(artifact.parts || []),
-          ];
-          if (artifact.description) existingArtifact.description = artifact.description;
-          if (artifact.name) existingArtifact.name = artifact.name;
-          if (artifact.metadata)
-            existingArtifact.metadata = {
-              ...existingArtifact.metadata,
-              ...structuredClone(artifact.metadata),
-            };
-        } else {
-          this.currentTask.artifacts[existingArtifactIndex] = structuredClone(artifact);
-        }
-      } else {
-        this.currentTask.artifacts.push(structuredClone(artifact));
-      }
-      await this.saveCurrentTask();
+    // Under the per-taskId lock we always re-load fresh persisted state
+    // so a sibling RM's write isn't overwritten by a stale-snapshot
+    // merge.
+    const task = await this.loadPersistedTask(artifactEvent.taskId, 'artifact update');
+    if (!task || task.id !== artifactEvent.taskId) {
+      this.currentTask = task;
+      return;
     }
+
+    if (!task.artifacts) {
+      task.artifacts = [];
+    }
+    const existingArtifactIndex = task.artifacts.findIndex(
+      (art) => art.artifactId === artifact.artifactId
+    );
+    if (existingArtifactIndex !== -1) {
+      if (artifactEvent.append) {
+        // Basic append logic, assuming parts are compatible.
+        // Clone incoming parts/metadata so the persisted artifact owns
+        // its own deep copies and the event payload can be reused
+        // safely by the executor.
+        const existingArtifact = task.artifacts[existingArtifactIndex];
+        existingArtifact.parts = [
+          ...(existingArtifact.parts || []),
+          ...structuredClone(artifact.parts || []),
+        ];
+        if (artifact.description) existingArtifact.description = artifact.description;
+        if (artifact.name) existingArtifact.name = artifact.name;
+        if (artifact.metadata)
+          existingArtifact.metadata = {
+            ...existingArtifact.metadata,
+            ...structuredClone(artifact.metadata),
+          };
+      } else {
+        task.artifacts[existingArtifactIndex] = structuredClone(artifact);
+      }
+    } else {
+      task.artifacts.push(structuredClone(artifact));
+    }
+    this.currentTask = task;
+    await this.saveCurrentTask();
   }
 
   /**
@@ -268,6 +383,13 @@ export class ResultManager {
    * that downstream callers like `_applyHistoryLengthSemantics` can apply
    * in-place edits. Safe because `ResultManager` instances are scoped to a
    * single request and discarded immediately after this is called.
+   *
+   * The returned `currentTask` reflects whatever this RM saw at the end
+   * of its most recently completed `processEvent` (under the lock). A
+   * sibling RM running concurrently for the same `taskId` may have
+   * written newer state to the store after our last event; that's the
+   * documented snapshot contract — `getCurrentTask()` returns "what we
+   * processed", not "the store's current state".
    * @returns The final Message or the current Task.
    */
   public getFinalResult(): Message | Task | undefined {

--- a/src/server/result_manager.ts
+++ b/src/server/result_manager.ts
@@ -1,4 +1,10 @@
-import { Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent } from '../index.js';
+import {
+  Artifact,
+  Message,
+  Task,
+  TaskStatusUpdateEvent,
+  TaskArtifactUpdateEvent,
+} from '../index.js';
 import { ServerCallContext } from './context.js';
 import { AgentExecutionEvent, assertUnreachableEvent } from './events/execution_event_bus.js';
 import { TaskStore } from './store.js';
@@ -35,9 +41,53 @@ export class ResultManager {
       }
       case 'task': {
         const taskEvent = event.data;
-        this.currentTask = { ...taskEvent }; // Make a copy
 
-        // Ensure the latest user message is in history if not already present
+        // Merge with any persisted state instead of wholesale-replacing it.
+        // A fresh Task event published on a follow-up turn (e.g. after
+        // INPUT_REQUIRED) often has empty `history` / `artifacts`; replacing
+        // would drop the entire conversation.
+        //
+        // Unlike status/artifact updates, receiving a Task event with no
+        // prior persisted task is the normal create-flow, so we load
+        // directly rather than going through `ensureTaskLoaded` (which
+        // warns on misses).
+        if (!this.currentTask && taskEvent.id) {
+          const loaded = await this.taskStore.load(taskEvent.id, this.serverCallContext);
+          if (loaded) {
+            this.currentTask = loaded;
+          }
+        }
+        const persistedTask =
+          this.currentTask && this.currentTask.id === taskEvent.id ? this.currentTask : undefined;
+
+        const mergedTask: Task = { ...taskEvent };
+
+        if (persistedTask) {
+          // Preserve persisted history when the incoming Task event omits it.
+          // If the incoming Task event carries its own history, treat it as
+          // authoritative (the executor is responsible for what gets persisted
+          // per §3.7).
+          if ((!mergedTask.history || mergedTask.history.length === 0) && persistedTask.history) {
+            mergedTask.history = [...persistedTask.history];
+          }
+
+          // Merge artifacts: keep persisted artifacts and overlay any incoming
+          // ones (matched by artifactId). Incoming wins for collisions; new
+          // ones are appended.
+          mergedTask.artifacts = this.mergeArtifacts(persistedTask.artifacts, taskEvent.artifacts);
+
+          // Merge metadata, incoming wins on key collisions.
+          if (persistedTask.metadata || taskEvent.metadata) {
+            mergedTask.metadata = {
+              ...(persistedTask.metadata ?? {}),
+              ...(taskEvent.metadata ?? {}),
+            };
+          }
+        }
+
+        this.currentTask = mergedTask;
+
+        // Ensure the latest user message is in history if not already present.
         if (this.latestUserMessage) {
           if (
             !this.currentTask.history?.find(
@@ -127,6 +177,38 @@ export class ResultManager {
       }
       await this.saveCurrentTask();
     }
+  }
+
+  /**
+   * Merges artifact arrays, deduplicating by `artifactId`. Persisted artifacts
+   * are retained and overlaid by any incoming artifact with the same id;
+   * artifacts only present in the incoming list are appended. Order is
+   * preserved (persisted first, then any newly-introduced incoming artifacts).
+   */
+  private mergeArtifacts(
+    persisted: Artifact[] | undefined,
+    incoming: Artifact[] | undefined
+  ): Artifact[] {
+    if (!persisted || persisted.length === 0) {
+      return incoming ? [...incoming] : [];
+    }
+    if (!incoming || incoming.length === 0) {
+      return [...persisted];
+    }
+
+    const incomingById = new Map<string, Artifact>();
+    for (const art of incoming) {
+      incomingById.set(art.artifactId, art);
+    }
+
+    const merged: Artifact[] = persisted.map((art) => incomingById.get(art.artifactId) ?? art);
+    const seenIds = new Set(persisted.map((art) => art.artifactId));
+    for (const art of incoming) {
+      if (!seenIds.has(art.artifactId)) {
+        merged.push(art);
+      }
+    }
+    return merged;
   }
 
   private async saveCurrentTask(): Promise<void> {

--- a/src/server/result_manager.ts
+++ b/src/server/result_manager.ts
@@ -9,6 +9,18 @@ import { ServerCallContext } from './context.js';
 import { AgentExecutionEvent, assertUnreachableEvent } from './events/execution_event_bus.js';
 import { TaskStore } from './store.js';
 
+/**
+ * Tracks the in-flight task/message state for a single A2A request and
+ * persists updates to the {@link TaskStore}.
+ *
+ * Mutation safety: every external object handed to this class (event
+ * payloads, user messages) is deep-cloned via `structuredClone` before
+ * being stored, and every object stored back into the task is likewise a
+ * fresh clone. This isolates `ResultManager`'s internal state from
+ * caller-side mutations of the same event objects (and vice versa). The
+ * `TaskStore.load` / `TaskStore.save` boundary clones independently, so
+ * this class is safe to combine with stores that share references.
+ */
 export class ResultManager {
   private readonly taskStore: TaskStore;
   private readonly serverCallContext: ServerCallContext;
@@ -23,7 +35,9 @@ export class ResultManager {
   }
 
   public setContext(latestUserMessage: Message): void {
-    this.latestUserMessage = latestUserMessage;
+    // Clone so a caller mutating the message later (or reusing the object
+    // across calls) can't perturb our internal copy.
+    this.latestUserMessage = structuredClone(latestUserMessage);
   }
 
   /**
@@ -33,7 +47,9 @@ export class ResultManager {
   public async processEvent(event: AgentExecutionEvent): Promise<void> {
     switch (event.kind) {
       case 'message': {
-        this.finalMessageResult = event.data;
+        // Final-result messages may be returned to callers verbatim, so
+        // store a defensive copy.
+        this.finalMessageResult = structuredClone(event.data);
         // If a message is received, it's usually the final result,
         // but we continue processing to ensure task state (if any) is also saved.
         // The ExecutionEventQueue will stop after a message event.
@@ -50,17 +66,26 @@ export class ResultManager {
         // Unlike status/artifact updates, receiving a Task event with no
         // prior persisted task is the normal create-flow, so we load
         // directly rather than going through `ensureTaskLoaded` (which
-        // warns on misses).
-        if (!this.currentTask && taskEvent.id) {
+        // warns on misses). We also re-load if the in-memory task is for
+        // a different id, otherwise we'd lose the persisted state for the
+        // new task id.
+        if ((!this.currentTask || this.currentTask.id !== taskEvent.id) && taskEvent.id) {
           const loaded = await this.taskStore.load(taskEvent.id, this.serverCallContext);
           if (loaded) {
             this.currentTask = loaded;
+          } else if (this.currentTask && this.currentTask.id !== taskEvent.id) {
+            // The previously-tracked task is unrelated to the incoming
+            // event; drop it so we don't accidentally merge across ids.
+            this.currentTask = undefined;
           }
         }
         const persistedTask =
           this.currentTask && this.currentTask.id === taskEvent.id ? this.currentTask : undefined;
 
-        const mergedTask: Task = { ...taskEvent };
+        // Deep-clone the incoming Task so further executor mutations or
+        // caller-side reuse of the same event object can't leak into our
+        // state.
+        const mergedTask: Task = structuredClone(taskEvent);
 
         if (persistedTask) {
           // Preserve persisted history when the incoming Task event omits it.
@@ -68,7 +93,7 @@ export class ResultManager {
           // authoritative (the executor is responsible for what gets persisted
           // per §3.7).
           if ((!mergedTask.history || mergedTask.history.length === 0) && persistedTask.history) {
-            mergedTask.history = [...persistedTask.history];
+            mergedTask.history = structuredClone(persistedTask.history);
           }
 
           // Merge artifacts: keep persisted artifacts and overlay any incoming
@@ -76,11 +101,12 @@ export class ResultManager {
           // ones are appended.
           mergedTask.artifacts = this.mergeArtifacts(persistedTask.artifacts, taskEvent.artifacts);
 
-          // Merge metadata, incoming wins on key collisions.
+          // Merge metadata, incoming wins on key collisions. structuredClone
+          // each half so nested values can't be shared with either source.
           if (persistedTask.metadata || taskEvent.metadata) {
             mergedTask.metadata = {
-              ...(persistedTask.metadata ?? {}),
-              ...(taskEvent.metadata ?? {}),
+              ...structuredClone(persistedTask.metadata ?? {}),
+              ...structuredClone(taskEvent.metadata ?? {}),
             };
           }
         }
@@ -88,6 +114,10 @@ export class ResultManager {
         this.currentTask = mergedTask;
 
         // Ensure the latest user message is in history if not already present.
+        // `latestUserMessage` was already cloned in `setContext`, but clone
+        // again so the same reference can't end up shared between the
+        // history array and the `latestUserMessage` slot if the same
+        // `ResultManager` is reused for multiple task events.
         if (this.latestUserMessage) {
           if (
             !this.currentTask.history?.find(
@@ -95,7 +125,7 @@ export class ResultManager {
             )
           ) {
             this.currentTask.history = [
-              this.latestUserMessage,
+              structuredClone(this.latestUserMessage),
               ...(this.currentTask.history || []),
             ];
           }
@@ -131,12 +161,14 @@ export class ResultManager {
     await this.ensureTaskLoaded(updateEvent.taskId, 'status update');
 
     if (this.currentTask && this.currentTask.id === updateEvent.taskId) {
-      this.currentTask.status = updateEvent.status;
+      // Clone the incoming status (and its nested message) so caller-side
+      // mutation of the original event payload can't drift our state.
+      this.currentTask.status = structuredClone(updateEvent.status);
       const update = updateEvent.status?.message;
       if (update) {
         // Add message to history if not already present
         if (!this.currentTask.history?.find((msg) => msg.messageId === update.messageId)) {
-          this.currentTask.history = [...(this.currentTask.history || []), update];
+          this.currentTask.history = [...(this.currentTask.history || []), structuredClone(update)];
         }
       }
       await this.saveCurrentTask();
@@ -158,22 +190,27 @@ export class ResultManager {
       );
       if (existingArtifactIndex !== -1) {
         if (artifactEvent.append) {
-          // Basic append logic, assuming parts are compatible
-          // More sophisticated merging might be needed for specific part types
+          // Basic append logic, assuming parts are compatible.
+          // Clone incoming parts/metadata so the persisted artifact owns
+          // its own deep copies and the event payload can be reused
+          // safely by the executor.
           const existingArtifact = this.currentTask.artifacts[existingArtifactIndex];
-          existingArtifact.parts = [...(existingArtifact.parts || []), ...(artifact.parts || [])];
+          existingArtifact.parts = [
+            ...(existingArtifact.parts || []),
+            ...structuredClone(artifact.parts || []),
+          ];
           if (artifact.description) existingArtifact.description = artifact.description;
           if (artifact.name) existingArtifact.name = artifact.name;
           if (artifact.metadata)
             existingArtifact.metadata = {
               ...existingArtifact.metadata,
-              ...artifact.metadata,
+              ...structuredClone(artifact.metadata),
             };
         } else {
-          this.currentTask.artifacts[existingArtifactIndex] = artifact;
+          this.currentTask.artifacts[existingArtifactIndex] = structuredClone(artifact);
         }
       } else {
-        this.currentTask.artifacts.push(artifact);
+        this.currentTask.artifacts.push(structuredClone(artifact));
       }
       await this.saveCurrentTask();
     }
@@ -184,16 +221,20 @@ export class ResultManager {
    * are retained and overlaid by any incoming artifact with the same id;
    * artifacts only present in the incoming list are appended. Order is
    * preserved (persisted first, then any newly-introduced incoming artifacts).
+   *
+   * Every artifact in the returned array is a fresh deep copy so subsequent
+   * in-place mutations (e.g. by `applyArtifactUpdate`) can't leak into the
+   * original `persisted` / `incoming` arrays the caller still holds.
    */
   private mergeArtifacts(
     persisted: Artifact[] | undefined,
     incoming: Artifact[] | undefined
   ): Artifact[] {
     if (!persisted || persisted.length === 0) {
-      return incoming ? [...incoming] : [];
+      return incoming ? structuredClone(incoming) : [];
     }
     if (!incoming || incoming.length === 0) {
-      return [...persisted];
+      return structuredClone(persisted);
     }
 
     const incomingById = new Map<string, Artifact>();
@@ -201,11 +242,13 @@ export class ResultManager {
       incomingById.set(art.artifactId, art);
     }
 
-    const merged: Artifact[] = persisted.map((art) => incomingById.get(art.artifactId) ?? art);
+    const merged: Artifact[] = persisted.map((art) =>
+      structuredClone(incomingById.get(art.artifactId) ?? art)
+    );
     const seenIds = new Set(persisted.map((art) => art.artifactId));
     for (const art of incoming) {
       if (!seenIds.has(art.artifactId)) {
-        merged.push(art);
+        merged.push(structuredClone(art));
       }
     }
     return merged;
@@ -220,6 +263,11 @@ export class ResultManager {
   /**
    * Gets the final result, which could be a Message or a Task.
    * This should be called after the event stream has been fully processed.
+   *
+   * Returns a reference to the internally-tracked object (not a clone) so
+   * that downstream callers like `_applyHistoryLengthSemantics` can apply
+   * in-place edits. Safe because `ResultManager` instances are scoped to a
+   * single request and discarded immediately after this is called.
    * @returns The final Message or the current Task.
    */
   public getFinalResult(): Message | Task | undefined {
@@ -232,6 +280,9 @@ export class ResultManager {
   /**
    * Gets the task currently being managed by this ResultManager instance.
    * This task could be one that was started with or one created during agent execution.
+   *
+   * Returns the internal reference (see {@link getFinalResult} for the
+   * rationale).
    * @returns The current Task or undefined if no task is active.
    */
   public getCurrentTask(): Task | undefined {

--- a/src/server/result_manager.ts
+++ b/src/server/result_manager.ts
@@ -10,8 +10,8 @@ import { AgentExecutionEvent, assertUnreachableEvent } from './events/execution_
 import { TaskStore } from './store.js';
 
 /**
- * Per-`taskId` write serializer shared across every `ResultManager`
- * instance in this process.
+ * Per-(tenant, owner, taskId) write serializer shared across every
+ * `ResultManager` instance in this process.
  *
  * Multiple `ResultManager`s can run concurrently against the same task:
  * - The AUTH_REQUIRED background drain holds one RM while a follow-up
@@ -28,27 +28,52 @@ import { TaskStore } from './store.js';
  * merge semantics make the race observable as missing history /
  * artifacts.
  *
+ * Scoping: the lock key mirrors the {@link TaskStore} scoping contract
+ * — `(tenant, owner, taskId)` — so two different tenants (or two
+ * different owners within the same tenant) that happen to reuse the
+ * same `taskId` do NOT serialize against each other. The `tenant` part
+ * comes from {@link ServerCallContext.tenant}; the owner is derived
+ * from `context.user.userName` (mirroring the default
+ * {@link OwnerResolver}, `resolveUserScope`). Custom store owner
+ * resolvers may produce a slightly different bucketing — this is an
+ * acceptable approximation: the lock is at worst over-conservative
+ * (serializing two callers that the store would have kept separate),
+ * never under-conservative for the default scoping.
+ *
  * Scope: in-process only. Cross-process serialization belongs in the
- * `TaskStore` interface (compare-and-swap or transactional `update`) and
- * is intentionally out of scope here.
+ * `TaskStore` interface (compare-and-swap or transactional `update`)
+ * and is intentionally out of scope here.
  */
 const taskWriteLocks = new Map<string, Promise<unknown>>();
 
-async function serializeByTaskId<T>(taskId: string, fn: () => Promise<T>): Promise<T> {
-  const prev = taskWriteLocks.get(taskId) ?? Promise.resolve();
-  // `.then(fn, fn)` ensures one RM's rejection doesn't block the chain —
-  // the next queued function still runs.
+/**
+ * Builds a stable string key that uniquely identifies a `(tenant,
+ * owner, taskId)` triple. The `\x00` separator guarantees there's no
+ * collision between e.g. `{tenant: 'a\x00b', owner: 'c'}` and `{tenant:
+ * 'a', owner: 'b\x00c'}` because the NUL byte cannot appear in the
+ * input segments under any realistic header/identifier policy.
+ */
+function lockKey(context: ServerCallContext, taskId: string): string {
+  const tenant = context.tenant ?? '';
+  const owner = context.user?.userName ?? '';
+  return `${tenant}\x00${owner}\x00${taskId}`;
+}
+
+/**
+ * Runs `fn` serialized against any prior calls for the same `key`,
+ * chaining onto the existing promise so rejections don't block the
+ * queue and evicting the map entry once the chain drains.
+ */
+async function serializeByScope<T>(key: string, fn: () => Promise<T>): Promise<T> {
+  const prev = taskWriteLocks.get(key) ?? Promise.resolve();
   const next = prev.then(fn, fn);
-  taskWriteLocks.set(
-    taskId,
-    next.finally(() => {
-      // Only evict if no newer call has extended the chain. Without this
-      // guard, a fast successor would be orphaned by our cleanup.
-      if (taskWriteLocks.get(taskId) === next) {
-        taskWriteLocks.delete(taskId);
-      }
-    })
-  );
+  taskWriteLocks.set(key, next);
+  const evict = (): void => {
+    if (taskWriteLocks.get(key) === next) {
+      taskWriteLocks.delete(key);
+    }
+  };
+  void next.then(evict, evict);
   return next;
 }
 
@@ -65,12 +90,15 @@ async function serializeByTaskId<T>(taskId: string, fn: () => Promise<T>): Promi
  * this class is safe to combine with stores that share references.
  *
  * Concurrency: `processEvent` serializes all store-touching branches
- * (`task` / `statusUpdate` / `artifactUpdate`) through a per-`taskId`
- * lock shared across every `ResultManager` instance in the process.
- * Inside the lock we always invalidate `currentTask` and re-load from
- * the store, so a sibling RM's write (e.g. the AUTH_REQUIRED background
- * drain interleaving with a follow-up `sendMessage`) cannot be silently
- * overwritten by a merge against a stale cached snapshot.
+ * (`task` / `statusUpdate` / `artifactUpdate`) through a per-(tenant,
+ * owner, `taskId`) lock shared across every `ResultManager` instance in
+ * the process. The lock key mirrors {@link TaskStore} scoping so two
+ * tenants (or two owners within the same tenant) reusing the same
+ * `taskId` do not falsely serialize. Inside the lock we always
+ * invalidate `currentTask` and re-load from the store, so a sibling
+ * RM's write (e.g. the AUTH_REQUIRED background drain interleaving
+ * with a follow-up `sendMessage`) cannot be silently overwritten by a
+ * merge against a stale cached snapshot.
  */
 export class ResultManager {
   private readonly taskStore: TaskStore;
@@ -129,7 +157,9 @@ export class ResultManager {
           await this.processTaskEventLocked(taskEvent);
           break;
         }
-        await serializeByTaskId(taskEvent.id, () => this.processTaskEventLocked(taskEvent));
+        await serializeByScope(lockKey(this.serverCallContext, taskEvent.id), () =>
+          this.processTaskEventLocked(taskEvent)
+        );
         break;
       }
       case 'statusUpdate': {
@@ -138,7 +168,9 @@ export class ResultManager {
           await this.applyStatusUpdate(updateEvent);
           break;
         }
-        await serializeByTaskId(updateEvent.taskId, () => this.applyStatusUpdate(updateEvent));
+        await serializeByScope(lockKey(this.serverCallContext, updateEvent.taskId), () =>
+          this.applyStatusUpdate(updateEvent)
+        );
         break;
       }
       case 'artifactUpdate': {
@@ -147,7 +179,7 @@ export class ResultManager {
           await this.applyArtifactUpdate(artifactEvent);
           break;
         }
-        await serializeByTaskId(artifactEvent.taskId, () =>
+        await serializeByScope(lockKey(this.serverCallContext, artifactEvent.taskId), () =>
           this.applyArtifactUpdate(artifactEvent)
         );
         break;

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -493,6 +493,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
 
     let finalTaskSaved: Task | undefined;
     const errorMessage = 'Error thrown on saving completed task notification';
+    const taskByState = new Map<TaskState, Task>();
     (mockTaskStore as MockTaskStore).save.mockImplementation(async (task) => {
       if (task.status.state == TaskState.TASK_STATE_COMPLETED) {
         throw new Error(errorMessage);
@@ -501,6 +502,13 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       if (task.status.state == TaskState.TASK_STATE_FAILED) {
         finalTaskSaved = task;
       }
+      taskByState.set(task.status.state, task);
+    });
+    (mockTaskStore as MockTaskStore).load.mockImplementation(async (id) => {
+      for (const t of [...taskByState.values()].reverse()) {
+        if (t.id === id) return t;
+      }
+      return undefined;
     });
 
     // This call should return as soon as the first 'task' event is published

--- a/test/server/result_manager.spec.ts
+++ b/test/server/result_manager.spec.ts
@@ -1,0 +1,357 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { Artifact, Message, Role, Task, TaskState } from '../../src/types/pb/a2a.js';
+import { ServerCallContext } from '../../src/server/context.js';
+import { ResultManager } from '../../src/server/result_manager.js';
+import { InMemoryTaskStore } from '../../src/server/store.js';
+import { AgentEvent } from '../../src/server/events/execution_event_bus.js';
+
+function createMessage(messageId: string, text: string, role: Role = Role.ROLE_USER): Message {
+  return {
+    messageId,
+    role,
+    parts: [
+      {
+        content: { $case: 'text', value: text },
+        mediaType: 'text/plain',
+        filename: '',
+        metadata: undefined,
+      },
+    ],
+    taskId: '',
+    contextId: '',
+    extensions: [],
+    metadata: {},
+    referenceTaskIds: [],
+  };
+}
+
+function createArtifact(artifactId: string, text: string): Artifact {
+  return {
+    artifactId,
+    name: artifactId,
+    description: '',
+    parts: [
+      {
+        content: { $case: 'text', value: text },
+        mediaType: 'text/plain',
+        filename: '',
+        metadata: undefined,
+      },
+    ],
+    metadata: {},
+    extensions: [],
+  };
+}
+
+function createTask(id: string, contextId: string, overrides: Partial<Task> = {}): Task {
+  return {
+    id,
+    contextId,
+    status: {
+      state: TaskState.TASK_STATE_SUBMITTED,
+      message: undefined,
+      timestamp: undefined,
+    },
+    artifacts: [],
+    history: [],
+    metadata: {},
+    ...overrides,
+  };
+}
+
+describe('ResultManager.processEvent("task")', () => {
+  let store: InMemoryTaskStore;
+  let context: ServerCallContext;
+
+  beforeEach(() => {
+    store = new InMemoryTaskStore();
+    context = new ServerCallContext();
+  });
+
+  it('persists the task as-is when no prior state exists', async () => {
+    const rm = new ResultManager(store, context);
+    const userMsg = createMessage('user-1', 'hello');
+    rm.setContext(userMsg);
+
+    const task = createTask('task-1', 'ctx-1');
+    await rm.processEvent(AgentEvent.task(task));
+
+    const saved = await store.load('task-1', context);
+    expect(saved).toBeDefined();
+    expect(saved!.id).toBe('task-1');
+    // The latest user message is still injected when missing.
+    expect(saved!.history).toHaveLength(1);
+    expect(saved!.history![0].messageId).toBe('user-1');
+  });
+
+  it('preserves persisted history when the incoming Task event has empty history', async () => {
+    // Turn 1: prime the store with a task that already has a multi-message
+    // history (the user message and the agent's INPUT_REQUIRED response).
+    const turn1Task = createTask('task-multi', 'ctx-multi', {
+      status: {
+        state: TaskState.TASK_STATE_INPUT_REQUIRED,
+        message: undefined,
+        timestamp: undefined,
+      },
+      history: [
+        createMessage('user-1', 'first user message'),
+        createMessage('agent-1', 'please clarify', Role.ROLE_AGENT),
+      ],
+    });
+    await store.save(turn1Task, context);
+
+    // Turn 2: the executor publishes a fresh Task event with empty history
+    // (e.g. a follow-up after INPUT_REQUIRED). Before the merge fix this
+    // wholesale-replaced the persisted task and dropped the conversation.
+    const rm = new ResultManager(store, context);
+    const followUpUserMsg = createMessage('user-2', 'follow up answer');
+    rm.setContext(followUpUserMsg);
+
+    const turn2Task = createTask('task-multi', 'ctx-multi', {
+      status: {
+        state: TaskState.TASK_STATE_WORKING,
+        message: undefined,
+        timestamp: undefined,
+      },
+      history: [], // executor doesn't re-send history on follow-up turns.
+      artifacts: [],
+    });
+    await rm.processEvent(AgentEvent.task(turn2Task));
+
+    const saved = await store.load('task-multi', context);
+    expect(saved).toBeDefined();
+    expect(saved!.status?.state).toBe(TaskState.TASK_STATE_WORKING);
+
+    // History is preserved AND the latest user message is appended/prepended.
+    const ids = (saved!.history ?? []).map((m) => m.messageId);
+    expect(ids).toContain('user-1');
+    expect(ids).toContain('agent-1');
+    expect(ids).toContain('user-2');
+    expect(saved!.history!.length).toBe(3);
+  });
+
+  it('appends new artifacts to persisted artifacts instead of replacing them', async () => {
+    const persistedArtifact = createArtifact('artifact-keep', 'keep me');
+    const turn1Task = createTask('task-artifacts', 'ctx-art', {
+      history: [createMessage('user-1', 'do work')],
+      artifacts: [persistedArtifact],
+      status: {
+        state: TaskState.TASK_STATE_INPUT_REQUIRED,
+        message: undefined,
+        timestamp: undefined,
+      },
+    });
+    await store.save(turn1Task, context);
+
+    const rm = new ResultManager(store, context);
+    const turn2UserMsg = createMessage('user-2', 'continue');
+    rm.setContext(turn2UserMsg);
+
+    const newArtifact = createArtifact('artifact-new', 'newly added');
+    const turn2Task = createTask('task-artifacts', 'ctx-art', {
+      history: [],
+      artifacts: [newArtifact],
+      status: {
+        state: TaskState.TASK_STATE_WORKING,
+        message: undefined,
+        timestamp: undefined,
+      },
+    });
+    await rm.processEvent(AgentEvent.task(turn2Task));
+
+    const saved = await store.load('task-artifacts', context);
+    expect(saved).toBeDefined();
+    const artifactIds = (saved!.artifacts ?? []).map((a) => a.artifactId);
+    // Persisted artifact survives and the new one is added.
+    expect(artifactIds).toEqual(['artifact-keep', 'artifact-new']);
+  });
+
+  it('overlays incoming artifact onto persisted one when artifactIds collide', async () => {
+    const persistedArtifact = createArtifact('artifact-shared', 'old content');
+    const turn1Task = createTask('task-overlap', 'ctx-overlap', {
+      artifacts: [persistedArtifact],
+      history: [createMessage('user-1', 'go')],
+      status: {
+        state: TaskState.TASK_STATE_INPUT_REQUIRED,
+        message: undefined,
+        timestamp: undefined,
+      },
+    });
+    await store.save(turn1Task, context);
+
+    const rm = new ResultManager(store, context);
+    rm.setContext(createMessage('user-2', 'more'));
+
+    const updatedArtifact = createArtifact('artifact-shared', 'new content');
+    const turn2Task = createTask('task-overlap', 'ctx-overlap', {
+      artifacts: [updatedArtifact],
+    });
+    await rm.processEvent(AgentEvent.task(turn2Task));
+
+    const saved = await store.load('task-overlap', context);
+    expect(saved!.artifacts).toHaveLength(1);
+    const parts = saved!.artifacts![0].parts;
+    expect((parts[0].content as { $case: 'text'; value: string }).value).toBe('new content');
+  });
+
+  it('lets the executor override persisted history when it provides a non-empty history', async () => {
+    const turn1Task = createTask('task-replace-hist', 'ctx-rh', {
+      history: [createMessage('stale-1', 'old')],
+      status: {
+        state: TaskState.TASK_STATE_INPUT_REQUIRED,
+        message: undefined,
+        timestamp: undefined,
+      },
+    });
+    await store.save(turn1Task, context);
+
+    const rm = new ResultManager(store, context);
+    rm.setContext(createMessage('user-2', 'next'));
+
+    // Executor explicitly publishes a history list; this is authoritative
+    // per §3.7, so we should NOT keep the persisted history.
+    const turn2Task = createTask('task-replace-hist', 'ctx-rh', {
+      history: [createMessage('fresh-1', 'agent rewrote history', Role.ROLE_AGENT)],
+    });
+    await rm.processEvent(AgentEvent.task(turn2Task));
+
+    const saved = await store.load('task-replace-hist', context);
+    const ids = (saved!.history ?? []).map((m) => m.messageId);
+    expect(ids).toContain('fresh-1');
+    expect(ids).not.toContain('stale-1');
+    // Latest user message is still added if missing.
+    expect(ids).toContain('user-2');
+  });
+
+  it('merges metadata, with incoming Task event values winning on key collisions', async () => {
+    const turn1Task = createTask('task-meta', 'ctx-meta', {
+      metadata: { keep: 'persisted', shared: 'old' },
+      history: [createMessage('user-1', 'hi')],
+      status: {
+        state: TaskState.TASK_STATE_INPUT_REQUIRED,
+        message: undefined,
+        timestamp: undefined,
+      },
+    });
+    await store.save(turn1Task, context);
+
+    const rm = new ResultManager(store, context);
+    rm.setContext(createMessage('user-2', 'again'));
+
+    const turn2Task = createTask('task-meta', 'ctx-meta', {
+      metadata: { shared: 'new', extra: 'added' },
+    });
+    await rm.processEvent(AgentEvent.task(turn2Task));
+
+    const saved = await store.load('task-meta', context);
+    expect(saved!.metadata).toEqual({
+      keep: 'persisted',
+      shared: 'new',
+      extra: 'added',
+    });
+  });
+
+  it('multi-turn scenario: turn-1 sets history, turn-2 preserves history and adds artifacts', async () => {
+    const contextId = 'ctx-multi-turn';
+    const taskId = 'task-multi-turn';
+
+    // ---- Turn 1: user asks, agent enters INPUT_REQUIRED ----
+    const turn1Rm = new ResultManager(store, context);
+    const turn1UserMsg = createMessage('user-1', 'tell me a movie');
+    turn1Rm.setContext(turn1UserMsg);
+
+    await turn1Rm.processEvent(
+      AgentEvent.task(
+        createTask(taskId, contextId, {
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+        })
+      )
+    );
+
+    await turn1Rm.processEvent(
+      AgentEvent.statusUpdate({
+        taskId,
+        contextId,
+        status: {
+          state: TaskState.TASK_STATE_INPUT_REQUIRED,
+          timestamp: undefined,
+          message: {
+            ...createMessage('agent-1', 'which genre?', Role.ROLE_AGENT),
+            taskId,
+            contextId,
+          },
+        },
+        metadata: {},
+      })
+    );
+
+    const afterTurn1 = await store.load(taskId, context);
+    expect(afterTurn1!.status?.state).toBe(TaskState.TASK_STATE_INPUT_REQUIRED);
+    expect((afterTurn1!.history ?? []).map((m) => m.messageId)).toEqual(['user-1', 'agent-1']);
+
+    // ---- Turn 2: fresh ResultManager (simulating a follow-up request); the
+    // executor re-publishes a Task event with empty history. ----
+    const turn2Rm = new ResultManager(store, context);
+    const turn2UserMsg = createMessage('user-2', 'sci-fi');
+    turn2Rm.setContext(turn2UserMsg);
+
+    await turn2Rm.processEvent(
+      AgentEvent.task(
+        createTask(taskId, contextId, {
+          status: {
+            state: TaskState.TASK_STATE_WORKING,
+            message: undefined,
+            timestamp: undefined,
+          },
+          history: [], // executor does not re-send history.
+          artifacts: [],
+        })
+      )
+    );
+
+    // The agent then produces an artifact and completes the task.
+    await turn2Rm.processEvent(
+      AgentEvent.artifactUpdate({
+        taskId,
+        contextId,
+        artifact: createArtifact('movie-rec', 'Blade Runner'),
+        append: false,
+        lastChunk: true,
+        metadata: {},
+      })
+    );
+
+    await turn2Rm.processEvent(
+      AgentEvent.statusUpdate({
+        taskId,
+        contextId,
+        status: {
+          state: TaskState.TASK_STATE_COMPLETED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        metadata: {},
+      })
+    );
+
+    const finalTask = await store.load(taskId, context);
+    expect(finalTask).toBeDefined();
+    expect(finalTask!.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+
+    // Conversation history from turn 1 is preserved AND the turn-2 user
+    // message is included.
+    const finalIds = (finalTask!.history ?? []).map((m) => m.messageId);
+    expect(finalIds).toContain('user-1');
+    expect(finalIds).toContain('agent-1');
+    expect(finalIds).toContain('user-2');
+
+    // The new artifact landed without clobbering anything.
+    expect(finalTask!.artifacts).toHaveLength(1);
+    expect(finalTask!.artifacts![0].artifactId).toBe('movie-rec');
+  });
+});

--- a/test/server/result_manager.spec.ts
+++ b/test/server/result_manager.spec.ts
@@ -776,4 +776,73 @@ describe('concurrent ResultManagers on the same taskId', () => {
     expect(rejected).toHaveLength(1);
     expect(fulfilled).toHaveLength(1);
   });
+
+  it('does not serialize writes across tenants that happen to share a taskId', async () => {
+    // Two tenants with the same `taskId` MUST NOT block each other. The
+    // lock key is keyed by (tenant, owner, taskId) so different tenants
+    // get independent chains. Verify this by holding tenant-A's lock
+    // open and asserting tenant-B's write still completes promptly.
+    const taskId = 'shared-task-id';
+    const contextId = 'ctx';
+    const ctxA = new ServerCallContext({ tenant: 'tenant-A' });
+    const ctxB = new ServerCallContext({ tenant: 'tenant-B' });
+
+    // Use a single store but with tenant-scoped isolation.
+    await store.save(
+      createTask(taskId, contextId, {
+        history: [createMessage('A-seed', 'A seed')],
+      }),
+      ctxA
+    );
+    await store.save(
+      createTask(taskId, contextId, {
+        history: [createMessage('B-seed', 'B seed')],
+      }),
+      ctxB
+    );
+
+    // Build a slow store wrapper for tenant-A that holds save() open
+    // until we release a gate. Tenant-B uses the unblocked store
+    // directly.
+    let releaseAGate!: () => void;
+    const aGate = new Promise<void>((r) => (releaseAGate = r));
+    const slowStoreA: InMemoryTaskStore = Object.create(store) as InMemoryTaskStore;
+    slowStoreA.save = async (task, ctx) => {
+      await aGate;
+      return store.save(task, ctx);
+    };
+    slowStoreA.load = (id, ctx) => store.load(id, ctx);
+
+    const rmA = new ResultManager(slowStoreA, ctxA);
+    rmA.setContext(createMessage('A-user', 'A user'));
+    const rmB = new ResultManager(store, ctxB);
+    rmB.setContext(createMessage('B-user', 'B user'));
+
+    // Fire tenant-A first; it will block at the gated save.
+    const aPromise = rmA.processEvent(AgentEvent.task(createTask(taskId, contextId)));
+    // Tenant-B's write must NOT wait on tenant-A's lock. Use a small
+    // timeout via Promise.race to assert B completes without A.
+    const bPromise = rmB.processEvent(AgentEvent.task(createTask(taskId, contextId)));
+    const bResult = await Promise.race([
+      bPromise.then(() => 'B-done' as const),
+      new Promise<'timeout'>((r) => setTimeout(() => r('timeout'), 50)),
+    ]);
+    expect(bResult).toBe('B-done');
+
+    // Release tenant-A and let it finish.
+    releaseAGate();
+    await aPromise;
+
+    // Both tenants ended up with their own histories preserved.
+    const finalA = await store.load(taskId, ctxA);
+    const finalB = await store.load(taskId, ctxB);
+    expect((finalA!.history ?? []).map((m) => m.messageId)).toContain('A-seed');
+    expect((finalA!.history ?? []).map((m) => m.messageId)).toContain('A-user');
+    expect((finalB!.history ?? []).map((m) => m.messageId)).toContain('B-seed');
+    expect((finalB!.history ?? []).map((m) => m.messageId)).toContain('B-user');
+    // Cross-contamination check: A's user message must not appear in B
+    // and vice versa.
+    expect((finalA!.history ?? []).map((m) => m.messageId)).not.toContain('B-user');
+    expect((finalB!.history ?? []).map((m) => m.messageId)).not.toContain('A-user');
+  });
 });

--- a/test/server/result_manager.spec.ts
+++ b/test/server/result_manager.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import {
   Artifact,
@@ -363,6 +363,10 @@ describe('ResultManager.processEvent("task")', () => {
   });
 
   it('re-loads from the store when the cached task id differs from the incoming Task event', async () => {
+    // Silence the expected mid-stream-switch warn from `lastSeenTaskId`
+    // tracking; the dedicated "warns" test below verifies it fires.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
     // Prime the store with two distinct tasks.
     const taskA = createTask('task-A', 'ctx-A', {
       history: [createMessage('a-user-1', 'A first')],
@@ -386,7 +390,8 @@ describe('ResultManager.processEvent("task")', () => {
     const rm = new ResultManager(store, context);
     rm.setContext(createMessage('a-user-2', 'A second'));
 
-    // First publish a Task event for task-A so the ResultManager caches it.
+    // First publish a Task event for task-A so the ResultManager has a
+    // cached `currentTask` from a prior event.
     await rm.processEvent(
       AgentEvent.task(
         createTask('task-A', 'ctx-A', {
@@ -400,10 +405,10 @@ describe('ResultManager.processEvent("task")', () => {
     );
     expect(rm.getCurrentTask()?.id).toBe('task-A');
 
-    // Now publish a Task event for task-B with empty history. Without the
-    // defensive reload this would have wholesale-overwritten task-B's
-    // persisted history (because the cached currentTask had id task-A and
-    // wouldn't have matched, so persistedTask would have been undefined).
+    // Now publish a Task event for task-B with empty history. Under the
+    // always-reload-inside-lock semantics, this must load task-B fresh
+    // from the store (not merge against the stale task-A cache) so
+    // task-B's history is preserved.
     rm.setContext(createMessage('b-user-2', 'B second'));
     await rm.processEvent(
       AgentEvent.task(
@@ -429,6 +434,8 @@ describe('ResultManager.processEvent("task")', () => {
     expect(finalAIds).toContain('a-user-1');
     expect(finalAIds).toContain('a-user-2');
     expect(finalAIds).toHaveLength(2);
+
+    warnSpy.mockRestore();
   });
 
   it('isolates persisted state from later mutation of the incoming Task event payload', async () => {
@@ -523,5 +530,250 @@ describe('ResultManager.processEvent("task")', () => {
     expect(
       (snapshot!.artifacts![0].parts[0].content as { $case: 'text'; value: string }).value
     ).toBe('original');
+  });
+});
+
+describe('concurrent ResultManagers on the same taskId', () => {
+  let store: InMemoryTaskStore;
+  let context: ServerCallContext;
+
+  beforeEach(() => {
+    store = new InMemoryTaskStore();
+    context = new ServerCallContext();
+  });
+
+  it('serializes concurrent Task event writes from two RMs without losing user messages', async () => {
+    // Pre-seed an INPUT_REQUIRED task — the common AUTH_REQUIRED-style
+    // setup where two RMs (background drain + follow-up sendMessage) end
+    // up racing on the same row.
+    const taskId = 'task-concurrent-1';
+    const contextId = 'ctx-concurrent-1';
+    await store.save(
+      createTask(taskId, contextId, {
+        history: [createMessage('seed-1', 'seed')],
+        status: {
+          state: TaskState.TASK_STATE_INPUT_REQUIRED,
+          message: undefined,
+          timestamp: undefined,
+        },
+      }),
+      context
+    );
+
+    const rmA = new ResultManager(store, context);
+    rmA.setContext(createMessage('user-A', 'from A'));
+    const rmB = new ResultManager(store, context);
+    rmB.setContext(createMessage('user-B', 'from B'));
+
+    const taskEvent = createTask(taskId, contextId, {
+      status: {
+        state: TaskState.TASK_STATE_WORKING,
+        message: undefined,
+        timestamp: undefined,
+      },
+      history: [],
+    });
+
+    // Fire both concurrently. Without the lock, one RM's load happens
+    // before the other's save, and the second merge clobbers the first
+    // sibling's user message.
+    await Promise.all([
+      rmA.processEvent(AgentEvent.task(structuredClone(taskEvent))),
+      rmB.processEvent(AgentEvent.task(structuredClone(taskEvent))),
+    ]);
+
+    const final = await store.load(taskId, context);
+    const ids = (final!.history ?? []).map((m) => m.messageId);
+    expect(ids).toContain('seed-1');
+    expect(ids).toContain('user-A');
+    expect(ids).toContain('user-B');
+  });
+
+  it('serializes interleaved status + artifact updates from two RMs', async () => {
+    const taskId = 'task-concurrent-2';
+    const contextId = 'ctx-concurrent-2';
+    await store.save(
+      createTask(taskId, contextId, {
+        history: [createMessage('user-1', 'go')],
+        status: {
+          state: TaskState.TASK_STATE_SUBMITTED,
+          message: undefined,
+          timestamp: undefined,
+        },
+      }),
+      context
+    );
+
+    const rmA = new ResultManager(store, context);
+    const rmB = new ResultManager(store, context);
+
+    await Promise.all([
+      rmA.processEvent(
+        AgentEvent.artifactUpdate({
+          taskId,
+          contextId,
+          artifact: createArtifact('art-A', 'from A'),
+          append: false,
+          lastChunk: true,
+          metadata: {},
+        })
+      ),
+      rmB.processEvent(
+        AgentEvent.statusUpdate({
+          taskId,
+          contextId,
+          status: {
+            state: TaskState.TASK_STATE_WORKING,
+            timestamp: undefined,
+            message: createMessage('agent-B', 'from B', Role.ROLE_AGENT),
+          },
+          metadata: {},
+        })
+      ),
+    ]);
+
+    const final = await store.load(taskId, context);
+    // Both writes survived: the artifact from RM-A and the agent message
+    // from RM-B's status update. Without the lock, one of the two would
+    // have been overwritten by the other's save.
+    expect(final!.artifacts?.map((a) => a.artifactId)).toContain('art-A');
+    expect(final!.history?.map((m) => m.messageId)).toContain('agent-B');
+  });
+
+  it('end-to-end: background drain + follow-up sendMessage preserve combined state', async () => {
+    // Models the AUTH_REQUIRED scenario: the original blocking call's RM is still draining events
+    // in the background while the credential-injecting follow-up
+    // sendMessage spins up its own RM. Both run against the same bus and
+    // the same TaskStore row.
+    const taskId = 'task-concurrent-3';
+    const contextId = 'ctx-concurrent-3';
+
+    // Turn 1: initial sendMessage reaches AUTH_REQUIRED.
+    const rmTurn1 = new ResultManager(store, context);
+    rmTurn1.setContext(createMessage('user-1', 'turn 1'));
+    await rmTurn1.processEvent(
+      AgentEvent.task(
+        createTask(taskId, contextId, {
+          status: {
+            state: TaskState.TASK_STATE_AUTH_REQUIRED,
+            message: undefined,
+            timestamp: undefined,
+          },
+        })
+      )
+    );
+
+    // Background drain (rmTurn1 is still alive) interleaves with a new
+    // rmTurn2 from the credential-injecting follow-up sendMessage.
+    const rmTurn2 = new ResultManager(store, context);
+    rmTurn2.setContext(createMessage('user-2', 'with credential'));
+
+    await Promise.all([
+      // Background drain sees a working statusUpdate.
+      rmTurn1.processEvent(
+        AgentEvent.statusUpdate({
+          taskId,
+          contextId,
+          status: {
+            state: TaskState.TASK_STATE_WORKING,
+            timestamp: undefined,
+            message: createMessage('agent-1', 'resumed', Role.ROLE_AGENT),
+          },
+          metadata: {},
+        })
+      ),
+      // Follow-up sendMessage's RM publishes its own task event.
+      rmTurn2.processEvent(
+        AgentEvent.task(
+          createTask(taskId, contextId, {
+            status: {
+              state: TaskState.TASK_STATE_WORKING,
+              message: undefined,
+              timestamp: undefined,
+            },
+          })
+        )
+      ),
+      // Background drain then sees an artifact.
+      rmTurn1.processEvent(
+        AgentEvent.artifactUpdate({
+          taskId,
+          contextId,
+          artifact: createArtifact('art-result', 'final answer'),
+          append: false,
+          lastChunk: true,
+          metadata: {},
+        })
+      ),
+    ]);
+
+    const final = await store.load(taskId, context);
+    const ids = (final!.history ?? []).map((m) => m.messageId);
+    expect(ids).toContain('user-1');
+    expect(ids).toContain('user-2');
+    expect(ids).toContain('agent-1');
+    expect(final!.artifacts?.map((a) => a.artifactId)).toContain('art-result');
+  });
+
+  it('warns when an executor publishes events for a different taskId on the same RM', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const rm = new ResultManager(store, context);
+    rm.setContext(createMessage('user-1', 'hi'));
+    await rm.processEvent(AgentEvent.task(createTask('task-X', 'ctx-X')));
+    await rm.processEvent(AgentEvent.task(createTask('task-Y', 'ctx-Y')));
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringMatching(/switched tasks mid-stream/));
+    warnSpy.mockRestore();
+  });
+
+  it('does not deadlock if a sibling RM throws inside the lock', async () => {
+    const taskId = 'task-concurrent-throw';
+    const contextId = 'ctx-concurrent-throw';
+    await store.save(
+      createTask(taskId, contextId, {
+        history: [createMessage('user-1', 'go')],
+      }),
+      context
+    );
+
+    // Stub a TaskStore that throws once on save, then succeeds, so the
+    // first RM's processEvent rejects under the lock.
+    let saveAttempt = 0;
+    const flakyStore: InMemoryTaskStore = Object.create(store) as InMemoryTaskStore;
+    flakyStore.save = async (task, ctx) => {
+      saveAttempt++;
+      if (saveAttempt === 1) {
+        throw new Error('boom');
+      }
+      return store.save(task, ctx);
+    };
+    flakyStore.load = (id, ctx) => store.load(id, ctx);
+
+    const rmA = new ResultManager(flakyStore, context);
+    rmA.setContext(createMessage('user-A', 'from A'));
+    const rmB = new ResultManager(flakyStore, context);
+    rmB.setContext(createMessage('user-B', 'from B'));
+
+    const taskEvent = createTask(taskId, contextId, {
+      status: {
+        state: TaskState.TASK_STATE_WORKING,
+        message: undefined,
+        timestamp: undefined,
+      },
+    });
+
+    const results = await Promise.allSettled([
+      rmA.processEvent(AgentEvent.task(structuredClone(taskEvent))),
+      rmB.processEvent(AgentEvent.task(structuredClone(taskEvent))),
+    ]);
+
+    // One should have rejected (the flaky save), the other should have
+    // succeeded — the lock chain must not deadlock or swallow the
+    // success.
+    const rejected = results.filter((r) => r.status === 'rejected');
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    expect(rejected).toHaveLength(1);
+    expect(fulfilled).toHaveLength(1);
   });
 });

--- a/test/server/result_manager.spec.ts
+++ b/test/server/result_manager.spec.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 
-import { Artifact, Message, Role, Task, TaskState } from '../../src/types/pb/a2a.js';
+import {
+  Artifact,
+  Message,
+  Role,
+  Task,
+  TaskState,
+  TaskStatusUpdateEvent,
+} from '../../src/types/pb/a2a.js';
 import { ServerCallContext } from '../../src/server/context.js';
 import { ResultManager } from '../../src/server/result_manager.js';
 import { InMemoryTaskStore } from '../../src/server/store.js';
@@ -353,5 +360,168 @@ describe('ResultManager.processEvent("task")', () => {
     // The new artifact landed without clobbering anything.
     expect(finalTask!.artifacts).toHaveLength(1);
     expect(finalTask!.artifacts![0].artifactId).toBe('movie-rec');
+  });
+
+  it('re-loads from the store when the cached task id differs from the incoming Task event', async () => {
+    // Prime the store with two distinct tasks.
+    const taskA = createTask('task-A', 'ctx-A', {
+      history: [createMessage('a-user-1', 'A first')],
+      status: {
+        state: TaskState.TASK_STATE_INPUT_REQUIRED,
+        message: undefined,
+        timestamp: undefined,
+      },
+    });
+    const taskB = createTask('task-B', 'ctx-B', {
+      history: [createMessage('b-user-1', 'B first')],
+      status: {
+        state: TaskState.TASK_STATE_INPUT_REQUIRED,
+        message: undefined,
+        timestamp: undefined,
+      },
+    });
+    await store.save(taskA, context);
+    await store.save(taskB, context);
+
+    const rm = new ResultManager(store, context);
+    rm.setContext(createMessage('a-user-2', 'A second'));
+
+    // First publish a Task event for task-A so the ResultManager caches it.
+    await rm.processEvent(
+      AgentEvent.task(
+        createTask('task-A', 'ctx-A', {
+          status: {
+            state: TaskState.TASK_STATE_WORKING,
+            message: undefined,
+            timestamp: undefined,
+          },
+        })
+      )
+    );
+    expect(rm.getCurrentTask()?.id).toBe('task-A');
+
+    // Now publish a Task event for task-B with empty history. Without the
+    // defensive reload this would have wholesale-overwritten task-B's
+    // persisted history (because the cached currentTask had id task-A and
+    // wouldn't have matched, so persistedTask would have been undefined).
+    rm.setContext(createMessage('b-user-2', 'B second'));
+    await rm.processEvent(
+      AgentEvent.task(
+        createTask('task-B', 'ctx-B', {
+          status: {
+            state: TaskState.TASK_STATE_WORKING,
+            message: undefined,
+            timestamp: undefined,
+          },
+        })
+      )
+    );
+
+    const finalB = await store.load('task-B', context);
+    const finalBIds = (finalB!.history ?? []).map((m) => m.messageId);
+    expect(finalBIds).toContain('b-user-1'); // history preserved across reload
+    expect(finalBIds).toContain('b-user-2');
+    // task-A's persisted state should not have been touched by the task-B
+    // event. The latest user message is prepended by ResultManager when
+    // missing from history.
+    const finalA = await store.load('task-A', context);
+    const finalAIds = (finalA!.history ?? []).map((m) => m.messageId);
+    expect(finalAIds).toContain('a-user-1');
+    expect(finalAIds).toContain('a-user-2');
+    expect(finalAIds).toHaveLength(2);
+  });
+
+  it('isolates persisted state from later mutation of the incoming Task event payload', async () => {
+    const rm = new ResultManager(store, context);
+    const userMsg = createMessage('user-1', 'hi');
+    rm.setContext(userMsg);
+
+    const sharedArtifact = createArtifact('art-1', 'original content');
+    const taskEvent = createTask('task-mutate', 'ctx-mutate', {
+      artifacts: [sharedArtifact],
+      metadata: { agentVersion: 'v1' },
+    });
+    await rm.processEvent(AgentEvent.task(taskEvent));
+
+    // Mutate the originals after publication; the persisted task must not
+    // observe these changes.
+    sharedArtifact.name = 'mutated-name';
+    sharedArtifact.parts[0].content = { $case: 'text', value: 'mutated content' };
+    (taskEvent.metadata as Record<string, string>).agentVersion = 'v999';
+    taskEvent.history = [createMessage('injected', 'should not appear')];
+
+    const saved = await store.load('task-mutate', context);
+    expect(saved!.artifacts![0].name).toBe('art-1');
+    expect((saved!.artifacts![0].parts[0].content as { $case: 'text'; value: string }).value).toBe(
+      'original content'
+    );
+    expect((saved!.metadata as Record<string, string>).agentVersion).toBe('v1');
+    // The injected history entry must not have leaked into our stored task.
+    expect((saved!.history ?? []).map((m) => m.messageId)).not.toContain('injected');
+  });
+
+  it('isolates persisted state from later mutation of incoming status / artifact event payloads', async () => {
+    const taskId = 'task-mutate-updates';
+    const contextId = 'ctx-mutate-updates';
+
+    // Seed with a base task.
+    await store.save(
+      createTask(taskId, contextId, {
+        history: [createMessage('user-1', 'go')],
+        status: {
+          state: TaskState.TASK_STATE_SUBMITTED,
+          message: undefined,
+          timestamp: undefined,
+        },
+      }),
+      context
+    );
+
+    const rm = new ResultManager(store, context);
+
+    // Status update with a message — mutate the original after delivery.
+    const statusMessage = createMessage('agent-1', 'thinking', Role.ROLE_AGENT);
+    const statusEvent: TaskStatusUpdateEvent = {
+      taskId,
+      contextId,
+      status: {
+        state: TaskState.TASK_STATE_WORKING,
+        timestamp: undefined,
+        message: statusMessage,
+      },
+      metadata: {},
+    };
+    await rm.processEvent(AgentEvent.statusUpdate(statusEvent));
+    statusMessage.parts[0].content = { $case: 'text', value: 'mutated' };
+    statusEvent.status.state = TaskState.TASK_STATE_FAILED;
+
+    let snapshot = await store.load(taskId, context);
+    expect(snapshot!.status?.state).toBe(TaskState.TASK_STATE_WORKING);
+    const persistedAgentMsg = snapshot!.history!.find((m) => m.messageId === 'agent-1')!;
+    expect((persistedAgentMsg.parts[0].content as { $case: 'text'; value: string }).value).toBe(
+      'thinking'
+    );
+
+    // Artifact update — mutate after delivery and verify persisted artifact
+    // is unchanged.
+    const artifact = createArtifact('art-x', 'original');
+    await rm.processEvent(
+      AgentEvent.artifactUpdate({
+        taskId,
+        contextId,
+        artifact,
+        append: false,
+        lastChunk: true,
+        metadata: {},
+      })
+    );
+    artifact.parts[0].content = { $case: 'text', value: 'mutated artifact' };
+    artifact.name = 'mutated';
+
+    snapshot = await store.load(taskId, context);
+    expect(snapshot!.artifacts![0].name).toBe('art-x');
+    expect(
+      (snapshot!.artifacts![0].parts[0].content as { $case: 'text'; value: string }).value
+    ).toBe('original');
   });
 });


### PR DESCRIPTION
# Description

## What

`ResultManager.processEvent('task')` merges the incoming Task with the persisted
Task (preserving history + artifacts) instead of wholesale replacement.

## Why

Multi-turn conversations: after INPUT_REQUIRED → follow-up, the executor often
publishes a fresh Task event without history. Wholesale replacement lost the
entire conversation history.

Closes #532
