### PR TITLE
fix(server): propagate return to SSE generators to prevent listener leaks

### DIFF
--- a/src/compat/v0_3/server/express/rest_handler.ts
+++ b/src/compat/v0_3/server/express/rest_handler.ts
@@ -357,13 +357,6 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
       if (!firstResult.done) {
         res.write(formatSSEEvent(encodeStreamEvent(firstResult.value)));
       }
-      // Delegate through `delegateAsyncIterator` so `.return()` is
-      // explicitly forwarded to the underlying generator on disposal —
-      // the inline `{ [Symbol.asyncIterator]: () => iterator }` wrapper
-      // relies on host-engine `for await` semantics for that cleanup,
-      // which is unreliable across runtimes. Without explicit
-      // propagation the generator's `finally` (event-bus listener
-      // cleanup, queue stop) may not run, leaking listeners.
       for await (const event of delegateAsyncIterator(iterator)) {
         res.write(formatSSEEvent(encodeStreamEvent(event)));
       }

--- a/src/compat/v0_3/server/express/rest_handler.ts
+++ b/src/compat/v0_3/server/express/rest_handler.ts
@@ -25,7 +25,7 @@ import express, {
 import { A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER } from '../../../../constants.js';
 import { Extensions } from '../../../../extensions.js';
 import { ServerCallContext } from '../../../../server/context.js';
-import { UserBuilder } from '../../../../server/express/common.js';
+import { UserBuilder, delegateAsyncIterator } from '../../../../server/express/common.js';
 import { type A2ARequestHandler } from '../../../../server/request_handler/a2a_request_handler.js';
 import { SSE_HEADERS, formatSSEEvent, formatSSEErrorEvent } from '../../../../sse_utils.js';
 import { validateVersion } from '../../../../server/version.js';
@@ -357,7 +357,14 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
       if (!firstResult.done) {
         res.write(formatSSEEvent(encodeStreamEvent(firstResult.value)));
       }
-      for await (const event of { [Symbol.asyncIterator]: () => iterator }) {
+      // Delegate through `delegateAsyncIterator` so `.return()` is
+      // explicitly forwarded to the underlying generator on disposal —
+      // the inline `{ [Symbol.asyncIterator]: () => iterator }` wrapper
+      // relies on host-engine `for await` semantics for that cleanup,
+      // which is unreliable across runtimes. Without explicit
+      // propagation the generator's `finally` (event-bus listener
+      // cleanup, queue stop) may not run, leaking listeners.
+      for await (const event of delegateAsyncIterator(iterator)) {
         res.write(formatSSEEvent(encodeStreamEvent(event)));
       }
     } catch (streamError: unknown) {

--- a/src/server/express/common.ts
+++ b/src/server/express/common.ts
@@ -38,6 +38,15 @@ export const UserBuilder = {
  * of how the consumer exits the loop, on every runtime that hosts
  * standard `async function*` semantics.
  *
+ * Notably, `it.return()` is NOT called when `it.next()` itself
+ * rejects: per the iterator protocol an iterator that throws from
+ * `next()` is already considered closed, and calling `return()` on
+ * such an iterator may either be a no-op or throw a secondary error
+ * that would mask the original. This matches the host language's
+ * `for await … of` semantics, which only invoke
+ * `IfAbruptCloseAsyncIterator` when the loop body completes abruptly,
+ * not when `IteratorStep` itself throws.
+ *
  * Mirror of the client-side `readFrom` helper in `sse_utils.ts`,
  * which applies the same try/finally shape around
  * `ReadableStreamDefaultReader.releaseLock()`.
@@ -47,13 +56,28 @@ export const UserBuilder = {
  * @yields Values produced by the underlying iterator until it's done.
  */
 export async function* delegateAsyncIterator<T>(it: AsyncIterator<T>): AsyncGenerator<T> {
+  // Track whether the producer (`it.next()`) threw. If it did, the
+  // iterator is already closed per the iterator protocol and calling
+  // `it.return()` would either no-op or surface a secondary error that
+  // masks the original. Only invoke `it.return()` for consumer-side
+  // abrupt completion (`break` / `throw` / `return` inside `for await`),
+  // mirroring `IfAbruptCloseAsyncIterator` in the ECMAScript spec.
+  let nextThrew = false;
   try {
     while (true) {
-      const { value, done } = await it.next();
-      if (done) return;
-      yield value;
+      let result: IteratorResult<T>;
+      try {
+        result = await it.next();
+      } catch (err) {
+        nextThrew = true;
+        throw err;
+      }
+      if (result.done) return;
+      yield result.value;
     }
   } finally {
-    await it.return?.();
+    if (!nextThrew) {
+      await it.return?.();
+    }
   }
 }

--- a/src/server/express/common.ts
+++ b/src/server/express/common.ts
@@ -6,3 +6,54 @@ export type UserBuilder = (req: Request) => Promise<User>;
 export const UserBuilder = {
   noAuthentication: () => Promise.resolve(new UnauthenticatedUser()),
 };
+
+/**
+ * Wraps an `AsyncIterator` in an `AsyncGenerator` that explicitly
+ * propagates `.return()` back to the underlying iterator when the
+ * generator is disposed (e.g. when the consuming `for await … of`
+ * loop is broken out of via `break`, `throw`, or an early `return`,
+ * or when the wrapping generator is itself garbage-collected).
+ *
+ * Replaces the naive inline wrapper
+ * `{ [Symbol.asyncIterator]: () => iterator }` that the three express
+ * SSE handlers used after pulling the first event eagerly to detect
+ * early errors. That wrapper has no `finally` of its own and relies
+ * entirely on the host engine's `for await` semantics to forward
+ * `.return()` to the underlying iterator. In practice that's fragile:
+ *   - Engine-dependent: works on modern V8 but varies across older
+ *     engines and non-V8 runtimes (Workers, Deno).
+ *   - No explicit cleanup site to instrument, log, or extend.
+ *   - When the wrapped generator is passed onward (rather than consumed
+ *     in-place) lifecycle boundaries can drop the `.return()` invocation
+ *     entirely.
+ *
+ * When `.return()` is dropped, the underlying agent execution
+ * generator's `finally` block never runs — leaking event-bus
+ * listeners and leaving the `ExecutionEventQueue` unstopped. In
+ * long-running production deployments this surfaces as unbounded
+ * memory growth and eventual OOM.
+ *
+ * This helper's own `finally` invokes `await it.return?.()` so the
+ * underlying generator's cleanup runs deterministically regardless
+ * of how the consumer exits the loop, on every runtime that hosts
+ * standard `async function*` semantics.
+ *
+ * Mirror of the client-side `readFrom` helper in `sse_utils.ts`,
+ * which applies the same try/finally shape around
+ * `ReadableStreamDefaultReader.releaseLock()`.
+ *
+ * @param it - The async iterator to delegate to (typically obtained via
+ *   `stream[Symbol.asyncIterator]()` after peeking the first event).
+ * @yields Values produced by the underlying iterator until it's done.
+ */
+export async function* delegateAsyncIterator<T>(it: AsyncIterator<T>): AsyncGenerator<T> {
+  try {
+    while (true) {
+      const { value, done } = await it.next();
+      if (done) return;
+      yield value;
+    }
+  } finally {
+    await it.return?.();
+  }
+}

--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -11,7 +11,7 @@ import { A2ARequestHandler } from '../request_handler/a2a_request_handler.js';
 import { JsonRpcTransportHandler } from '../transports/jsonrpc/jsonrpc_transport_handler.js';
 import { ServerCallContext } from '../context.js';
 import { A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER, JSON_CONTENT_TYPE } from '../../constants.js';
-import { UserBuilder } from './common.js';
+import { UserBuilder, delegateAsyncIterator } from './common.js';
 import { SSE_HEADERS, formatSSEEvent, formatSSEErrorEvent } from '../../sse_utils.js';
 import { Extensions } from '../../extensions.js';
 import { ContentTypeNotSupportedError, RequestMalformedError } from '../../errors.js';
@@ -167,7 +167,14 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
           if (!firstResult.done) {
             res.write(formatSSEEvent(firstResult.value));
           }
-          for await (const event of { [Symbol.asyncIterator]: () => iterator }) {
+          // Delegate through `delegateAsyncIterator` so `.return()` is
+          // explicitly forwarded to the underlying generator on disposal —
+          // the inline `{ [Symbol.asyncIterator]: () => iterator }` wrapper
+          // relies on host-engine `for await` semantics for that cleanup,
+          // which is unreliable across runtimes. Without explicit
+          // propagation the generator's `finally` (event-bus listener
+          // cleanup, queue stop) may not run, leaking listeners.
+          for await (const event of delegateAsyncIterator(iterator)) {
             res.write(formatSSEEvent(event));
           }
         } catch (streamError) {

--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -167,13 +167,6 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
           if (!firstResult.done) {
             res.write(formatSSEEvent(firstResult.value));
           }
-          // Delegate through `delegateAsyncIterator` so `.return()` is
-          // explicitly forwarded to the underlying generator on disposal —
-          // the inline `{ [Symbol.asyncIterator]: () => iterator }` wrapper
-          // relies on host-engine `for await` semantics for that cleanup,
-          // which is unreliable across runtimes. Without explicit
-          // propagation the generator's `finally` (event-bus listener
-          // cleanup, queue stop) may not run, leaking listeners.
           for await (const event of delegateAsyncIterator(iterator)) {
             res.write(formatSSEEvent(event));
           }

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -20,7 +20,7 @@ import {
   A2A_VERSION_HEADER,
   HTTP_EXTENSION_HEADER,
 } from '../../constants.js';
-import { UserBuilder } from './common.js';
+import { UserBuilder, delegateAsyncIterator } from './common.js';
 import { Extensions } from '../../extensions.js';
 import { validateVersion } from '../version.js';
 import { legacyRestRouter } from '../../compat/v0_3/server/express/index.js';
@@ -301,7 +301,14 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
         const result = StreamResponse.toJSON(firstResult.value);
         res.write(formatSSEEvent(result));
       }
-      for await (const event of { [Symbol.asyncIterator]: () => iterator }) {
+      // Delegate through `delegateAsyncIterator` so `.return()` is
+      // explicitly forwarded to the underlying generator on disposal —
+      // the inline `{ [Symbol.asyncIterator]: () => iterator }` wrapper
+      // relies on host-engine `for await` semantics for that cleanup,
+      // which is unreliable across runtimes. Without explicit
+      // propagation the generator's `finally` (event-bus listener
+      // cleanup, queue stop) may not run, leaking listeners.
+      for await (const event of delegateAsyncIterator(iterator)) {
         const result = StreamResponse.toJSON(event);
         res.write(formatSSEEvent(result));
       }

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -301,13 +301,6 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
         const result = StreamResponse.toJSON(firstResult.value);
         res.write(formatSSEEvent(result));
       }
-      // Delegate through `delegateAsyncIterator` so `.return()` is
-      // explicitly forwarded to the underlying generator on disposal —
-      // the inline `{ [Symbol.asyncIterator]: () => iterator }` wrapper
-      // relies on host-engine `for await` semantics for that cleanup,
-      // which is unreliable across runtimes. Without explicit
-      // propagation the generator's `finally` (event-bus listener
-      // cleanup, queue stop) may not run, leaking listeners.
       for await (const event of delegateAsyncIterator(iterator)) {
         const result = StreamResponse.toJSON(event);
         res.write(formatSSEEvent(result));

--- a/test/server/express/sse_cleanup.spec.ts
+++ b/test/server/express/sse_cleanup.spec.ts
@@ -219,6 +219,40 @@ describe('delegateAsyncIterator', () => {
     expect(returnCalls).toBe(1);
   });
 
+  it('does not call .return() and propagates the original error when .next() throws', async () => {
+    // Per the iterator protocol, an iterator that throws from `.next()`
+    // is already considered closed and `.return()` should NOT be
+    // invoked on it. Calling `.return()` in that case may either be a
+    // no-op or — if `.return()` itself throws — mask the original
+    // producer error. This matches ECMAScript's `for await … of`
+    // semantics: `IfAbruptCloseAsyncIterator` only fires for
+    // consumer-side abrupt completion, not when `IteratorStep`
+    // (i.e. `.next()`) itself errors.
+    let returnCalled = false;
+    const it: AsyncIterator<number> = {
+      next: async () => {
+        throw new Error('next error');
+      },
+      return: async () => {
+        returnCalled = true;
+        // Simulate a stream whose `.return()` ALSO throws on an
+        // already-errored handle (common pattern for streams that
+        // were torn down by the underlying error). If the helper
+        // mistakenly invokes `.return()`, this would mask the
+        // 'next error' the caller actually cares about.
+        throw new Error('return error');
+      },
+    };
+
+    await expect(async () => {
+      for await (const value of delegateAsyncIterator(it)) {
+        // unreachable — the underlying `.next()` throws immediately.
+        expect(value).toBeUndefined();
+      }
+    }).rejects.toThrow('next error');
+    expect(returnCalled).toBe(false);
+  });
+
   it('mirrors the readFrom shape from src/sse_utils.ts (client-side fix)', async () => {
     // Documents the symmetry with the client-side helper that motivated
     // this PR. `sse_utils.ts:178-191` wraps `ReadableStreamDefaultReader`

--- a/test/server/express/sse_cleanup.spec.ts
+++ b/test/server/express/sse_cleanup.spec.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest';
+
+import { delegateAsyncIterator } from '../../../src/server/express/common.js';
+
+/**
+ * Tests for `delegateAsyncIterator` — the SSE-cleanup helper used by
+ * the three express SSE response paths
+ * (`server/express/rest_handler.ts`, `server/express/json_rpc_handler.ts`,
+ * and `compat/v0_3/server/express/rest_handler.ts`).
+ *
+ * Before this fix, those three handlers wrapped a peeked iterator in
+ * `{ [Symbol.asyncIterator]: () => iterator }` so they could resume
+ * the `for await` loop AFTER pulling the first event eagerly. That
+ * inline wrapper does not run any cleanup of its own — its lifecycle
+ * is fully fused with whatever the underlying iterator does. In the
+ * happy path (consumer iterates to completion) modern V8 engines DO
+ * still propagate `.return()` from the outer `for await`, but the
+ * pattern is fragile:
+ *   - It relies on host-engine `for await` semantics (older engines and
+ *     non-V8 runtimes — Workers, Deno — vary).
+ *   - There is no explicit cleanup site to instrument or extend.
+ *   - When the underlying iterator is "rebuilt" (peek-first then
+ *     re-iterate) the engine has no view of the original generator's
+ *     lifecycle and cannot guarantee `.return()` invocation on the
+ *     boundary.
+ *
+ * `delegateAsyncIterator` replaces the inline wrapper with a real
+ * `async function*` that explicitly calls `await it.return?.()` in
+ * its own `finally`. This guarantees the underlying generator's
+ * `finally` block (which detaches event-bus listeners and stops the
+ * `ExecutionEventQueue`) runs whenever the wrapping generator is
+ * disposed — by `break`, exception, GC, or natural completion.
+ *
+ * Mirror of the client-side `readFrom` helper in `src/sse_utils.ts:178-191`,
+ * which uses the same try/finally shape around `reader.releaseLock()`.
+ */
+describe('delegateAsyncIterator', () => {
+  it('yields every value produced by the underlying iterator in order', async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+
+    const collected: number[] = [];
+    for await (const value of delegateAsyncIterator(source()[Symbol.asyncIterator]())) {
+      collected.push(value);
+    }
+    expect(collected).toEqual([1, 2, 3]);
+  });
+
+  it('runs the underlying generator finally exactly once on natural completion', async () => {
+    let finallyRan = 0;
+    async function* source() {
+      try {
+        yield 1;
+      } finally {
+        finallyRan += 1;
+      }
+    }
+
+    for await (const value of delegateAsyncIterator(source()[Symbol.asyncIterator]())) {
+      // consume all — `value` reads suppress the unused-binding lint.
+      expect(value).toBe(1);
+    }
+    expect(finallyRan).toBe(1);
+  });
+
+  it('propagates .return() to the underlying iterator on early break', async () => {
+    // THE PRIMARY FIX BEHAVIOUR. With the new helper, breaking out of
+    // the consuming `for await` loop early MUST run the underlying
+    // generator's `finally` so listeners attached on the event bus
+    // (and the `ExecutionEventQueue` stop hook) are released.
+    let finallyRan = 0;
+    async function* source() {
+      try {
+        yield 1;
+        yield 2;
+        yield 3;
+      } finally {
+        finallyRan += 1;
+      }
+    }
+
+    for await (const value of delegateAsyncIterator(source()[Symbol.asyncIterator]())) {
+      if (value === 1) break;
+    }
+    expect(finallyRan).toBe(1);
+  });
+
+  it('propagates .return() to the underlying iterator when consumer throws', async () => {
+    let finallyRan = 0;
+    async function* source() {
+      try {
+        yield 1;
+        yield 2;
+      } finally {
+        finallyRan += 1;
+      }
+    }
+
+    await expect(async () => {
+      for await (const value of delegateAsyncIterator(source()[Symbol.asyncIterator]())) {
+        // Consume the first value, then throw on the very next iteration.
+        if (value === 1) throw new Error('consumer error');
+      }
+    }).rejects.toThrow('consumer error');
+    expect(finallyRan).toBe(1);
+  });
+
+  it('explicitly calls .return() on the wrapped iterator when disposed early', async () => {
+    // Pinning the contract: `delegateAsyncIterator`'s own `finally` MUST
+    // invoke `.return()` on the wrapped iterator, not just hope the host
+    // engine does. We verify by spying on `.return()` directly.
+    let nextCalls = 0;
+    let returnCalls = 0;
+    const it: AsyncIterator<number> = {
+      next: async () => {
+        nextCalls += 1;
+        return { value: nextCalls, done: false };
+      },
+      return: async () => {
+        returnCalls += 1;
+        return { value: undefined, done: true };
+      },
+    };
+
+    for await (const value of delegateAsyncIterator(it)) {
+      if (value >= 2) break;
+    }
+
+    expect(nextCalls).toBeGreaterThanOrEqual(2);
+    expect(returnCalls).toBe(1);
+  });
+
+  it('explicitly calls .return() on the wrapped iterator on natural completion', async () => {
+    // Even on natural exhaustion of the underlying iterator, the helper
+    // calls `.return?.()` from its `finally`. This is the
+    // "happy path" cleanup — important when the underlying iterator
+    // holds external resources (file handles, locks, listener
+    // subscriptions) that need explicit release.
+    let returnCalls = 0;
+    let index = 0;
+    const values = [10, 20, 30];
+    const it: AsyncIterator<number> = {
+      next: async () => {
+        if (index >= values.length) {
+          return { value: undefined, done: true };
+        }
+        return { value: values[index++], done: false };
+      },
+      return: async () => {
+        returnCalls += 1;
+        return { value: undefined, done: true };
+      },
+    };
+
+    const seen: number[] = [];
+    for await (const value of delegateAsyncIterator(it)) {
+      seen.push(value);
+    }
+    expect(seen).toEqual(values);
+    expect(returnCalls).toBe(1);
+  });
+
+  it('handles iterators that have no .return() method gracefully (no throw)', async () => {
+    // `it.return?.()` must NOT throw when the underlying iterator
+    // doesn't implement `return`. Many hand-rolled `AsyncIterator`
+    // objects (e.g. cursor-based DB streams) omit it.
+    const values = [10, 20, 30];
+    let index = 0;
+    const it: AsyncIterator<number> = {
+      next: async () => {
+        if (index >= values.length) {
+          return { value: undefined, done: true };
+        }
+        return { value: values[index++], done: false };
+      },
+      // no `return` method
+    };
+
+    const collected: number[] = [];
+    for await (const value of delegateAsyncIterator(it)) {
+      collected.push(value);
+      if (value === 20) break;
+    }
+    expect(collected).toEqual([10, 20]);
+  });
+
+  it('does not double-call .return() when the iterator is naturally done', async () => {
+    // If the underlying iterator signals `done: true`, the helper
+    // returns from the loop and then enters its `finally` which calls
+    // `.return?.()` once. That's the documented contract; we don't
+    // try to suppress the `return` call after natural completion
+    // because (a) it's spec-compliant (`return()` on an exhausted
+    // iterator is a no-op per ES spec) and (b) iterator authors
+    // already handle the case.
+    let returnCalls = 0;
+    let index = 0;
+    const it: AsyncIterator<number> = {
+      next: async () => {
+        if (index >= 1) return { value: undefined, done: true };
+        index += 1;
+        return { value: index, done: false };
+      },
+      return: async () => {
+        returnCalls += 1;
+        return { value: undefined, done: true };
+      },
+    };
+
+    let lastValue: number | undefined;
+    for await (const value of delegateAsyncIterator(it)) {
+      lastValue = value;
+    }
+    expect(lastValue).toBe(1);
+    // Exactly one call from the `finally`; the wrapper does not call
+    // it during the `done: true` branch.
+    expect(returnCalls).toBe(1);
+  });
+
+  it('mirrors the readFrom shape from src/sse_utils.ts (client-side fix)', async () => {
+    // Documents the symmetry with the client-side helper that motivated
+    // this PR. `sse_utils.ts:178-191` wraps `ReadableStreamDefaultReader`
+    // in a generator that runs `reader.releaseLock()` in its `finally`.
+    // `delegateAsyncIterator` is the server-side equivalent for
+    // `AsyncIterator<T>`, running `it.return?.()` in its `finally`.
+    //
+    // Both achieve the same goal: bridge a non-generator stream-like
+    // object into the `async function*` lifecycle so the host engine's
+    // `for await` cleanup hooks (and explicit `break`/`throw`) trigger
+    // resource release deterministically.
+    let cleanups = 0;
+    const it: AsyncIterator<number> = {
+      next: async () => ({ value: 1, done: false }),
+      return: async () => {
+        cleanups += 1;
+        return { value: undefined, done: true };
+      },
+    };
+
+    for await (const value of delegateAsyncIterator(it)) {
+      expect(value).toBe(1);
+      break;
+    }
+    expect(cleanups).toBe(1);
+  });
+});


### PR DESCRIPTION
# Description

## What

New `delegateAsyncIterator` helper in `server/express/common.ts` that forwards
`.return()` to wrapped async iterators. Replaces 3 inline wrappers that didn't.

## Why

The inline `{ [Symbol.asyncIterator]: () => iterator }` doesn't forward
`.return()`. When Express breaks the `for await` loop on client disconnect,
the underlying generator's `finally` block never runs — leaking event bus
listeners and unstopped queues. OOM in long-running production deployments.

Mirror of the client-side fix `sse_utils.ts:178-191`.

Closes #534 
