### PR TITLE
fix(compat): wrap primitive Part.data values instead of throwing

### DIFF
--- a/src/compat/v0_3/translate/parts.ts
+++ b/src/compat/v0_3/translate/parts.ts
@@ -16,12 +16,19 @@
  * **Data parts.** v1.0 `Part.data` is a `google.protobuf.Value`, so it can
  * carry primitives, arrays, and `null` in addition to objects. v0.3
  * `DataPart.data` is typed `{ [k: string]: unknown }` — strictly a JSON
- * object. v1.0 data parts whose `value` is a primitive, array, or `null`
- * therefore cannot be represented in v0.3 and throw `A2AError.invalidParams`
- * during `toCompatPart`. (The Python SDK wraps such values as
- * `{ value: <primitive> }` with a private `data_part_compat = true`
- * metadata flag, but that pollutes the v0.3 wire format with an out-of-spec
- * key; we deliberately diverge from Python here.)
+ * object. To round-trip the wider v1.0 set through the narrower v0.3
+ * schema, `toCompatPart` wraps primitive / array / `null` values as
+ * `{ value: <original> }` and tags the v0.3 part with a
+ * `metadata.dataPartCompat = true` flag. `toCorePart` looks for the same
+ * flag and unwraps `data.value` back to the original primitive, stripping
+ * the flag from the resulting v1.0 metadata. This mirrors the convention
+ * used by `a2a-python` (`compat/v0_3/conversions.py`) and `a2a-go`
+ * (`a2acompat/a2av0/conversions.go`).
+ *
+ * Values that are neither plain objects nor wrap-eligible primitives
+ * (`Symbol`, `function`, `bigint`, `undefined`, `Buffer`) still throw
+ * `A2AError.invalidParams` from `toCompatPart`: the wrapper itself would
+ * not survive serialization.
  */
 
 import { A2AError } from '../server/error.js';
@@ -29,10 +36,35 @@ import type * as legacy from '../types/types.js';
 import type { Part as V1Part } from '../../../types/pb/a2a.js';
 import { deepCloneMetadata } from './_clone.js';
 
+/**
+ * Metadata key set on v0.3 `DataPart`s whose `data` field carries a
+ * `{ value: <primitive|array|null> }` wrapper synthesized by
+ * `toCompatPart`. `toCorePart` strips both the wrapper and this flag.
+ *
+ * The key name matches the one used by `a2a-python` (lower-snake-cased to
+ * `data_part_compat` on the wire by Python's serializer) and `a2a-go`.
+ */
+const DATA_PART_COMPAT_FLAG = 'dataPartCompat';
+
 function isPlainObject(value: unknown): value is { [k: string]: unknown } {
   return (
     typeof value === 'object' && value !== null && !Array.isArray(value) && !Buffer.isBuffer(value)
   );
+}
+
+/**
+ * True for v1.0 `Part.data` values that are valid `google.protobuf.Value`s
+ * but cannot live directly under v0.3 `DataPart.data: { [k]: unknown }`
+ * (which only admits JSON objects). These are the values `toCompatPart`
+ * wraps as `{ value: <original> }` with the `dataPartCompat` flag.
+ */
+function isCompatWrappableDataValue(
+  value: unknown
+): value is string | number | boolean | null | unknown[] {
+  if (value === null) return true;
+  if (Array.isArray(value)) return true;
+  const t = typeof value;
+  return t === 'string' || t === 'number' || t === 'boolean';
 }
 
 /**
@@ -43,9 +75,13 @@ function isPlainObject(value: unknown): value is { [k: string]: unknown } {
  *   the base64 payload into a `Buffer`); `FileWithUri` → `content.$case:
  *   'url'`. The optional `mimeType` / `name` are lifted to the top-level
  *   `mediaType` / `filename` fields.
- * - Data parts pass `data` through unchanged (v0.3 schema guarantees
- *   `data` is a plain object, which is always valid for the v1.0
- *   `google.protobuf.Value` target).
+ * - Data parts pass `data` through unchanged, except when
+ *   `metadata.dataPartCompat === true` and `data` has the shape
+ *   `{ value: <primitive|array|null> }`. In that case the wrapper is
+ *   stripped, `data.value` becomes the v1.0 `content.value` directly, and
+ *   the `dataPartCompat` flag is removed from the resulting metadata
+ *   (with `metadata` itself omitted if no other keys remain). This
+ *   reverses the wrapping done by `toCompatPart`.
  */
 export function toCorePart(compatPart: legacy.Part): V1Part {
   if (compatPart.kind === 'text') {
@@ -83,9 +119,27 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
   }
 
   if (compatPart.kind === 'data') {
+    const metadata = deepCloneMetadata(compatPart.metadata);
+    let value: unknown = compatPart.data;
+    let outMetadata = metadata;
+
+    // Reverse the `{ value: <primitive> }` wrap added by `toCompatPart`
+    // when the source v1 value was a primitive/array/null. The flag is
+    // the load-bearing signal — without it we cannot distinguish a
+    // genuine `{ value: ... }` object from a synthesized wrapper.
+    if (metadata?.[DATA_PART_COMPAT_FLAG] === true) {
+      if (isPlainObject(compatPart.data) && 'value' in compatPart.data) {
+        value = compatPart.data.value;
+      }
+      delete metadata[DATA_PART_COMPAT_FLAG];
+      // Drop the metadata object entirely if the flag was its only key,
+      // so a round-trip from a primitive v1 value yields no metadata.
+      outMetadata = Object.keys(metadata).length > 0 ? metadata : undefined;
+    }
+
     return {
-      content: { $case: 'data', value: compatPart.data },
-      metadata: deepCloneMetadata(compatPart.metadata),
+      content: { $case: 'data', value },
+      metadata: outMetadata,
       filename: '',
       mediaType: '',
     };
@@ -105,12 +159,18 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
  *   `FileWithUri`. `filename` / `mediaType` are pushed down into the
  *   inner file's `name` / `mimeType`.
  * - `content.$case: 'data'`: when the v1.0 value is a plain object it is
- *   used directly. Throws `A2AError.invalidParams` when the value is a
- *   primitive, array, or `null` — those are not representable in v0.3's
- *   `DataPart.data: { [k: string]: unknown }` schema.
+ *   used directly. When the value is a primitive (string, number,
+ *   boolean), an array, or `null`, it is wrapped as `{ value: <original> }`
+ *   and `metadata.dataPartCompat: true` is set on the resulting v0.3 part
+ *   so `toCorePart` can unwrap it losslessly. Throws
+ *   `A2AError.invalidParams` only when the value is neither a plain
+ *   object nor a wrap-eligible primitive — i.e., `Symbol`, `function`,
+ *   `bigint`, `undefined`, or `Buffer` — for which even the
+ *   `{ value: ... }` wrapper could not survive JSON serialization.
  *
  * @throws {A2AError} when `content` is missing, has an unknown `$case`,
- * or carries a non-object `data` value.
+ * or carries a `data` value that is neither a plain object nor a
+ * wrap-eligible primitive / array / null.
  */
 export function toCompatPart(corePart: V1Part): legacy.Part {
   const content = corePart.content;
@@ -153,15 +213,33 @@ export function toCompatPart(corePart: V1Part): legacy.Part {
 
   if (content.$case === 'data') {
     const value: unknown = content.value;
-    if (!isPlainObject(value)) {
-      throw A2AError.invalidParams(
-        'Cannot translate v1 data part to v0.3: value is not a plain object. ' +
-          'v0.3 DataPart.data requires { [k: string]: unknown }; primitives, arrays, and null are not representable.'
-      );
+
+    if (isPlainObject(value)) {
+      const result: legacy.DataPart = { kind: 'data', data: value };
+      if (metadata !== undefined) result.metadata = metadata;
+      return result;
     }
-    const result: legacy.DataPart = { kind: 'data', data: value };
-    if (metadata !== undefined) result.metadata = metadata;
-    return result;
+
+    if (isCompatWrappableDataValue(value)) {
+      // Wrap the primitive / array / null in `{ value: <original> }` and
+      // tag the v0.3 part so `toCorePart` can losslessly unwrap. The
+      // wrapped reference is passed through as-is (no defensive clone),
+      // matching the plain-object branch above and the metadata-cloning
+      // policy already documented for this file.
+      const data: { [k: string]: unknown } = { value };
+      const outMetadata: { [k: string]: unknown } = metadata ?? {};
+      outMetadata[DATA_PART_COMPAT_FLAG] = true;
+      const result: legacy.DataPart = { kind: 'data', data, metadata: outMetadata };
+      return result;
+    }
+
+    throw A2AError.invalidParams(
+      'Cannot translate v1 data part to v0.3: value is neither a plain object ' +
+        'nor a wrap-eligible primitive / array / null ' +
+        '(e.g., Symbol, function, bigint, undefined, Buffer). ' +
+        'Primitives, arrays, and null are wrapped as { value: ... } with dataPartCompat=true; ' +
+        'all other non-plain-object values are rejected.'
+    );
   }
 
   throw A2AError.invalidParams(

--- a/src/compat/v0_3/translate/parts.ts
+++ b/src/compat/v0_3/translate/parts.ts
@@ -19,11 +19,12 @@
  * object. To round-trip the wider v1.0 set through the narrower v0.3
  * schema, `toCompatPart` wraps primitive / array / `null` values as
  * `{ value: <original> }` and tags the v0.3 part with a
- * `metadata.dataPartCompat = true` flag. `toCorePart` looks for the same
- * flag and unwraps `data.value` back to the original primitive, stripping
- * the flag from the resulting v1.0 metadata. This mirrors the convention
- * used by `a2a-python` (`compat/v0_3/conversions.py`) and `a2a-go`
- * (`a2acompat/a2av0/conversions.go`).
+ * `metadata.data_part_compat = true` flag. The key is snake_case to
+ * match `a2a-python` (`compat/v0_3/conversions.py:46, :96`) and `a2a-go`
+ * (`a2acompat/a2av0/conversions.go:333-336, :385`) byte-for-byte on the
+ * wire, so cross-SDK peers recognize the wrapper. `toCorePart` looks for
+ * the same flag and unwraps `data.value` back to the original primitive,
+ * stripping the flag from the resulting v1.0 metadata.
  *
  * Values that are neither plain objects nor wrap-eligible primitives
  * (`Symbol`, `function`, `bigint`, `undefined`, `Buffer`) still throw
@@ -37,14 +38,12 @@ import type { Part as V1Part } from '../../../types/pb/a2a.js';
 import { deepCloneMetadata } from './_clone.js';
 
 /**
- * Metadata key set on v0.3 `DataPart`s whose `data` field carries a
+ * Metadata key emitted on v0.3 `DataPart`s whose `data` field carries a
  * `{ value: <primitive|array|null> }` wrapper synthesized by
- * `toCompatPart`. `toCorePart` strips both the wrapper and this flag.
- *
- * The key name matches the one used by `a2a-python` (lower-snake-cased to
- * `data_part_compat` on the wire by Python's serializer) and `a2a-go`.
+ * `toCompatPart`. Wire format is snake_case to match `a2a-python` and
+ * `a2a-go` byte-for-byte, so peers across SDKs recognize the wrapper.
  */
-const DATA_PART_COMPAT_FLAG = 'dataPartCompat';
+const DATA_PART_COMPAT_FLAG = 'data_part_compat';
 
 function isPlainObject(value: unknown): value is { [k: string]: unknown } {
   return (
@@ -56,7 +55,7 @@ function isPlainObject(value: unknown): value is { [k: string]: unknown } {
  * True for v1.0 `Part.data` values that are valid `google.protobuf.Value`s
  * but cannot live directly under v0.3 `DataPart.data: { [k]: unknown }`
  * (which only admits JSON objects). These are the values `toCompatPart`
- * wraps as `{ value: <original> }` with the `dataPartCompat` flag.
+ * wraps as `{ value: <original> }` with the `data_part_compat` flag.
  */
 function isCompatWrappableDataValue(
   value: unknown
@@ -76,12 +75,13 @@ function isCompatWrappableDataValue(
  *   'url'`. The optional `mimeType` / `name` are lifted to the top-level
  *   `mediaType` / `filename` fields.
  * - Data parts pass `data` through unchanged, except when
- *   `metadata.dataPartCompat === true` and `data` has the shape
+ *   `metadata.data_part_compat === true` and `data` has the shape
  *   `{ value: <primitive|array|null> }`. In that case the wrapper is
  *   stripped, `data.value` becomes the v1.0 `content.value` directly, and
- *   the `dataPartCompat` flag is removed from the resulting metadata
- *   (with `metadata` itself omitted if no other keys remain). This
- *   reverses the wrapping done by `toCompatPart`.
+ *   the flag is removed from the resulting metadata (with `metadata`
+ *   itself omitted if no other keys remain). This reverses the wrapping
+ *   done by `toCompatPart` and by the cross-SDK equivalents in
+ *   `a2a-python` / `a2a-go`.
  */
 export function toCorePart(compatPart: legacy.Part): V1Part {
   if (compatPart.kind === 'text') {
@@ -124,10 +124,13 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
     let outMetadata = metadata;
 
     // Reverse the `{ value: <primitive> }` wrap added by `toCompatPart`
-    // when the source v1 value was a primitive/array/null. The flag is
-    // the load-bearing signal — without it we cannot distinguish a
-    // genuine `{ value: ... }` object from a synthesized wrapper.
-    if (metadata?.[DATA_PART_COMPAT_FLAG] === true) {
+    // (or by `a2a-python` / `a2a-go`) when the source v1 value was a
+    // primitive/array/null. The flag is the load-bearing signal —
+    // without it we cannot distinguish a genuine `{ value: ... }` object
+    // from a synthesized wrapper. Snake_case matches the reference SDKs'
+    // on-the-wire format; the flag is stripped so it does not leak into
+    // v1.0 metadata.
+    if (metadata !== undefined && metadata[DATA_PART_COMPAT_FLAG] === true) {
       if (isPlainObject(compatPart.data) && 'value' in compatPart.data) {
         value = compatPart.data.value;
       }
@@ -161,12 +164,15 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
  * - `content.$case: 'data'`: when the v1.0 value is a plain object it is
  *   used directly. When the value is a primitive (string, number,
  *   boolean), an array, or `null`, it is wrapped as `{ value: <original> }`
- *   and `metadata.dataPartCompat: true` is set on the resulting v0.3 part
- *   so `toCorePart` can unwrap it losslessly. Throws
- *   `A2AError.invalidParams` only when the value is neither a plain
- *   object nor a wrap-eligible primitive — i.e., `Symbol`, `function`,
- *   `bigint`, `undefined`, or `Buffer` — for which even the
- *   `{ value: ... }` wrapper could not survive JSON serialization.
+ *   and `metadata.data_part_compat: true` is set on the resulting v0.3
+ *   part (snake_case matches the on-the-wire format used by `a2a-python`
+ *   and `a2a-go`, so peers in those SDKs recognize the wrapper) so
+ *   `toCorePart` — and its cross-SDK equivalents — can unwrap it
+ *   losslessly. Throws `A2AError.invalidParams` only when the value is
+ *   neither a plain object nor a wrap-eligible primitive — i.e.,
+ *   `Symbol`, `function`, `bigint`, `undefined`, or `Buffer` — for which
+ *   even the `{ value: ... }` wrapper could not survive JSON
+ *   serialization.
  *
  * @throws {A2AError} when `content` is missing, has an unknown `$case`,
  * or carries a `data` value that is neither a plain object nor a
@@ -237,7 +243,7 @@ export function toCompatPart(corePart: V1Part): legacy.Part {
       'Cannot translate v1 data part to v0.3: value is neither a plain object ' +
         'nor a wrap-eligible primitive / array / null ' +
         '(e.g., Symbol, function, bigint, undefined, Buffer). ' +
-        'Primitives, arrays, and null are wrapped as { value: ... } with dataPartCompat=true; ' +
+        'Primitives, arrays, and null are wrapped as { value: ... } with data_part_compat=true; ' +
         'all other non-plain-object values are rejected.'
     );
   }

--- a/src/compat/v0_3/translate/parts.ts
+++ b/src/compat/v0_3/translate/parts.ts
@@ -1,35 +1,20 @@
 /**
  * `Part` translators between v1.0 proto and v0.3 JSON.
  *
- * The two formats differ in two structural ways:
+ * Shape differences:
+ *  - v1.0 discriminator: `part.content.$case` ∈ `'text' | 'raw' | 'url' | 'data'`.
+ *    v0.3 discriminator: `part.kind` ∈ `'text' | 'file' | 'data'`, with the
+ *    bytes-vs-uri choice nested under `part.file`.
+ *  - v1.0 carries `filename` / `mediaType` at the top level; v0.3 carries
+ *    `name` / `mimeType` on the inner `file`.
  *
- *  - **Outer discriminator.** v1.0 uses `part.content.$case` with the four
- *    cases `'text' | 'raw' | 'url' | 'data'`; v0.3 JSON uses `part.kind`
- *    with the three cases `'text' | 'file' | 'data'` and nests the
- *    file-bytes-vs-uri choice under `part.file` (`FileWithBytes |
- *    FileWithUri`).
- *  - **File metadata.** v1.0 carries `filename` and `mediaType` as
- *    top-level fields on every Part (only meaningful for file parts);
- *    v0.3 puts the equivalents (`name`, `mimeType`) on the inner `file`
- *    object.
- *
- * **Data parts.** v1.0 `Part.data` is a `google.protobuf.Value`, so it can
- * carry primitives, arrays, and `null` in addition to objects. v0.3
- * `DataPart.data` is typed `{ [k: string]: unknown }` — strictly a JSON
- * object. To round-trip the wider v1.0 set through the narrower v0.3
- * schema, `toCompatPart` wraps primitive / array / `null` values as
- * `{ value: <original> }` and tags the v0.3 part with a
- * `metadata.data_part_compat = true` flag. The key is snake_case to
- * match `a2a-python` (`compat/v0_3/conversions.py:46, :96`) and `a2a-go`
- * (`a2acompat/a2av0/conversions.go:333-336, :385`) byte-for-byte on the
- * wire, so cross-SDK peers recognize the wrapper. `toCorePart` looks for
- * the same flag and unwraps `data.value` back to the original primitive,
- * stripping the flag from the resulting v1.0 metadata.
- *
- * Values that are neither plain objects nor wrap-eligible primitives
- * (`Symbol`, `function`, `bigint`, `undefined`, `Buffer`) still throw
- * `A2AError.invalidParams` from `toCompatPart`: the wrapper itself would
- * not survive serialization.
+ * Data parts: v1.0 `Part.data` admits any JSON value (primitives, arrays,
+ * `null`, objects); v0.3 `DataPart.data` admits only objects. Primitive /
+ * array / `null` values are wrapped as `{ value: <original> }` and tagged
+ * with `metadata.data_part_compat = true`; `toCorePart` reverses the
+ * wrap when the flag is present and strips the flag from the result.
+ * Values that cannot be JSON-serialized (`Symbol`, `function`, `bigint`,
+ * `undefined`, `Buffer`) still throw `A2AError.invalidParams`.
  */
 
 import { A2AError } from '../server/error.js';
@@ -38,10 +23,9 @@ import type { Part as V1Part } from '../../../types/pb/a2a.js';
 import { deepCloneMetadata } from './_clone.js';
 
 /**
- * Metadata key emitted on v0.3 `DataPart`s whose `data` field carries a
+ * Metadata key tagging v0.3 `DataPart`s whose `data` field carries the
  * `{ value: <primitive|array|null> }` wrapper synthesized by
- * `toCompatPart`. Wire format is snake_case to match `a2a-python` and
- * `a2a-go` byte-for-byte, so peers across SDKs recognize the wrapper.
+ * `toCompatPart`. Snake_case is the on-the-wire form.
  */
 const DATA_PART_COMPAT_FLAG = 'data_part_compat';
 
@@ -52,10 +36,9 @@ function isPlainObject(value: unknown): value is { [k: string]: unknown } {
 }
 
 /**
- * True for v1.0 `Part.data` values that are valid `google.protobuf.Value`s
- * but cannot live directly under v0.3 `DataPart.data: { [k]: unknown }`
- * (which only admits JSON objects). These are the values `toCompatPart`
- * wraps as `{ value: <original> }` with the `data_part_compat` flag.
+ * True for JSON values valid in v1.0 `Part.data` but unrepresentable in
+ * v0.3 `DataPart.data: { [k]: unknown }` (objects only). These are the
+ * values `toCompatPart` wraps as `{ value: <original> }`.
  */
 function isCompatWrappableDataValue(
   value: unknown
@@ -69,19 +52,15 @@ function isCompatWrappableDataValue(
 /**
  * Converts a v0.3 JSON `Part` into a v1.0 proto `Part`.
  *
- * - Text parts map directly onto `content.$case: 'text'`.
- * - File parts split: `FileWithBytes` → `content.$case: 'raw'` (decoding
- *   the base64 payload into a `Buffer`); `FileWithUri` → `content.$case:
- *   'url'`. The optional `mimeType` / `name` are lifted to the top-level
- *   `mediaType` / `filename` fields.
- * - Data parts pass `data` through unchanged, except when
- *   `metadata.data_part_compat === true` and `data` has the shape
- *   `{ value: <primitive|array|null> }`. In that case the wrapper is
- *   stripped, `data.value` becomes the v1.0 `content.value` directly, and
- *   the flag is removed from the resulting metadata (with `metadata`
- *   itself omitted if no other keys remain). This reverses the wrapping
- *   done by `toCompatPart` and by the cross-SDK equivalents in
- *   `a2a-python` / `a2a-go`.
+ * - Text → `content.$case: 'text'`.
+ * - File: `FileWithBytes` → `'raw'` (base64-decoded into a `Buffer`);
+ *   `FileWithUri` → `'url'`. Inner `mimeType` / `name` lift to top-level
+ *   `mediaType` / `filename`.
+ * - Data: `data` passes through unchanged, except when
+ *   `metadata.data_part_compat === true` and `data` has shape
+ *   `{ value: <primitive|array|null> }` — then the wrapper is stripped,
+ *   `data.value` becomes the v1.0 value, and the flag is removed
+ *   (dropping `metadata` entirely if empty).
  */
 export function toCorePart(compatPart: legacy.Part): V1Part {
   if (compatPart.kind === 'text') {
@@ -123,13 +102,10 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
     let value: unknown = compatPart.data;
     let outMetadata = metadata;
 
-    // Reverse the `{ value: <primitive> }` wrap added by `toCompatPart`
-    // (or by `a2a-python` / `a2a-go`) when the source v1 value was a
-    // primitive/array/null. The flag is the load-bearing signal —
-    // without it we cannot distinguish a genuine `{ value: ... }` object
-    // from a synthesized wrapper. Snake_case matches the reference SDKs'
-    // on-the-wire format; the flag is stripped so it does not leak into
-    // v1.0 metadata.
+    // Reverse the `{ value: <primitive> }` wrap. The flag is the
+    // load-bearing signal — without it a genuine `{ value: ... }`
+    // payload is indistinguishable from a synthesized wrapper. The
+    // flag is stripped so it does not leak into v1.0 metadata.
     if (metadata !== undefined && metadata[DATA_PART_COMPAT_FLAG] === true) {
       if (isPlainObject(compatPart.data) && 'value' in compatPart.data) {
         value = compatPart.data.value;
@@ -156,27 +132,18 @@ export function toCorePart(compatPart: legacy.Part): V1Part {
 /**
  * Converts a v1.0 proto `Part` into a v0.3 JSON `Part`.
  *
- * - `content.$case: 'text'` ↔ `kind: 'text'`.
- * - `content.$case: 'raw'` ↔ `kind: 'file'` with `FileWithBytes` (base64
- *   encoding the `Buffer`); `content.$case: 'url'` ↔ `kind: 'file'` with
- *   `FileWithUri`. `filename` / `mediaType` are pushed down into the
- *   inner file's `name` / `mimeType`.
- * - `content.$case: 'data'`: when the v1.0 value is a plain object it is
- *   used directly. When the value is a primitive (string, number,
- *   boolean), an array, or `null`, it is wrapped as `{ value: <original> }`
- *   and `metadata.data_part_compat: true` is set on the resulting v0.3
- *   part (snake_case matches the on-the-wire format used by `a2a-python`
- *   and `a2a-go`, so peers in those SDKs recognize the wrapper) so
- *   `toCorePart` — and its cross-SDK equivalents — can unwrap it
- *   losslessly. Throws `A2AError.invalidParams` only when the value is
- *   neither a plain object nor a wrap-eligible primitive — i.e.,
- *   `Symbol`, `function`, `bigint`, `undefined`, or `Buffer` — for which
- *   even the `{ value: ... }` wrapper could not survive JSON
- *   serialization.
+ * - `'text'` ↔ `kind: 'text'`.
+ * - `'raw'` ↔ `kind: 'file'` + `FileWithBytes` (base64-encoded `Buffer`).
+ * - `'url'` ↔ `kind: 'file'` + `FileWithUri`. Top-level `filename` /
+ *   `mediaType` push down to inner `name` / `mimeType`.
+ * - `'data'`: plain object → used directly. Primitive / array / `null`
+ *   → wrapped as `{ value: <original> }` with
+ *   `metadata.data_part_compat: true` so `toCorePart` can unwrap.
  *
  * @throws {A2AError} when `content` is missing, has an unknown `$case`,
  * or carries a `data` value that is neither a plain object nor a
- * wrap-eligible primitive / array / null.
+ * wrap-eligible primitive / array / null (`Symbol`, `function`,
+ * `bigint`, `undefined`, `Buffer`).
  */
 export function toCompatPart(corePart: V1Part): legacy.Part {
   const content = corePart.content;
@@ -227,11 +194,8 @@ export function toCompatPart(corePart: V1Part): legacy.Part {
     }
 
     if (isCompatWrappableDataValue(value)) {
-      // Wrap the primitive / array / null in `{ value: <original> }` and
-      // tag the v0.3 part so `toCorePart` can losslessly unwrap. The
-      // wrapped reference is passed through as-is (no defensive clone),
-      // matching the plain-object branch above and the metadata-cloning
-      // policy already documented for this file.
+      // Wrap and tag so `toCorePart` can losslessly unwrap. No
+      // defensive clone — matches the plain-object branch above.
       const data: { [k: string]: unknown } = { value };
       const outMetadata: { [k: string]: unknown } = metadata ?? {};
       outMetadata[DATA_PART_COMPAT_FLAG] = true;

--- a/test/compat/v0_3/translate/parts.spec.ts
+++ b/test/compat/v0_3/translate/parts.spec.ts
@@ -57,6 +57,59 @@ describe('parts', () => {
       expect(core.content).toEqual({ $case: 'data', value: { x: 1 } });
     });
 
+    it('unwraps a wrapped primitive data part when dataPartCompat=true', () => {
+      const compat: legacy.Part = {
+        kind: 'data',
+        data: { value: 42 },
+        metadata: { dataPartCompat: true },
+      };
+      const core = toCorePart(compat);
+      expect(core.content).toEqual({ $case: 'data', value: 42 });
+      // The flag is the only key, so metadata is dropped entirely.
+      expect(core.metadata).toBeUndefined();
+    });
+
+    it('unwraps a wrapped null data part when dataPartCompat=true', () => {
+      const compat: legacy.Part = {
+        kind: 'data',
+        data: { value: null },
+        metadata: { dataPartCompat: true },
+      };
+      const core = toCorePart(compat);
+      expect(core.content).toEqual({ $case: 'data', value: null });
+      expect(core.metadata).toBeUndefined();
+    });
+
+    it('unwraps a wrapped array data part when dataPartCompat=true', () => {
+      const compat: legacy.Part = {
+        kind: 'data',
+        data: { value: [1, 2, 3] },
+        metadata: { dataPartCompat: true },
+      };
+      const core = toCorePart(compat);
+      expect(core.content).toEqual({ $case: 'data', value: [1, 2, 3] });
+      expect(core.metadata).toBeUndefined();
+    });
+
+    it('preserves non-flag metadata when unwrapping a wrapped data part', () => {
+      const compat: legacy.Part = {
+        kind: 'data',
+        data: { value: 'hello' },
+        metadata: { dataPartCompat: true, ext: 'keep-me' },
+      };
+      const core = toCorePart(compat);
+      expect(core.content).toEqual({ $case: 'data', value: 'hello' });
+      expect(core.metadata).toEqual({ ext: 'keep-me' });
+    });
+
+    it('does not unwrap a {value: ...} object when dataPartCompat is absent', () => {
+      // Without the flag, `data` is treated as an ordinary v0.3 payload —
+      // the literal `{ value: ... }` object must survive as-is.
+      const compat: legacy.Part = { kind: 'data', data: { value: 42 } };
+      const core = toCorePart(compat);
+      expect(core.content).toEqual({ $case: 'data', value: { value: 42 } });
+    });
+
     it('throws for an unknown kind', () => {
       const compat = { kind: 'unknown' } as unknown as legacy.Part;
       expect(() => toCorePart(compat)).toThrow(A2AError);
@@ -133,9 +186,50 @@ describe('parts', () => {
       expect(toCompatPart(core)).toEqual({ kind: 'data', data: { x: 1 } });
     });
 
-    it('throws when v1 data part value is not a plain object', () => {
-      const nonObjectValues: unknown[] = ['hello', 42, true, null, [1, 2, 3]];
-      for (const value of nonObjectValues) {
+    it.each([
+      ['string', 'hello'],
+      ['number', 42],
+      ['boolean true', true],
+      ['boolean false', false],
+      ['null', null],
+      ['array', [1, 2, 3]],
+    ])('wraps a non-object data value (%s) with dataPartCompat=true', (_label, value) => {
+      const core: V1Part = {
+        content: { $case: 'data', value },
+        metadata: undefined,
+        filename: '',
+        mediaType: '',
+      };
+      expect(toCompatPart(core)).toEqual({
+        kind: 'data',
+        data: { value },
+        metadata: { dataPartCompat: true },
+      });
+    });
+
+    it('merges the dataPartCompat flag with existing metadata when wrapping', () => {
+      const core: V1Part = {
+        content: { $case: 'data', value: 42 },
+        metadata: { ext: 'keep-me' },
+        filename: '',
+        mediaType: '',
+      };
+      expect(toCompatPart(core)).toEqual({
+        kind: 'data',
+        data: { value: 42 },
+        metadata: { ext: 'keep-me', dataPartCompat: true },
+      });
+    });
+
+    it.each([
+      ['Symbol', Symbol('s') as unknown],
+      ['function', (() => 0) as unknown],
+      ['bigint', 1n as unknown],
+      ['undefined', undefined as unknown],
+      ['Buffer', Buffer.from('x') as unknown],
+    ])(
+      'throws when v1 data part value is neither a plain object nor a wrap-eligible primitive (%s)',
+      (_label, value: unknown) => {
         const core: V1Part = {
           content: { $case: 'data', value },
           metadata: undefined,
@@ -144,7 +238,7 @@ describe('parts', () => {
         };
         expect(() => toCompatPart(core)).toThrow(A2AError);
       }
-    });
+    );
 
     it('throws when content is missing', () => {
       const core: V1Part = {
@@ -187,6 +281,33 @@ describe('parts', () => {
       const compat: legacy.Part = { kind: 'data', data: { x: 1, y: [2, 3] } };
       expect(toCompatPart(toCorePart(compat))).toEqual(compat);
     });
+
+    it.each([
+      ['string', 'hello'],
+      ['number', 42],
+      ['boolean', true],
+      ['null', null],
+      ['array', [1, 2, 3]],
+    ])(
+      'round-trips a v1 data part with a non-object value (%s) through the v0.3 wrap-and-flag form',
+      (_label, value) => {
+        const core: V1Part = {
+          content: { $case: 'data', value },
+          metadata: undefined,
+          filename: '',
+          mediaType: '',
+        };
+        const compat = toCompatPart(core);
+        expect(compat).toEqual({
+          kind: 'data',
+          data: { value },
+          metadata: { dataPartCompat: true },
+        });
+        const roundTripped = toCorePart(compat);
+        expect(roundTripped.content).toEqual({ $case: 'data', value });
+        expect(roundTripped.metadata).toBeUndefined();
+      }
+    );
   });
 
   describe('metadata deep-cloning', () => {

--- a/test/compat/v0_3/translate/parts.spec.ts
+++ b/test/compat/v0_3/translate/parts.spec.ts
@@ -57,11 +57,11 @@ describe('parts', () => {
       expect(core.content).toEqual({ $case: 'data', value: { x: 1 } });
     });
 
-    it('unwraps a wrapped primitive data part when dataPartCompat=true', () => {
+    it('unwraps a wrapped primitive data part when data_part_compat=true', () => {
       const compat: legacy.Part = {
         kind: 'data',
         data: { value: 42 },
-        metadata: { dataPartCompat: true },
+        metadata: { data_part_compat: true },
       };
       const core = toCorePart(compat);
       expect(core.content).toEqual({ $case: 'data', value: 42 });
@@ -69,22 +69,22 @@ describe('parts', () => {
       expect(core.metadata).toBeUndefined();
     });
 
-    it('unwraps a wrapped null data part when dataPartCompat=true', () => {
+    it('unwraps a wrapped null data part when data_part_compat=true', () => {
       const compat: legacy.Part = {
         kind: 'data',
         data: { value: null },
-        metadata: { dataPartCompat: true },
+        metadata: { data_part_compat: true },
       };
       const core = toCorePart(compat);
       expect(core.content).toEqual({ $case: 'data', value: null });
       expect(core.metadata).toBeUndefined();
     });
 
-    it('unwraps a wrapped array data part when dataPartCompat=true', () => {
+    it('unwraps a wrapped array data part when data_part_compat=true', () => {
       const compat: legacy.Part = {
         kind: 'data',
         data: { value: [1, 2, 3] },
-        metadata: { dataPartCompat: true },
+        metadata: { data_part_compat: true },
       };
       const core = toCorePart(compat);
       expect(core.content).toEqual({ $case: 'data', value: [1, 2, 3] });
@@ -95,19 +95,32 @@ describe('parts', () => {
       const compat: legacy.Part = {
         kind: 'data',
         data: { value: 'hello' },
-        metadata: { dataPartCompat: true, ext: 'keep-me' },
+        metadata: { data_part_compat: true, ext: 'keep-me' },
       };
       const core = toCorePart(compat);
       expect(core.content).toEqual({ $case: 'data', value: 'hello' });
       expect(core.metadata).toEqual({ ext: 'keep-me' });
     });
 
-    it('does not unwrap a {value: ...} object when dataPartCompat is absent', () => {
+    it('does not unwrap a {value: ...} object when data_part_compat is absent', () => {
       // Without the flag, `data` is treated as an ordinary v0.3 payload —
       // the literal `{ value: ... }` object must survive as-is.
       const compat: legacy.Part = { kind: 'data', data: { value: 42 } };
       const core = toCorePart(compat);
       expect(core.content).toEqual({ $case: 'data', value: { value: 42 } });
+    });
+
+    it('does not unwrap when the compat flag is present but not strictly true', () => {
+      // Only the literal boolean `true` is honored; truthy strings, 1, etc.
+      // do not trigger unwrap — they're foreign metadata that must round-trip.
+      const compat: legacy.Part = {
+        kind: 'data',
+        data: { value: 42 },
+        metadata: { data_part_compat: 'yes' as unknown as boolean },
+      };
+      const core = toCorePart(compat);
+      expect(core.content).toEqual({ $case: 'data', value: { value: 42 } });
+      expect(core.metadata).toEqual({ data_part_compat: 'yes' });
     });
 
     it('throws for an unknown kind', () => {
@@ -193,21 +206,24 @@ describe('parts', () => {
       ['boolean false', false],
       ['null', null],
       ['array', [1, 2, 3]],
-    ])('wraps a non-object data value (%s) with dataPartCompat=true', (_label, value) => {
-      const core: V1Part = {
-        content: { $case: 'data', value },
-        metadata: undefined,
-        filename: '',
-        mediaType: '',
-      };
-      expect(toCompatPart(core)).toEqual({
-        kind: 'data',
-        data: { value },
-        metadata: { dataPartCompat: true },
-      });
-    });
+    ])(
+      'wraps a non-object data value (%s) with data_part_compat=true (snake_case on the wire)',
+      (_label, value) => {
+        const core: V1Part = {
+          content: { $case: 'data', value },
+          metadata: undefined,
+          filename: '',
+          mediaType: '',
+        };
+        expect(toCompatPart(core)).toEqual({
+          kind: 'data',
+          data: { value },
+          metadata: { data_part_compat: true },
+        });
+      }
+    );
 
-    it('merges the dataPartCompat flag with existing metadata when wrapping', () => {
+    it('merges the data_part_compat flag with existing metadata when wrapping', () => {
       const core: V1Part = {
         content: { $case: 'data', value: 42 },
         metadata: { ext: 'keep-me' },
@@ -217,7 +233,7 @@ describe('parts', () => {
       expect(toCompatPart(core)).toEqual({
         kind: 'data',
         data: { value: 42 },
-        metadata: { ext: 'keep-me', dataPartCompat: true },
+        metadata: { ext: 'keep-me', data_part_compat: true },
       });
     });
 
@@ -301,11 +317,35 @@ describe('parts', () => {
         expect(compat).toEqual({
           kind: 'data',
           data: { value },
-          metadata: { dataPartCompat: true },
+          metadata: { data_part_compat: true },
         });
         const roundTripped = toCorePart(compat);
         expect(roundTripped.content).toEqual({ $case: 'data', value });
         expect(roundTripped.metadata).toBeUndefined();
+      }
+    );
+
+    it.each([
+      ['string', 'hello'],
+      ['number', 42],
+      ['boolean', true],
+      ['null', null],
+      ['array', [1, 2, 3]],
+    ])(
+      'unwraps a v0.3 payload (%s) wrapped by a cross-SDK peer using snake_case',
+      (_label, value) => {
+        // Simulates a v0.3 message produced by `a2a-python` / `a2a-go`,
+        // which emit `data_part_compat: true`. JS must recognize and
+        // unwrap so the v1 layer sees the original primitive / array /
+        // null instead of a stray `{ value: ... }` object.
+        const compat: legacy.Part = {
+          kind: 'data',
+          data: { value },
+          metadata: { data_part_compat: true },
+        };
+        const core = toCorePart(compat);
+        expect(core.content).toEqual({ $case: 'data', value });
+        expect(core.metadata).toBeUndefined();
       }
     );
   });

--- a/test/compat/v0_3/translate/parts.spec.ts
+++ b/test/compat/v0_3/translate/parts.spec.ts
@@ -65,7 +65,6 @@ describe('parts', () => {
       };
       const core = toCorePart(compat);
       expect(core.content).toEqual({ $case: 'data', value: 42 });
-      // The flag is the only key, so metadata is dropped entirely.
       expect(core.metadata).toBeUndefined();
     });
 
@@ -103,16 +102,14 @@ describe('parts', () => {
     });
 
     it('does not unwrap a {value: ...} object when data_part_compat is absent', () => {
-      // Without the flag, `data` is treated as an ordinary v0.3 payload —
-      // the literal `{ value: ... }` object must survive as-is.
       const compat: legacy.Part = { kind: 'data', data: { value: 42 } };
       const core = toCorePart(compat);
       expect(core.content).toEqual({ $case: 'data', value: { value: 42 } });
     });
 
     it('does not unwrap when the compat flag is present but not strictly true', () => {
-      // Only the literal boolean `true` is honored; truthy strings, 1, etc.
-      // do not trigger unwrap — they're foreign metadata that must round-trip.
+      // Only the literal boolean `true` triggers unwrap; truthy strings,
+      // 1, etc. are foreign metadata that must round-trip.
       const compat: legacy.Part = {
         kind: 'data',
         data: { value: 42 },
@@ -206,22 +203,19 @@ describe('parts', () => {
       ['boolean false', false],
       ['null', null],
       ['array', [1, 2, 3]],
-    ])(
-      'wraps a non-object data value (%s) with data_part_compat=true (snake_case on the wire)',
-      (_label, value) => {
-        const core: V1Part = {
-          content: { $case: 'data', value },
-          metadata: undefined,
-          filename: '',
-          mediaType: '',
-        };
-        expect(toCompatPart(core)).toEqual({
-          kind: 'data',
-          data: { value },
-          metadata: { data_part_compat: true },
-        });
-      }
-    );
+    ])('wraps a non-object data value (%s) with data_part_compat=true', (_label, value) => {
+      const core: V1Part = {
+        content: { $case: 'data', value },
+        metadata: undefined,
+        filename: '',
+        mediaType: '',
+      };
+      expect(toCompatPart(core)).toEqual({
+        kind: 'data',
+        data: { value },
+        metadata: { data_part_compat: true },
+      });
+    });
 
     it('merges the data_part_compat flag with existing metadata when wrapping', () => {
       const core: V1Part = {
@@ -332,12 +326,10 @@ describe('parts', () => {
       ['null', null],
       ['array', [1, 2, 3]],
     ])(
-      'unwraps a v0.3 payload (%s) wrapped by a cross-SDK peer using snake_case',
+      'unwraps an incoming v0.3 payload (%s) tagged with data_part_compat=true',
       (_label, value) => {
-        // Simulates a v0.3 message produced by `a2a-python` / `a2a-go`,
-        // which emit `data_part_compat: true`. JS must recognize and
-        // unwrap so the v1 layer sees the original primitive / array /
-        // null instead of a stray `{ value: ... }` object.
+        // The v1 layer must see the original primitive / array / null,
+        // not a stray `{ value: ... }` object.
         const compat: legacy.Part = {
           kind: 'data',
           data: { value },


### PR DESCRIPTION
# Description

## What
`toCompatPart` for `Part.data` wraps primitive / array / null values in
`{value: <original>}` with `metadata.data_part_compat: true` instead of
throwing. `toCorePart` unwraps via the same flag.


## Why
Spec §4.1.6 (Part): `Part.data` carries "a JSON value (object, array,
string, number, boolean, or null)" — the normative proto definition
(`spec/a2a.proto`, per §1.4) types it as `google.protobuf.Value`. v0.3
`DataPart.data` is `{[k]: unknown}`, which can only represent JSON
objects. JS threw `A2AError.invalidParams` for any non-object value and
broke the entire RPC.


Both reference SDKs (a2a-python `compat/v0_3/conversions.py:75-99`,
a2a-go `a2acompat/a2av0/conversions.go:372-383`) use the same
wrap-with-flag pattern, with snake_case `data_part_compat` on the wire
so peers across SDKs recognize the wrapper.

Fixes #536  🦕
