### PR TITLE
fix(server): synthesize correct error Task id in blocking and streaming paths

### DIFF
--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -447,8 +447,13 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         // Publish a synthetic error event so the consumer's event loop
         // can settle the first-result promise and so any concurrent
         // resubscribers see the failure on the wire.
+        //
+        // The synthetic Task id MUST be `requestContext.taskId` — that's
+        // the id the bus is registered under and the id we hand back to
+        // the client. Fabricating a fresh `uuidv4()` here would make the
+        // returned Task unreachable via `getTask` (TaskNotFoundError).
         const errorTask: Task = {
-          id: requestContext.task?.id || uuidv4(),
+          id: requestContext.taskId,
           contextId: finalMessageForAgent.contextId!,
           status: {
             state: TaskState.TASK_STATE_FAILED,
@@ -540,23 +545,50 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   /**
    * Streaming variant of {@link _runExecutor}.
    *
-   * Differs in error handling: only publishes a synthetic statusUpdate
-   * (not a fresh Task event) when the executor rejects, because the
-   * stream is required to start with the executor's own Task event per
-   * §3.1.2. If the executor failed BEFORE publishing any Task event
-   * (e.g. argument validation), the consumer would otherwise hang
-   * forever — `eventBus.finished()` in the finally block unblocks it.
+   * Error handling mirrors the blocking path:
+   *
+   *   * If the executor has already published a Task event before
+   *     throwing, only a synthetic statusUpdate(FAILED) is published —
+   *     publishing a fresh Task event in that state would violate the
+   *     §3.1.2 task-lifecycle ordering enforced by
+   *     {@link _advanceStreamPattern}.
+   *   * If the executor threw BEFORE publishing any Task event (e.g.
+   *     argument validation, auth check), we synthesize BOTH the Task
+   *     event and the statusUpdate(FAILED) so the SSE consumer sees a
+   *     well-formed task-lifecycle stream that terminates in FAILED.
+   *     Previously this path silently returned, leaving the client with
+   *     an empty stream and no signal that the request failed —
+   *     asymmetric with the blocking path which always synthesizes the
+   *     error Task.
+   *
+   * The synthetic Task id is `requestContext.taskId` (the bus
+   * registration key and the id the client will use for subsequent
+   * `getTask` calls); the executor-published `latestTask` (if any) is
+   * preferred for the statusUpdate so the failure carries the same id
+   * the consumer has already seen on the wire.
+   *
+   * Note: we read the most-recently-published Task off the bus listener
+   * rather than from `ResultManager`. The consumer loop that drains the
+   * bus into `ResultManager` runs in a separate microtask, so
+   * `ResultManager.getCurrentTask()` would still return `undefined`
+   * immediately after a synchronous `bus.publish(...)` followed by a
+   * `throw` — which is exactly the typical executor pattern. See
+   * `trackLatestPublishedTask` and `_runExecutor` for the same
+   * rationale.
    */
   private _runStreamExecutor(
     taskId: string,
     eventBus: ExecutionEventBus,
     requestContext: RequestContext,
-    resultManager: ResultManager
+    _resultManager: ResultManager
   ): void {
     const finalMessageForAgent = requestContext.userMessage;
     // See `_runExecutor` for why we snoop the bus directly instead of
-    // re-reading state from `resultManager` in the `.finally` block.
+    // re-reading state from `resultManager` in the `.finally` block,
+    // and `trackLatestPublishedTask` for the analogous reasoning in
+    // the `.catch` block below.
     const stateTracker = trackLatestTaskState(eventBus);
+    const publishedTaskTracker = trackLatestPublishedTask(eventBus);
     this.agentExecutor
       .execute(requestContext, eventBus)
       .catch((err: unknown) => {
@@ -568,24 +600,65 @@ export class DefaultRequestHandler implements A2ARequestHandler {
           `Agent execution failed for stream message ${finalMessageForAgent.messageId}:`,
           err
         );
-        // Only publish a synthetic error status update if the task already
-        // exists in the store. If the agent failed before creating a task,
-        // the `finished()` signal below unblocks the consumer without
-        // producing a stream-pattern violation.
-        const currentTask = resultManager.getCurrentTask();
-        if (!currentTask) {
-          return;
+
+        const latestTask = publishedTaskTracker();
+        const errorTaskId = latestTask?.id ?? requestContext.taskId;
+        const errorContextId = latestTask?.contextId ?? finalMessageForAgent.contextId!;
+
+        // If no Task event has been published yet, synthesize one first
+        // so the SSE consumer's stream pattern transitions into
+        // TASK_LIFECYCLE (per §3.1.2) before the statusUpdate(FAILED)
+        // lands. Without this, the executor would silently close an
+        // empty stream and the client would have no way to learn the
+        // request failed — the asymmetry called out in PR 2.
+        if (!latestTask) {
+          const errorTask: Task = {
+            id: requestContext.taskId,
+            contextId: finalMessageForAgent.contextId!,
+            status: {
+              state: TaskState.TASK_STATE_FAILED,
+              message: {
+                role: Role.ROLE_AGENT,
+                messageId: uuidv4(),
+                taskId: requestContext.taskId,
+                contextId: finalMessageForAgent.contextId!,
+                parts: [
+                  {
+                    content: { $case: 'text', value: `Agent execution error: ${errorMessage}` },
+                    mediaType: 'text/plain',
+                    filename: '',
+                    metadata: {},
+                  },
+                ],
+                metadata: {},
+                extensions: [],
+                referenceTaskIds: [],
+              },
+              timestamp: new Date().toISOString(),
+            },
+            artifacts: [],
+            history: requestContext.task?.history ? [...requestContext.task.history] : [],
+            metadata: {},
+          };
+          if (
+            finalMessageForAgent &&
+            !errorTask.history?.find((m) => m.messageId === finalMessageForAgent.messageId)
+          ) {
+            errorTask.history?.push(finalMessageForAgent);
+          }
+          eventBus.publish(AgentEvent.task(errorTask));
         }
+
         const errorTaskStatus: TaskStatusUpdateEvent = {
-          taskId: requestContext.taskId,
-          contextId: finalMessageForAgent.contextId!,
+          taskId: errorTaskId,
+          contextId: errorContextId,
           status: {
             state: TaskState.TASK_STATE_FAILED,
             message: {
               role: Role.ROLE_AGENT,
               messageId: uuidv4(),
-              taskId: requestContext.taskId,
-              contextId: finalMessageForAgent.contextId!,
+              taskId: errorTaskId,
+              contextId: errorContextId,
               parts: [
                 {
                   content: { $case: 'text', value: `Agent execution error: ${errorMessage}` },
@@ -1244,5 +1317,39 @@ function trackLatestTaskState(bus: ExecutionEventBus): () => TaskState | undefin
   return () => {
     bus.off('event', listener);
     return lastState;
+  };
+}
+
+/**
+ * Subscribes a lightweight listener on `bus` that records the
+ * most-recent `Task` event published. Returns a thunk that detaches
+ * the listener and yields the captured `Task` (or `undefined` if none
+ * was published).
+ *
+ * Used by `_runStreamExecutor`'s error path to decide whether to
+ * synthesize a fresh Task event before the terminal statusUpdate.
+ * Reading from the `ResultManager` is unsafe at the point we need to
+ * make this decision: the consumer loop that drains the bus into the
+ * `ResultManager` runs in a separate microtask, so an executor that
+ * synchronously `bus.publish(...)`s a Task and then throws would
+ * appear (via `ResultManager`) to have published nothing — and we'd
+ * incorrectly re-publish a Task, violating the §3.1.2 stream-pattern
+ * ordering enforced by `_advanceStreamPattern`.
+ *
+ * The same per-execution listener-detach contract as
+ * {@link trackLatestTaskState} applies: detach on read in `.finally()`
+ * so a long-lived bus doesn't accumulate listeners across turns.
+ */
+function trackLatestPublishedTask(bus: ExecutionEventBus): () => Task | undefined {
+  let lastTask: Task | undefined;
+  const listener = (event: AgentExecutionEvent) => {
+    if (event.kind === 'task') {
+      lastTask = event.data;
+    }
+  };
+  bus.on('event', listener);
+  return () => {
+    bus.off('event', listener);
+    return lastTask;
   };
 }

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -587,8 +587,22 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     // re-reading state from `resultManager` in the `.finally` block,
     // and `trackLatestPublishedTask` for the analogous reasoning in
     // the `.catch` block below.
-    const stateTracker = trackLatestTaskState(eventBus);
+    const rawStateTracker = trackLatestTaskState(eventBus);
     const publishedTaskTracker = trackLatestPublishedTask(eventBus);
+    // Compose the two trackers so `.finally()` always detaches BOTH
+    // listeners — including on the success path, which never enters
+    // `.catch` and so never invokes `publishedTaskTracker()` directly.
+    // Without this, the published-task listener leaks on the bus, and
+    // since the bus is kept alive across INPUT_REQUIRED / AUTH_REQUIRED
+    // turns, every follow-up `sendMessageStream` on the same task would
+    // pile on another listener. The detach thunks are idempotent
+    // (`bus.off` on an already-removed listener is a no-op), so calling
+    // `publishedTaskTracker()` here after the `.catch` block has already
+    // consumed it is safe.
+    const stateTracker = () => {
+      publishedTaskTracker();
+      return rawStateTracker();
+    };
     this.agentExecutor
       .execute(requestContext, eventBus)
       .catch((err: unknown) => {

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -567,42 +567,26 @@ export class DefaultRequestHandler implements A2ARequestHandler {
    * preferred for the statusUpdate so the failure carries the same id
    * the consumer has already seen on the wire.
    *
-   * Note: we read the most-recently-published Task off the bus listener
-   * rather than from `ResultManager`. The consumer loop that drains the
-   * bus into `ResultManager` runs in a separate microtask, so
+   * Note: we read the most-recent published Task and task state off
+   * the bus via {@link trackLatestTaskAndState} rather than from
+   * `ResultManager`. The consumer loop that drains the bus into
+   * `ResultManager` runs in a separate microtask, so
    * `ResultManager.getCurrentTask()` would still return `undefined`
    * immediately after a synchronous `bus.publish(...)` followed by a
-   * `throw` — which is exactly the typical executor pattern. See
-   * `trackLatestPublishedTask` and `_runExecutor` for the same
-   * rationale.
+   * `throw` — which is exactly the typical executor pattern.
    */
   private _runStreamExecutor(
     taskId: string,
     eventBus: ExecutionEventBus,
-    requestContext: RequestContext,
-    _resultManager: ResultManager
+    requestContext: RequestContext
   ): void {
     const finalMessageForAgent = requestContext.userMessage;
-    // See `_runExecutor` for why we snoop the bus directly instead of
-    // re-reading state from `resultManager` in the `.finally` block,
-    // and `trackLatestPublishedTask` for the analogous reasoning in
-    // the `.catch` block below.
-    const rawStateTracker = trackLatestTaskState(eventBus);
-    const publishedTaskTracker = trackLatestPublishedTask(eventBus);
-    // Compose the two trackers so `.finally()` always detaches BOTH
-    // listeners — including on the success path, which never enters
-    // `.catch` and so never invokes `publishedTaskTracker()` directly.
-    // Without this, the published-task listener leaks on the bus, and
-    // since the bus is kept alive across INPUT_REQUIRED / AUTH_REQUIRED
-    // turns, every follow-up `sendMessageStream` on the same task would
-    // pile on another listener. The detach thunks are idempotent
-    // (`bus.off` on an already-removed listener is a no-op), so calling
-    // `publishedTaskTracker()` here after the `.catch` block has already
-    // consumed it is safe.
-    const stateTracker = () => {
-      publishedTaskTracker();
-      return rawStateTracker();
-    };
+    // Single per-execution listener captures both the most-recent Task
+    // event and the most-recent task state — see
+    // `trackLatestTaskAndState` for why combining them in one listener
+    // avoids double dispatch and why reading the snapshot from
+    // ResultManager here is unsafe.
+    const snapshotTracker = trackLatestTaskAndState(eventBus);
     this.agentExecutor
       .execute(requestContext, eventBus)
       .catch((err: unknown) => {
@@ -615,7 +599,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
           err
         );
 
-        const latestTask = publishedTaskTracker();
+        const latestTask = snapshotTracker().task;
         const errorTaskId = latestTask?.id ?? requestContext.taskId;
         const errorContextId = latestTask?.contextId ?? finalMessageForAgent.contextId!;
 
@@ -692,10 +676,11 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         eventBus.publish(AgentEvent.statusUpdate(errorTaskStatus));
       })
       .finally(() => {
-        // Closes the bus for terminal tasks; kept alive for
+        // Detach the bus listener and read the final state in one
+        // call. Closes the bus for terminal tasks; kept alive for
         // INPUT_REQUIRED / AUTH_REQUIRED so follow-up sends and
         // resubscribers can still attach.
-        this._settleBus(taskId, eventBus, stateTracker());
+        this._settleBus(taskId, eventBus, snapshotTracker().state);
       });
   }
 
@@ -864,7 +849,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     // to attach via `tasks/resubscribe` while the executor keeps
     // running, so we cannot tear down the bus here when this generator
     // settles.
-    this._runStreamExecutor(taskId, eventBus, requestContext, resultManager);
+    this._runStreamExecutor(taskId, eventBus, requestContext);
 
     let streamPattern = StreamPattern.UNDETERMINED;
     try {
@@ -1335,35 +1320,73 @@ function trackLatestTaskState(bus: ExecutionEventBus): () => TaskState | undefin
 }
 
 /**
- * Subscribes a lightweight listener on `bus` that records the
- * most-recent `Task` event published. Returns a thunk that detaches
- * the listener and yields the captured `Task` (or `undefined` if none
- * was published).
+ * Snapshot exposed by {@link trackLatestTaskAndState}.
+ */
+interface LatestTaskSnapshot {
+  /**
+   * The most-recent `Task` event published on the bus, or `undefined`
+   * if no Task event has been seen.
+   */
+  task: Task | undefined;
+  /**
+   * The most-recent task state observed on the bus — either via a
+   * `Task` event or a subsequent `TaskStatusUpdateEvent`. May be more
+   * recent than `task.status.state`.
+   */
+  state: TaskState | undefined;
+}
+
+/**
+ * Subscribes a single lightweight listener on `bus` that records both:
  *
- * Used by `_runStreamExecutor`'s error path to decide whether to
- * synthesize a fresh Task event before the terminal statusUpdate.
- * Reading from the `ResultManager` is unsafe at the point we need to
- * make this decision: the consumer loop that drains the bus into the
- * `ResultManager` runs in a separate microtask, so an executor that
- * synchronously `bus.publish(...)`s a Task and then throws would
+ *   * the most-recent `Task` event published, and
+ *   * the most-recent task state (from `Task` or
+ *     `TaskStatusUpdateEvent`, whichever is newer).
+ *
+ * Returns a thunk that detaches the listener and yields the snapshot.
+ *
+ * Combines what used to be two separate per-execution listeners into
+ * one to avoid double dispatch on every `bus.publish(...)`. Used by
+ * {@link DefaultRequestHandler._runStreamExecutor} to make two
+ * decisions in the executor's `.finally` / `.catch` blocks:
+ *
+ *   1. Whether to settle the bus or keep it alive for follow-ups
+ *      (driven by `state`).
+ *   2. Whether to synthesize a Task event before the terminal
+ *      statusUpdate on the error path (driven by `task`).
+ *
+ * Reading state from `ResultManager` would be unsafe at the point we
+ * need to make these decisions: the consumer loop that drains the bus
+ * into `ResultManager` runs in a separate microtask, so an executor
+ * that synchronously `bus.publish(...)`s a Task and then throws would
  * appear (via `ResultManager`) to have published nothing — and we'd
  * incorrectly re-publish a Task, violating the §3.1.2 stream-pattern
  * ordering enforced by `_advanceStreamPattern`.
  *
- * The same per-execution listener-detach contract as
- * {@link trackLatestTaskState} applies: detach on read in `.finally()`
- * so a long-lived bus doesn't accumulate listeners across turns.
+ * Detach contract: the returned thunk must be invoked exactly once,
+ * in a `.finally` block, so the listener is removed regardless of
+ * whether the executor succeeded or threw. Otherwise long-lived buses
+ * (kept alive for INPUT_REQUIRED / AUTH_REQUIRED) would accumulate
+ * one listener per turn. The thunk's `bus.off` is idempotent at the
+ * bus level, so an extra read after the listener is already detached
+ * just returns the last-known snapshot.
  */
-function trackLatestPublishedTask(bus: ExecutionEventBus): () => Task | undefined {
+function trackLatestTaskAndState(bus: ExecutionEventBus): () => LatestTaskSnapshot {
   let lastTask: Task | undefined;
+  let lastState: TaskState | undefined;
   const listener = (event: AgentExecutionEvent) => {
     if (event.kind === 'task') {
       lastTask = event.data;
+      if (event.data.status?.state !== undefined) {
+        lastState = event.data.status.state;
+      }
+    } else if (event.kind === 'statusUpdate' && event.data.status?.state !== undefined) {
+      lastState = event.data.status.state;
     }
   };
   bus.on('event', listener);
   return () => {
     bus.off('event', listener);
-    return lastTask;
+    return { task: lastTask, state: lastState };
   };
 }

--- a/test/server/request_handler/error_envelope.spec.ts
+++ b/test/server/request_handler/error_envelope.spec.ts
@@ -1,0 +1,266 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+
+import { DefaultRequestHandler, InMemoryTaskStore, TaskStore } from '../../../src/server/index.js';
+import {
+  AgentCard,
+  GetTaskRequest,
+  Message,
+  Role,
+  SendMessageRequest,
+  Task,
+  TaskState,
+} from '../../../src/types/pb/a2a.js';
+import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
+import { ServerCallContext } from '../../../src/server/context.js';
+import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
+
+/**
+ * Coverage for the synthetic error Task fabricated by
+ * {@link DefaultRequestHandler._runExecutor} when the agent rejects
+ * BEFORE publishing a Task event.
+ *
+ * The contract verified here:
+ *
+ *   1. The synthetic Task's `id` matches `requestContext.taskId` — i.e.
+ *      the same id under which the event bus is registered and that the
+ *      handler hands to the client. Previously the code used
+ *      `requestContext.task?.id || uuidv4()`, which fabricated a brand
+ *      new UUID divorced from the bus registration key; the client
+ *      received an id that produced `TaskNotFoundError` on a subsequent
+ *      `getTask` call.
+ *
+ *   2. A subsequent `getTask(returnedId)` resolves successfully and
+ *      yields the FAILED task — proving the synthetic Task is reachable
+ *      via the same id returned in the blocking response.
+ *
+ *   3. When the request supplied an explicit `taskId`, the synthetic
+ *      Task uses it verbatim (no UUID round-trip).
+ *
+ *   4. When the request did NOT supply a `taskId`, the synthetic Task
+ *      uses the handler-generated `requestContext.taskId` (the same id
+ *      the bus is keyed under), and `getTask` resolves with the
+ *      handler-generated id.
+ */
+describe('DefaultRequestHandler synthetic error Task id (blocking path)', () => {
+  let handler: DefaultRequestHandler;
+  let taskStore: TaskStore;
+  let mockExecutor: MockAgentExecutor;
+  let eventBusManager: DefaultExecutionEventBusManager;
+
+  const agentCard: AgentCard = {
+    name: 'Error Envelope Agent',
+    description: 'Test agent for synthetic-error-Task id assertions',
+    version: '1.0.0',
+    provider: undefined,
+    documentationUrl: '',
+    supportedInterfaces: [
+      {
+        url: 'http://localhost/a2a',
+        protocolBinding: 'HTTP+JSON',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+    ],
+    capabilities: {
+      extensions: [],
+      streaming: true,
+      pushNotifications: false,
+    },
+    securitySchemes: {},
+    securityRequirements: [],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    signatures: [],
+  };
+
+  const serverContext = new ServerCallContext();
+
+  beforeEach(() => {
+    taskStore = new InMemoryTaskStore();
+    mockExecutor = new MockAgentExecutor();
+    eventBusManager = new DefaultExecutionEventBusManager();
+    handler = new DefaultRequestHandler(agentCard, taskStore, mockExecutor, eventBusManager);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeMessage = (id: string, text: string, overrides: Partial<Message> = {}): Message => ({
+    messageId: id,
+    role: Role.ROLE_USER,
+    parts: [
+      {
+        content: { $case: 'text', value: text },
+        mediaType: 'text/plain',
+        filename: '',
+        metadata: undefined,
+      },
+    ],
+    taskId: '',
+    contextId: '',
+    extensions: [],
+    metadata: {},
+    referenceTaskIds: [],
+    ...overrides,
+  });
+
+  it('synthetic Task id matches requestContext.taskId (handler-generated) when message has no taskId', async () => {
+    // Capture the taskId the handler assigned so we can prove the
+    // synthetic error Task uses the SAME id, not a fresh `uuidv4()`.
+    let observedRequestTaskId = '';
+    mockExecutor.execute.mockImplementation(async (ctx) => {
+      observedRequestTaskId = ctx.taskId;
+      throw new Error('boom before any Task event');
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-err-1', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const result = (await handler.sendMessage(params, serverContext)) as Task;
+
+    expect(observedRequestTaskId).not.toBe('');
+    expect(result.id).toBe(observedRequestTaskId);
+    expect(result.status.state).toBe(TaskState.TASK_STATE_FAILED);
+  });
+
+  it('synthetic Task id matches the explicit taskId the client supplied on the incoming message', async () => {
+    // First, prime the store with an existing non-terminal task so the
+    // handler's `_createRequestContext` finds it and binds the new
+    // request to its id (per §3.4.3). Without this, the handler raises
+    // `TaskNotFoundError` for an unknown `incomingMessage.taskId`.
+    const existingTaskId = 'client-supplied-task-id';
+    const existingContextId = 'client-supplied-context-id';
+    await taskStore.save(
+      {
+        id: existingTaskId,
+        contextId: existingContextId,
+        status: {
+          state: TaskState.TASK_STATE_INPUT_REQUIRED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      },
+      serverContext
+    );
+
+    let observedRequestTaskId = '';
+    mockExecutor.execute.mockImplementation(async (ctx) => {
+      observedRequestTaskId = ctx.taskId;
+      throw new Error('boom before any Task event');
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-err-2', 'kick off', {
+        taskId: existingTaskId,
+        contextId: existingContextId,
+      }),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const result = (await handler.sendMessage(params, serverContext)) as Task;
+
+    expect(observedRequestTaskId).toBe(existingTaskId);
+    expect(result.id).toBe(existingTaskId);
+    expect(result.status.state).toBe(TaskState.TASK_STATE_FAILED);
+  });
+
+  it('getTask(returnedId) resolves to the FAILED task — synthetic Task is reachable via its returned id', async () => {
+    // This is the regression test for the bug: previously the
+    // synthetic Task used a fabricated `uuidv4()` that did not match
+    // any key in the event bus or the task store, so `getTask(id)`
+    // raised `TaskNotFoundError`. With the fix, `id ==
+    // requestContext.taskId`, and the synthetic Task is persisted via
+    // the normal ResultManager → TaskStore drain.
+    const errorMessage = 'agent blew up before publishing a Task';
+    mockExecutor.execute.mockRejectedValue(new Error(errorMessage));
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-err-3', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const sendResult = (await handler.sendMessage(params, serverContext)) as Task;
+    expect(sendResult.status.state).toBe(TaskState.TASK_STATE_FAILED);
+
+    const getParams: GetTaskRequest = {
+      id: sendResult.id,
+      tenant: '',
+      historyLength: undefined,
+    };
+    const loaded = await handler.getTask(getParams, serverContext);
+    expect(loaded.id).toBe(sendResult.id);
+    expect(loaded.status.state).toBe(TaskState.TASK_STATE_FAILED);
+    expect(
+      (loaded.status.message?.parts[0].content as { $case: 'text'; value: string }).value
+    ).toContain(errorMessage);
+  });
+
+  it('synthetic Task carries the original user message in history so subsequent reads see what the client sent', async () => {
+    // When the executor fails before publishing a Task, the user
+    // message that triggered the request would otherwise be lost from
+    // the synthesized Task. The blocking-path synthesis appends the
+    // user message to `history` so the FAILED task is self-describing.
+    mockExecutor.execute.mockRejectedValue(new Error('failed before publishing task'));
+
+    const userMessage = makeMessage('msg-err-4', 'please tell me a joke');
+    const params: SendMessageRequest = {
+      message: userMessage,
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const result = (await handler.sendMessage(params, serverContext)) as Task;
+    expect(result.status.state).toBe(TaskState.TASK_STATE_FAILED);
+    expect(result.history?.find((m) => m.messageId === userMessage.messageId)).toBeDefined();
+  });
+
+  it('non-blocking sendMessage path also returns the synthetic Task with id == requestContext.taskId', async () => {
+    // The non-blocking branch resolves on the first published event;
+    // the synthetic Task IS that first event when the executor rejects
+    // before publishing anything. Confirms the fix is consistent across
+    // both branches that share `_runExecutor`.
+    let observedRequestTaskId = '';
+    mockExecutor.execute.mockImplementation(async (ctx) => {
+      observedRequestTaskId = ctx.taskId;
+      throw new Error('non-blocking boom');
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-err-5', 'kick off'),
+      tenant: '',
+      configuration: {
+        acceptedOutputModes: [],
+        taskPushNotificationConfig: undefined,
+        returnImmediately: true,
+      },
+      metadata: {},
+    };
+
+    const result = (await handler.sendMessage(params, serverContext)) as Task;
+    expect(observedRequestTaskId).not.toBe('');
+    expect(result.id).toBe(observedRequestTaskId);
+    expect(result.status.state).toBe(TaskState.TASK_STATE_FAILED);
+
+    // And the synthetic Task is reachable via `getTask` afterward.
+    const loaded = await handler.getTask(
+      { id: result.id, tenant: '', historyLength: undefined },
+      serverContext
+    );
+    expect(loaded.id).toBe(result.id);
+    expect(loaded.status.state).toBe(TaskState.TASK_STATE_FAILED);
+  });
+});

--- a/test/server/request_handler/streaming_errors.spec.ts
+++ b/test/server/request_handler/streaming_errors.spec.ts
@@ -12,7 +12,10 @@ import {
   TaskStatusUpdateEvent,
 } from '../../../src/types/pb/a2a.js';
 import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
-import { AgentEvent } from '../../../src/server/events/execution_event_bus.js';
+import {
+  AgentEvent,
+  DefaultExecutionEventBus,
+} from '../../../src/server/events/execution_event_bus.js';
 import { ServerCallContext } from '../../../src/server/context.js';
 import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
 
@@ -342,5 +345,144 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(eventBusManager.getByTaskId(observedRequestTaskId)).toBeUndefined();
+  });
+
+  it('does not leak the published-task listener on the success path (regression: gemini-code-assist)', async () => {
+    // Regression for the listener leak gemini-code-assist flagged on
+    // PR #525: `trackLatestPublishedTask` registers a listener on the
+    // bus at the top of `_runStreamExecutor`, but the detach thunk it
+    // returns is only invoked inside the `.catch` block. On the
+    // success path the `.catch` is skipped, so the listener leaks on
+    // the bus — and because the bus is kept alive across
+    // INPUT_REQUIRED / AUTH_REQUIRED turns (§3.4.3, §7.6.1), every
+    // follow-up `sendMessageStream` on the same task adds another
+    // listener.
+    //
+    // Strategy: drive several successful INPUT_REQUIRED turns on the
+    // same task (so the bus stays alive across turns) and read the
+    // bus's internal `eventListeners` map size after each turn
+    // settles. With the bug, the map size would grow by 1 per turn
+    // (the un-detached `trackLatestPublishedTask` listener). With the
+    // fix, the map shrinks back to its baseline after each turn.
+    const taskId = 'leak-task-1';
+    const contextId = 'leak-context-1';
+
+    // Pre-create the task in the store so the handler binds each
+    // follow-up `message/send` to this taskId (per §3.4.3) and finds
+    // the bus we install below.
+    await taskStore.save(
+      {
+        id: taskId,
+        contextId,
+        status: {
+          state: TaskState.TASK_STATE_INPUT_REQUIRED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      },
+      serverContext
+    );
+
+    const bus = new DefaultExecutionEventBus();
+
+    // Install the bus into the manager BEFORE the handler is asked to
+    // create one, so `createOrGetByTaskId` returns this instance.
+    const localBusManager = new DefaultExecutionEventBusManager();
+    (localBusManager as unknown as { taskIdToBus: Map<string, unknown> }).taskIdToBus.set(
+      taskId,
+      bus
+    );
+
+    const localHandler = new DefaultRequestHandler(
+      agentCard,
+      taskStore,
+      mockExecutor,
+      localBusManager
+    );
+
+    // Reach into the bus's private listener map to read its size.
+    // The DefaultExecutionEventBus tracks 'event' listeners in a
+    // private `Map<Listener, WrappedListener[]>`; counting its size
+    // gives us the number of distinct registered `event` listeners.
+    const eventListenerCount = (): number =>
+      (bus as unknown as { eventListeners: Map<unknown, unknown> }).eventListeners.size;
+
+    // Drive N successful INPUT_REQUIRED turns. Pre-fix, each turn
+    // leaks one listener (the `trackLatestPublishedTask` one),
+    // monotonically growing the listener map. Post-fix, the size
+    // returns to the same baseline after each turn settles.
+    const turns = 3;
+    const sizesAfterTurns: number[] = [];
+
+    const runInputRequiredTurn = async (turnIdx: number): Promise<void> => {
+      mockExecutor.execute.mockImplementationOnce(async (_ctx, busArg) => {
+        busArg.publish(
+          AgentEvent.task({
+            id: taskId,
+            contextId,
+            status: {
+              state: TaskState.TASK_STATE_SUBMITTED,
+              message: undefined,
+              timestamp: undefined,
+            },
+            artifacts: [],
+            history: [],
+            metadata: {},
+          })
+        );
+        busArg.publish(
+          AgentEvent.statusUpdate({
+            taskId,
+            contextId,
+            status: {
+              state: TaskState.TASK_STATE_INPUT_REQUIRED,
+              message: undefined,
+              timestamp: undefined,
+            },
+            metadata: {},
+          })
+        );
+      });
+
+      const params: SendMessageRequest = {
+        message: makeMessage(`msg-leak-${turnIdx}`, `turn ${turnIdx}`, { taskId, contextId }),
+        tenant: '',
+        configuration: undefined,
+        metadata: {},
+      };
+      for await (const _event of localHandler.sendMessageStream(params, serverContext)) {
+        void _event;
+      }
+      // Allow `.finally()` (which detaches the tracker listeners) and
+      // the queue's stop() (which detaches its own listeners) to run.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      // Bus must still be alive at INPUT_REQUIRED per §3.4.3.
+      expect(localBusManager.getByTaskId(taskId)).toBe(bus);
+      sizesAfterTurns.push(eventListenerCount());
+    };
+
+    for (let i = 0; i < turns; i++) {
+      await runInputRequiredTurn(i);
+    }
+
+    // After every settled turn, the bus must hold exactly the same
+    // number of `event` listeners — the baseline (0 in this setup, but
+    // we assert equality rather than zero to stay robust against
+    // future infrastructure listeners). A leaking
+    // `trackLatestPublishedTask` would make the sequence monotonically
+    // increasing (e.g., [1, 2, 3]).
+    const baseline = sizesAfterTurns[0];
+    for (let i = 1; i < sizesAfterTurns.length; i++) {
+      expect(sizesAfterTurns[i]).toBe(baseline);
+    }
+    // And the baseline itself must be 0: there's no executor running
+    // between turns and no live consumer, so nothing should remain
+    // attached to the bus.
+    expect(baseline).toBe(0);
   });
 });

--- a/test/server/request_handler/streaming_errors.spec.ts
+++ b/test/server/request_handler/streaming_errors.spec.ts
@@ -1,0 +1,346 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+
+import { DefaultRequestHandler, InMemoryTaskStore, TaskStore } from '../../../src/server/index.js';
+import {
+  AgentCard,
+  Message,
+  Role,
+  SendMessageRequest,
+  StreamResponse,
+  Task,
+  TaskState,
+  TaskStatusUpdateEvent,
+} from '../../../src/types/pb/a2a.js';
+import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
+import { AgentEvent } from '../../../src/server/events/execution_event_bus.js';
+import { ServerCallContext } from '../../../src/server/context.js';
+import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
+
+/**
+ * Coverage for the streaming error path in
+ * {@link DefaultRequestHandler._runStreamExecutor}.
+ *
+ * Two scenarios are exercised, mirroring the asymmetry called out in
+ * PR 2:
+ *
+ *   1. Executor throws BEFORE publishing any Task event. Previously
+ *      `_runStreamExecutor` silently returned from its `.catch` block
+ *      after seeing `resultManager.getCurrentTask()` is undefined,
+ *      leaving the SSE consumer with an empty stream and no error
+ *      indication. With the fix it now synthesizes BOTH a Task event
+ *      (so the stream pattern transitions into TASK_LIFECYCLE per
+ *      §3.1.2) AND a statusUpdate(FAILED), using `requestContext.taskId`
+ *      as the synthetic Task id.
+ *
+ *   2. Executor publishes a Task event, then throws. This was already
+ *      handled before the fix (only a synthetic statusUpdate(FAILED) is
+ *      published; a fresh Task event would violate the §3.1.2 ordering
+ *      enforced by `_advanceStreamPattern`). Pinned here as a regression
+ *      guard so future refactors don't accidentally re-emit a Task.
+ */
+describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)', () => {
+  let handler: DefaultRequestHandler;
+  let taskStore: TaskStore;
+  let mockExecutor: MockAgentExecutor;
+  let eventBusManager: DefaultExecutionEventBusManager;
+
+  const agentCard: AgentCard = {
+    name: 'Streaming Errors Agent',
+    description: 'Test agent for streaming-error synthesis assertions',
+    version: '1.0.0',
+    provider: undefined,
+    documentationUrl: '',
+    supportedInterfaces: [
+      {
+        url: 'http://localhost/a2a',
+        protocolBinding: 'HTTP+JSON',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+    ],
+    capabilities: {
+      extensions: [],
+      streaming: true,
+      pushNotifications: false,
+    },
+    securitySchemes: {},
+    securityRequirements: [],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    signatures: [],
+  };
+
+  const serverContext = new ServerCallContext();
+
+  beforeEach(() => {
+    taskStore = new InMemoryTaskStore();
+    mockExecutor = new MockAgentExecutor();
+    eventBusManager = new DefaultExecutionEventBusManager();
+    handler = new DefaultRequestHandler(agentCard, taskStore, mockExecutor, eventBusManager);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeMessage = (id: string, text: string, overrides: Partial<Message> = {}): Message => ({
+    messageId: id,
+    role: Role.ROLE_USER,
+    parts: [
+      {
+        content: { $case: 'text', value: text },
+        mediaType: 'text/plain',
+        filename: '',
+        metadata: undefined,
+      },
+    ],
+    taskId: '',
+    contextId: '',
+    extensions: [],
+    metadata: {},
+    referenceTaskIds: [],
+    ...overrides,
+  });
+
+  it('executor throws before any Task event: stream yields synthetic Task + statusUpdate(FAILED), not empty', async () => {
+    // This is the core regression test for PR 2's streaming half:
+    // previously the SSE consumer saw an empty stream, making
+    // production debugging impossible. Now the consumer sees a
+    // well-formed task-lifecycle terminating in FAILED.
+    let observedRequestTaskId = '';
+    const errorMessage = 'pre-publish failure in streaming executor';
+    mockExecutor.execute.mockImplementation(async (ctx) => {
+      observedRequestTaskId = ctx.taskId;
+      throw new Error(errorMessage);
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-stream-err-1', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const events: StreamResponse[] = [];
+    for await (const event of handler.sendMessageStream(params, serverContext)) {
+      events.push(event);
+    }
+
+    // Two events: synthetic Task followed by terminal status update.
+    expect(events.length).toBe(2);
+
+    // First event: synthetic Task carrying the FAILED state, keyed by
+    // `requestContext.taskId` — the same id the bus is registered
+    // under and that the client would use for a subsequent
+    // `tasks/resubscribe` or `getTask`.
+    const taskPayload = events[0].payload as { $case: 'task'; value: Task };
+    expect(taskPayload.$case).toBe('task');
+    expect(taskPayload.value.id).toBe(observedRequestTaskId);
+    expect(taskPayload.value.status?.state).toBe(TaskState.TASK_STATE_FAILED);
+
+    // Second event: statusUpdate(FAILED) referencing the same task id.
+    const statusPayload = events[1].payload as {
+      $case: 'statusUpdate';
+      value: TaskStatusUpdateEvent;
+    };
+    expect(statusPayload.$case).toBe('statusUpdate');
+    expect(statusPayload.value.taskId).toBe(observedRequestTaskId);
+    expect(statusPayload.value.status?.state).toBe(TaskState.TASK_STATE_FAILED);
+    expect(
+      (statusPayload.value.status?.message?.parts[0].content as { $case: 'text'; value: string })
+        .value
+    ).toContain(errorMessage);
+  });
+
+  it('synthetic Task is reachable via taskStore after the stream closes', async () => {
+    // The Task event is drained through ResultManager into the store
+    // exactly the same way a real executor-published Task would be, so
+    // the FAILED state is queryable via getTask afterward.
+    const errorMessage = 'reachable after failure';
+    mockExecutor.execute.mockRejectedValue(new Error(errorMessage));
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-stream-err-2', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const events: StreamResponse[] = [];
+    for await (const event of handler.sendMessageStream(params, serverContext)) {
+      events.push(event);
+    }
+
+    const taskPayload = events[0].payload as { $case: 'task'; value: Task };
+    const taskId = taskPayload.value.id;
+
+    const stored = await taskStore.load(taskId, serverContext);
+    expect(stored).toBeDefined();
+    expect(stored!.id).toBe(taskId);
+    expect(stored!.status?.state).toBe(TaskState.TASK_STATE_FAILED);
+  });
+
+  it('synthetic Task includes the original user message in history', async () => {
+    // The stream-error synthesis appends the originating user message
+    // to the Task's history so the failed task is self-describing —
+    // matches the blocking-path synthesis in `_runExecutor`.
+    mockExecutor.execute.mockRejectedValue(new Error('boom'));
+
+    const userMessage = makeMessage('msg-stream-err-3', 'tell me a joke');
+    const params: SendMessageRequest = {
+      message: userMessage,
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const events: StreamResponse[] = [];
+    for await (const event of handler.sendMessageStream(params, serverContext)) {
+      events.push(event);
+    }
+
+    const taskPayload = events[0].payload as { $case: 'task'; value: Task };
+    expect(
+      taskPayload.value.history?.find((m) => m.messageId === userMessage.messageId)
+    ).toBeDefined();
+  });
+
+  it('executor publishes Task then throws: stream yields the original Task + a synthetic FAILED statusUpdate (no duplicate Task)', async () => {
+    // Pre-existing behaviour preserved: when the executor has already
+    // published a Task event, we must NOT publish a second Task event
+    // in the error path (would violate stream-pattern ordering); only
+    // a statusUpdate(FAILED) is appended.
+    const errorMessage = 'post-publish failure';
+    let observedRequestTaskId = '';
+    let observedContextId = '';
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+      observedRequestTaskId = ctx.taskId;
+      observedContextId = ctx.contextId;
+      bus.publish(
+        AgentEvent.task({
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        })
+      );
+      throw new Error(errorMessage);
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-stream-err-4', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const events: StreamResponse[] = [];
+    for await (const event of handler.sendMessageStream(params, serverContext)) {
+      events.push(event);
+    }
+
+    expect(events.length).toBe(2);
+
+    const firstTask = events[0].payload as { $case: 'task'; value: Task };
+    expect(firstTask.$case).toBe('task');
+    expect(firstTask.value.id).toBe(observedRequestTaskId);
+    // The first Task event was the SUBMITTED one published by the
+    // executor before it threw — not a second synthetic FAILED Task.
+    expect(firstTask.value.status?.state).toBe(TaskState.TASK_STATE_SUBMITTED);
+
+    const failed = events[1].payload as { $case: 'statusUpdate'; value: TaskStatusUpdateEvent };
+    expect(failed.$case).toBe('statusUpdate');
+    expect(failed.value.taskId).toBe(observedRequestTaskId);
+    expect(failed.value.contextId).toBe(observedContextId);
+    expect(failed.value.status?.state).toBe(TaskState.TASK_STATE_FAILED);
+    expect(
+      (failed.value.status?.message?.parts[0].content as { $case: 'text'; value: string }).value
+    ).toContain(errorMessage);
+  });
+
+  it('synthetic Task uses the explicit taskId the client supplied on the incoming message', async () => {
+    // When the client targets an existing non-terminal task and the
+    // executor blows up before publishing, the synthetic Task must use
+    // the client-supplied id — same contract as the blocking path.
+    const existingTaskId = 'client-supplied-stream-task-id';
+    const existingContextId = 'client-supplied-stream-context-id';
+    await taskStore.save(
+      {
+        id: existingTaskId,
+        contextId: existingContextId,
+        status: {
+          state: TaskState.TASK_STATE_INPUT_REQUIRED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      },
+      serverContext
+    );
+
+    mockExecutor.execute.mockRejectedValue(new Error('stream boom on existing task'));
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-stream-err-5', 'continue', {
+        taskId: existingTaskId,
+        contextId: existingContextId,
+      }),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const events: StreamResponse[] = [];
+    for await (const event of handler.sendMessageStream(params, serverContext)) {
+      events.push(event);
+    }
+
+    expect(events.length).toBe(2);
+    const taskPayload = events[0].payload as { $case: 'task'; value: Task };
+    expect(taskPayload.value.id).toBe(existingTaskId);
+    expect(taskPayload.value.status?.state).toBe(TaskState.TASK_STATE_FAILED);
+
+    const statusPayload = events[1].payload as {
+      $case: 'statusUpdate';
+      value: TaskStatusUpdateEvent;
+    };
+    expect(statusPayload.value.taskId).toBe(existingTaskId);
+  });
+
+  it('event bus is cleaned up after the stream-error path runs', async () => {
+    // FAILED is a terminal state, so `_settleBus` must close the bus
+    // and detach it from the manager. Otherwise long-lived listeners
+    // (e.g. `trackLatestTaskState`) would leak on each failure.
+    let observedRequestTaskId = '';
+    mockExecutor.execute.mockImplementation(async (ctx) => {
+      observedRequestTaskId = ctx.taskId;
+      throw new Error('settle after error');
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-stream-err-6', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    for await (const _event of handler.sendMessageStream(params, serverContext)) {
+      void _event;
+    }
+
+    // Give `.finally()` a tick to call `_settleBus`.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(eventBusManager.getByTaskId(observedRequestTaskId)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
# Description

## What

Two coordinated fixes to the executor error path, both rooted in not using
`requestContext.taskId` for the synthetic error Task:

- Blocking `_runExecutor`: synthetic Task id is `requestContext.taskId`
  (was `requestContext.task?.id || uuidv4()`).
- Streaming `_runStreamExecutor`: when the executor throws before publishing
  any Task event, synthesize Task + statusUpdate(FAILED) instead of silently
  closing the stream.

## Why

- Blocking: the fabricated UUID didn't match the event bus registration key,
  so `getTask(id)` with the returned id raised TaskNotFoundError. The client
  had no way to learn the task failed.
- Streaming: silent empty stream is asymmetric with the blocking path (which
  always synthesizes the error Task) and makes production debugging impossible.

Closes #533 
