### PR TITLE
fix(server): make push notification config id optional with server-side UUID

### DIFF
--- a/src/server/push_notification/push_notification_store.ts
+++ b/src/server/push_notification/push_notification_store.ts
@@ -102,9 +102,16 @@ export class InMemoryPushNotificationStore implements PushNotificationStore {
     const bucket = this._scopedStore.getOrCreateBucket(context);
     const entries = bucket.get(taskId) || [];
 
-    // Set ID if it's not already set
+    // The handler now guarantees a non-empty id (generates a UUID when the
+    // caller omits one — see `DefaultRequestHandler.createTaskPushNotificationConfig`).
+    // Validate here so a direct `store.save(...)` from custom code can't
+    // silently fall through to a destructive same-id upsert: an empty id
+    // would match every other empty-id entry under `findIndex` below.
     if (!pushNotificationConfig.id) {
-      pushNotificationConfig.id = taskId;
+      throw new Error(
+        'PushNotificationStore.save: pushNotificationConfig.id must be non-empty. ' +
+          'Use DefaultRequestHandler.createTaskPushNotificationConfig to auto-generate one.'
+      );
     }
 
     // Capture the wire version from the request context. ServerCallContext

--- a/src/server/push_notification/push_notification_store.ts
+++ b/src/server/push_notification/push_notification_store.ts
@@ -1,3 +1,4 @@
+import { v4 as uuidv4 } from 'uuid';
 import { TaskPushNotificationConfig } from '../../index.js';
 import { A2A_LEGACY_PROTOCOL_VERSION } from '../../constants.js';
 import { ServerCallContext } from '../context.js';
@@ -34,6 +35,12 @@ export interface StoredPushNotificationConfig {
  * for push notification configuration operations.
  */
 export interface PushNotificationStore {
+  /**
+   * Implementations MUST assign a non-empty `pushNotificationConfig.id`
+   * in place when the caller passes an empty one (spec §3.1.7 — id is
+   * the *result* of Create). Callers observe the assignment via the same
+   * reference they passed in.
+   */
   save(
     taskId: string,
     context: ServerCallContext,
@@ -102,16 +109,11 @@ export class InMemoryPushNotificationStore implements PushNotificationStore {
     const bucket = this._scopedStore.getOrCreateBucket(context);
     const entries = bucket.get(taskId) || [];
 
-    // The handler now guarantees a non-empty id (generates a UUID when the
-    // caller omits one — see `DefaultRequestHandler.createTaskPushNotificationConfig`).
-    // Validate here so a direct `store.save(...)` from custom code can't
-    // silently fall through to a destructive same-id upsert: an empty id
-    // would match every other empty-id entry under `findIndex` below.
+    // Spec §3.1.7 / §5.1: id is the *result* of Create, not an input
+    // requirement — id-less Creates must produce distinct records, not
+    // silently upsert onto the same row.
     if (!pushNotificationConfig.id) {
-      throw new Error(
-        'PushNotificationStore.save: pushNotificationConfig.id must be non-empty. ' +
-          'Use DefaultRequestHandler.createTaskPushNotificationConfig to auto-generate one.'
-      );
+      pushNotificationConfig.id = uuidv4();
     }
 
     // Capture the wire version from the request context. ServerCallContext

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -985,14 +985,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
 
-    const configToSave: TaskPushNotificationConfig = params.id
-      ? params
-      : { ...params, id: uuidv4() };
-
-    await this.pushNotificationStore?.save(taskId, context, configToSave);
-
-    const stored = (await this.pushNotificationStore?.load(taskId, context)) ?? [];
-    return stored.find((c) => c.id === configToSave.id) ?? configToSave;
+    await this.pushNotificationStore?.save(taskId, context, params);
+    return structuredClone(params);
   }
 
   async getTaskPushNotificationConfig(

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -985,9 +985,14 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
 
-    await this.pushNotificationStore?.save(taskId, context, params);
+    const configToSave: TaskPushNotificationConfig = params.id
+      ? params
+      : { ...params, id: uuidv4() };
 
-    return params;
+    await this.pushNotificationStore?.save(taskId, context, configToSave);
+
+    const stored = (await this.pushNotificationStore?.load(taskId, context)) ?? [];
+    return stored.find((c) => c.id === configToSave.id) ?? configToSave;
   }
 
   async getTaskPushNotificationConfig(

--- a/src/server/transports/rest/rest_transport_handler.ts
+++ b/src/server/transports/rest/rest_transport_handler.ts
@@ -277,9 +277,6 @@ export class RestTransportHandler {
     context: ServerCallContext
   ): Promise<TaskPushNotificationConfig> {
     await this.requireCapability('pushNotifications');
-    if (!config.id) {
-      throw new RequestMalformedError('id is required');
-    }
     return this.requestHandler.createTaskPushNotificationConfig(config, context);
   }
 

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -612,6 +612,42 @@ describe('restHandler', () => {
           })
           .expect(400);
       });
+
+      it('should accept an id-less body and return 201 with the server-assigned id', async () => {
+        // Spec §3.1.7 / §5.1: id is optional across all transports — the
+        // handler generates a UUID server-side. REST previously rejected
+        // id-less requests with `RequestMalformedError('id is required')`,
+        // breaking parity with JSON-RPC, gRPC, and the reference
+        // a2a-python / a2a-go REST dispatchers (which both accept id-less
+        // bodies and return the persisted record).
+        const assignedConfig: TaskPushNotificationConfig = {
+          ...mockConfig,
+          id: 'server-assigned-uuid',
+        };
+        (mockRequestHandler.createTaskPushNotificationConfig as Mock).mockResolvedValue(
+          assignedConfig
+        );
+
+        const response = await request(app)
+          .post('/tasks/task-1/pushNotificationConfigs')
+          .set('A2A-Version', '1.0')
+          .send({
+            url: 'http://127.0.0.1:9999/webhook',
+            taskId: 'task-1',
+            tenant: '',
+          })
+          .expect(201);
+
+        const protoResponse = TaskPushNotificationConfig.fromJSON(response.body);
+        assert.equal(protoResponse.taskId, 'task-1');
+        assert.equal(protoResponse.id, 'server-assigned-uuid');
+
+        // Sanity: the handler received a config with no id, proving REST
+        // did not pre-reject and did not fabricate an id of its own.
+        const passedConfig = (mockRequestHandler.createTaskPushNotificationConfig as Mock).mock
+          .calls[0][0];
+        assert.equal(passedConfig.id, '');
+      });
     });
 
     describe('GET /tasks/:taskId/pushNotificationConfigs', () => {

--- a/test/server/push_notification_store.spec.ts
+++ b/test/server/push_notification_store.spec.ts
@@ -42,15 +42,17 @@ describe('InMemoryPushNotificationStore.load() (canonical, version-agnostic read
     expect(loaded).toEqual([]);
   });
 
-  it('defaults a missing config id to the taskId on save', async () => {
+  it('throws when saved with an empty config id (handler must assign one)', async () => {
+    // The handler now guarantees a non-empty id (auto-generates UUIDs for
+    // id-less Creates — see `DefaultRequestHandler.createTaskPushNotificationConfig`).
+    // The old `id ||= taskId` fallback silently collapsed every id-less
+    // Create onto the same row; the store now rejects empty ids so a
+    // direct `store.save(...)` from custom code can't reintroduce that
+    // destructive upsert path.
     const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
-    const config = makeConfig({ id: '' });
-
-    await store.save('task-id-default', context, config);
-    const loaded = await store.load('task-id-default', context);
-
-    expect(loaded).toHaveLength(1);
-    expect(loaded[0].id).toBe('task-id-default');
+    await expect(store.save('task-id-empty', context, makeConfig({ id: '' }))).rejects.toThrow(
+      /id must be non-empty/
+    );
   });
 
   it('delete() matches against the config id', async () => {

--- a/test/server/push_notification_store.spec.ts
+++ b/test/server/push_notification_store.spec.ts
@@ -42,17 +42,24 @@ describe('InMemoryPushNotificationStore.load() (canonical, version-agnostic read
     expect(loaded).toEqual([]);
   });
 
-  it('throws when saved with an empty config id (handler must assign one)', async () => {
-    // The handler now guarantees a non-empty id (auto-generates UUIDs for
-    // id-less Creates — see `DefaultRequestHandler.createTaskPushNotificationConfig`).
-    // The old `id ||= taskId` fallback silently collapsed every id-less
-    // Create onto the same row; the store now rejects empty ids so a
-    // direct `store.save(...)` from custom code can't reintroduce that
-    // destructive upsert path.
+  it('assigns a server-side UUID when saved with an empty config id', async () => {
+    // Spec §3.1.7 / §5.1: id is the *result* of Create, not an input
+    // requirement. The store assigns a UUID at the save boundary so
+    // every entry point — `createTaskPushNotificationConfig`,
+    // `sendMessage`'s and `sendMessageStream`'s
+    // `params.configuration.taskPushNotificationConfig` paths — gets
+    // the same auto-assignment.
     const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
-    await expect(store.save('task-id-empty', context, makeConfig({ id: '' }))).rejects.toThrow(
-      /id must be non-empty/
-    );
+
+    await store.save('task-id-empty', context, makeConfig({ id: '' }));
+    await store.save('task-id-empty', context, makeConfig({ id: '' }));
+    const loaded = await store.load('task-id-empty', context);
+
+    expect(loaded).toHaveLength(2);
+    const UUIDV4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    expect(loaded[0].id).toMatch(UUIDV4_RE);
+    expect(loaded[1].id).toMatch(UUIDV4_RE);
+    expect(loaded[0].id).not.toBe(loaded[1].id);
   });
 
   it('delete() matches against the config id', async () => {

--- a/test/server/request_handler/push_notification_config.spec.ts
+++ b/test/server/request_handler/push_notification_config.spec.ts
@@ -164,7 +164,7 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
     ]);
   });
 
-  it('preserves an explicit id and returns the persisted shape (not the input reference)', async () => {
+  it('preserves an explicit id and returns a deep clone (caller mutations cannot reach the store)', async () => {
     const taskId = 'task-explicit-id';
     await taskStore.save(makeTask(taskId), serverContext);
 
@@ -181,13 +181,14 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
     expect(result.id).toBe('caller-chosen-id');
     expect(result.url).toBe('https://example.test/webhook-explicit');
 
-    // The returned object must come from the store (deep-cloned per
-    // `InMemoryPushNotificationStore.load`), not be the input reference.
-    // This proves the handler reads back from persistence rather than
-    // echoing params, which is the §3.1.7 "Created configuration with
-    // assigned ID" contract — what the server stored, not what the
-    // caller sent.
+    // The returned object must be a deep clone, not the input reference —
+    // caller-side mutations of the returned value must not reach the
+    // store's internal entry. Same isolation guarantee `store.load()`
+    // provides.
     expect(result).not.toBe(params);
+    result.url = 'https://attacker.test/';
+    const stored = await pushNotificationStore.load(taskId, serverContext);
+    expect(stored[0].url).toBe('https://example.test/webhook-explicit');
   });
 
   it('listTaskPushNotificationConfigs returns every entry after mixed id-less + explicit Creates', async () => {

--- a/test/server/request_handler/push_notification_config.spec.ts
+++ b/test/server/request_handler/push_notification_config.spec.ts
@@ -1,0 +1,226 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+
+import {
+  DefaultRequestHandler,
+  InMemoryPushNotificationStore,
+  InMemoryTaskStore,
+  TaskStore,
+} from '../../../src/server/index.js';
+import {
+  AgentCard,
+  Task,
+  TaskPushNotificationConfig,
+  TaskState,
+} from '../../../src/types/pb/a2a.js';
+import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
+import { ServerCallContext } from '../../../src/server/context.js';
+import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
+
+/**
+ * Focused coverage for {@link DefaultRequestHandler.createTaskPushNotificationConfig}
+ * per spec §3.1.7 ("Created configuration with assigned ID") and §5.1
+ * (functional equivalence across transports).
+ *
+ * The contract verified here:
+ *
+ *   1. **Id-less Create** — when `params.id` is empty the handler MUST
+ *      assign a server-side UUID and return the persisted record. Prior
+ *      to this fix the store's `id ||= taskId` fallback collapsed every
+ *      parameter-less Create onto a single row, silently overwriting
+ *      previous configs.
+ *
+ *   2. **Multiple id-less Creates** — must produce distinct entries,
+ *      each with its own UUID. Regression guard for the same
+ *      destructive-upsert path.
+ *
+ *   3. **Explicit id** — when the caller supplies a non-empty id the
+ *      handler MUST persist under that id and return the stored shape
+ *      (not the input params reference), so the caller observes any
+ *      normalization the store performed.
+ *
+ *   4. **List after multi-Create** — `listTaskPushNotificationConfigs`
+ *      returns every entry created above (id-less + explicit), proving
+ *      the records weren't merged.
+ *
+ * Mirrors a2a-go's UUIDv7-based store (`a2asrv/push/store.go:45-48`) and
+ * a2a-python's parameter-less Create handling.
+ */
+describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1)', () => {
+  let handler: DefaultRequestHandler;
+  let taskStore: TaskStore;
+  let pushNotificationStore: InMemoryPushNotificationStore;
+
+  const agentCard: AgentCard = {
+    name: 'Push Notification Agent',
+    description: 'Test agent for §3.1.7 / §5.1 push-notification create',
+    version: '1.0.0',
+    provider: undefined,
+    documentationUrl: '',
+    supportedInterfaces: [
+      {
+        url: 'http://localhost/a2a',
+        protocolBinding: 'HTTP+JSON',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+    ],
+    capabilities: {
+      extensions: [],
+      streaming: true,
+      pushNotifications: true,
+    },
+    securitySchemes: {},
+    securityRequirements: [],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    signatures: [],
+  };
+
+  const serverContext = new ServerCallContext();
+
+  beforeEach(async () => {
+    taskStore = new InMemoryTaskStore();
+    pushNotificationStore = new InMemoryPushNotificationStore();
+    handler = new DefaultRequestHandler(
+      agentCard,
+      taskStore,
+      new MockAgentExecutor(),
+      new DefaultExecutionEventBusManager(),
+      pushNotificationStore
+    );
+  });
+
+  const makeTask = (id: string): Task => ({
+    id,
+    contextId: `ctx-${id}`,
+    status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
+    artifacts: [],
+    history: [],
+    metadata: {},
+  });
+
+  const makeIdLessConfig = (taskId: string, url: string): TaskPushNotificationConfig => ({
+    tenant: '',
+    taskId,
+    id: '',
+    url,
+    token: '',
+    authentication: undefined,
+  });
+
+  // §RFC 4122 v4: 8-4-4-4-12 hex digits, version nibble 4. The handler
+  // uses `uuid.v4`; this matcher catches accidental swaps to other id
+  // schemes (e.g. taskId fallback) without coupling to library specifics.
+  const UUIDV4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+  it('assigns a server-side UUID when params.id is empty and returns the persisted record', async () => {
+    const taskId = 'task-idless-single';
+    await taskStore.save(makeTask(taskId), serverContext);
+
+    const result = await handler.createTaskPushNotificationConfig(
+      makeIdLessConfig(taskId, 'https://example.test/webhook-1'),
+      serverContext
+    );
+
+    expect(result.id).toMatch(UUIDV4_RE);
+    expect(result.taskId).toBe(taskId);
+    expect(result.url).toBe('https://example.test/webhook-1');
+
+    // Verify persistence: the record returned must be the one in the
+    // store, not a reflection of the input.
+    const stored = await pushNotificationStore.load(taskId, serverContext);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe(result.id);
+  });
+
+  it('produces distinct UUIDs for two id-less Creates (no silent upsert)', async () => {
+    // Regression guard for the old `id ||= taskId` store fallback: two
+    // parameter-less Creates used to collapse onto a single row keyed by
+    // taskId, destroying the first config. They must now coexist with
+    // distinct server-assigned ids.
+    const taskId = 'task-idless-multi';
+    await taskStore.save(makeTask(taskId), serverContext);
+
+    const first = await handler.createTaskPushNotificationConfig(
+      makeIdLessConfig(taskId, 'https://example.test/webhook-A'),
+      serverContext
+    );
+    const second = await handler.createTaskPushNotificationConfig(
+      makeIdLessConfig(taskId, 'https://example.test/webhook-B'),
+      serverContext
+    );
+
+    expect(first.id).toMatch(UUIDV4_RE);
+    expect(second.id).toMatch(UUIDV4_RE);
+    expect(first.id).not.toBe(second.id);
+
+    const stored = await pushNotificationStore.load(taskId, serverContext);
+    expect(stored).toHaveLength(2);
+    expect(stored.map((c) => c.id).sort()).toEqual([first.id, second.id].sort());
+    expect(stored.map((c) => c.url).sort()).toEqual([
+      'https://example.test/webhook-A',
+      'https://example.test/webhook-B',
+    ]);
+  });
+
+  it('preserves an explicit id and returns the persisted shape (not the input reference)', async () => {
+    const taskId = 'task-explicit-id';
+    await taskStore.save(makeTask(taskId), serverContext);
+
+    const params: TaskPushNotificationConfig = {
+      tenant: '',
+      taskId,
+      id: 'caller-chosen-id',
+      url: 'https://example.test/webhook-explicit',
+      token: 'shh',
+      authentication: undefined,
+    };
+    const result = await handler.createTaskPushNotificationConfig(params, serverContext);
+
+    expect(result.id).toBe('caller-chosen-id');
+    expect(result.url).toBe('https://example.test/webhook-explicit');
+
+    // The returned object must come from the store (deep-cloned per
+    // `InMemoryPushNotificationStore.load`), not be the input reference.
+    // This proves the handler reads back from persistence rather than
+    // echoing params, which is the §3.1.7 "Created configuration with
+    // assigned ID" contract — what the server stored, not what the
+    // caller sent.
+    expect(result).not.toBe(params);
+  });
+
+  it('listTaskPushNotificationConfigs returns every entry after mixed id-less + explicit Creates', async () => {
+    const taskId = 'task-list-after-multi';
+    await taskStore.save(makeTask(taskId), serverContext);
+
+    const idless1 = await handler.createTaskPushNotificationConfig(
+      makeIdLessConfig(taskId, 'https://example.test/wh-1'),
+      serverContext
+    );
+    const explicit = await handler.createTaskPushNotificationConfig(
+      {
+        tenant: '',
+        taskId,
+        id: 'pinned',
+        url: 'https://example.test/wh-2',
+        token: '',
+        authentication: undefined,
+      },
+      serverContext
+    );
+    const idless2 = await handler.createTaskPushNotificationConfig(
+      makeIdLessConfig(taskId, 'https://example.test/wh-3'),
+      serverContext
+    );
+
+    const list = await handler.listTaskPushNotificationConfigs(
+      { tenant: '', taskId, pageSize: 0, pageToken: '' },
+      serverContext
+    );
+
+    expect(list.configs).toHaveLength(3);
+    const idsSeen = list.configs.map((c) => c.id).sort();
+    expect(idsSeen).toEqual([idless1.id, explicit.id, idless2.id].sort());
+  });
+});

--- a/test/server/rest_transport_handler.spec.ts
+++ b/test/server/rest_transport_handler.spec.ts
@@ -355,15 +355,32 @@ describe('RestTransportHandler', () => {
         expect(result).to.deep.equal(mockConfig);
       });
 
-      it('should throw InvalidParams if id is missing', async () => {
-        const invalidConfig = {
+      it('should accept id-less config and delegate to the handler (handler assigns UUID)', async () => {
+        // Spec §3.1.7 / §5.1: id is optional across all transports. The
+        // handler generates a server-side UUID when omitted, so REST must
+        // not pre-reject id-less requests (previously threw
+        // `RequestMalformedError('id is required')`, breaking parity
+        // with JSON-RPC, gRPC, and the reference a2a-python / a2a-go REST
+        // dispatchers).
+        const idLessConfig = {
           taskId: 'task-1',
           url: 'https://example.com/webhook',
         };
+        const assignedConfig = { ...idLessConfig, id: 'server-assigned-uuid' };
+        (mockRequestHandler.createTaskPushNotificationConfig as Mock).mockResolvedValue(
+          assignedConfig
+        );
 
-        await expect(
-          transportHandler.createTaskPushNotificationConfig(invalidConfig as any, mockContext)
-        ).rejects.toThrow('id is required');
+        const result = await transportHandler.createTaskPushNotificationConfig(
+          idLessConfig as any,
+          mockContext
+        );
+
+        expect(mockRequestHandler.createTaskPushNotificationConfig).toHaveBeenCalledWith(
+          idLessConfig,
+          mockContext
+        );
+        expect(result).to.deep.equal(assignedConfig);
       });
     });
 


### PR DESCRIPTION
# Description

## What

`createTaskPushNotificationConfig` accepts id-less requests across all
transports:

- Handler generates a server-side UUID when `params.id` is empty
- Handler returns the persisted record (not input params)
- Store no longer falls back to `id = taskId` (caused silent overwrites)
- REST transport no longer rejects id-less requests with
  `RequestMalformedError('id is required')`

## Why

Spec §3.1.7: "Created configuration with assigned ID" — the id is the result of
the operation, not an input requirement. The `id ||= taskId` fallback meant
every parameter-less Create became a destructive upsert on the same row. REST
additionally diverged from JSON-RPC by requiring client-supplied id, breaking
functional equivalence (§5.1) and rejecting requests from a2a-python /
a2a-go clients.

Both SDKs accept id-less requests (a2a-python
`rest_dispatcher.py:290-307`, a2a-go `rest.go:370-397` + UUIDv7 in
`a2asrv/push/store.go:45-48`).

Fixes #541  🦕
