### PR TITLE
fix(server/rest): handle undefined historyLength to return full task history

### DIFF
--- a/src/server/transports/rest/rest_transport_handler.ts
+++ b/src/server/transports/rest/rest_transport_handler.ts
@@ -213,7 +213,7 @@ export class RestTransportHandler {
     historyLength?: unknown,
     tenant?: string
   ): Promise<Task> {
-    const params: GetTaskRequest = { id: taskId, historyLength: 0, tenant: tenant || '' };
+    const params: GetTaskRequest = { id: taskId, tenant: tenant || '' };
     if (historyLength !== undefined) {
       params.historyLength = this.parseHistoryLength(historyLength);
     }

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -300,7 +300,7 @@ describe('restHandler', () => {
       // Status state is enum string
       assert.deepEqual(response.body.status.state, 'TASK_STATE_COMPLETED');
       expect(mockRequestHandler.getTask as Mock).toHaveBeenCalledWith(
-        { id: 'task-1', tenant: '', historyLength: 0 },
+        { id: 'task-1', tenant: '' },
         expect.anything()
       );
     });

--- a/test/server/rest_transport_handler.spec.ts
+++ b/test/server/rest_transport_handler.spec.ts
@@ -248,7 +248,7 @@ describe('RestTransportHandler', () => {
 
       expect(result).to.deep.equal(testTask);
       expect(mockRequestHandler.getTask as Mock).toHaveBeenCalledWith(
-        { id: 'task-1', historyLength: 0, tenant: '' },
+        { id: 'task-1', tenant: '' },
         mockContext
       );
     });


### PR DESCRIPTION
# Description

## What

REST `getTask` no longer defaults `historyLength: 0`. The field is omitted
when the client doesn't provide the query parameter, matching JSON-RPC and gRPC
bindings.

## Why

Spec §3.2.4: "Unset/undefined: No limit imposed; server returns its default
amount of history. 0: No history should be returned." JS REST diverged by
defaulting to 0, so `GET /tasks/{id}` without `?historyLength=N` returned an
empty history.

Closes #535 