### PR TITLE
fix(server): preserve activated extensions in response header

### DIFF
--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -71,7 +71,7 @@ export class ServerCallContext {
    * strand later `addActivatedExtension(...)` calls on a dead object
    * and response-side `A2A-Extensions` header would be missing.
    */
-  public setRequestedExtensions(extensions: Extensions) {
+  public setRequestedExtensions(extensions: Extensions | undefined) {
     this._requestedExtensions = extensions;
   }
 }

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -65,8 +65,11 @@ export class ServerCallContext {
   /**
    * Replaces the requested-extensions set. Used by
    * {@link DefaultRequestHandler} to narrow the list to those the agent
-   * actually exposes (§3.3.4) without orphaning the original context
-   * reference held by the Express / gRPC transport layer.
+   * actually exposes (per §4.6.3's "SHOULD ignore" rule for unsupported
+   * extensions) without orphaning the original context reference held
+   * by the Express / gRPC transport layer — replacing the context would
+   * strand later `addActivatedExtension(...)` calls on a dead object
+   * and response-side `A2A-Extensions` header would be missing.
    */
   public setRequestedExtensions(extensions: Extensions) {
     this._requestedExtensions = extensions;

--- a/src/server/context.ts
+++ b/src/server/context.ts
@@ -21,7 +21,7 @@ export interface ServerCallContextOptions {
 }
 
 export class ServerCallContext {
-  private readonly _requestedExtensions?: Extensions;
+  private _requestedExtensions?: Extensions;
   private readonly _user?: User;
   private readonly _requestedVersion: string;
   private readonly _tenant?: string;
@@ -60,5 +60,15 @@ export class ServerCallContext {
 
   public addActivatedExtension(uri: string) {
     this._activatedExtensions = Extensions.createFrom(this._activatedExtensions, uri);
+  }
+
+  /**
+   * Replaces the requested-extensions set. Used by
+   * {@link DefaultRequestHandler} to narrow the list to those the agent
+   * actually exposes (§3.3.4) without orphaning the original context
+   * reference held by the Express / gRPC transport layer.
+   */
+  public setRequestedExtensions(extensions: Extensions) {
+    this._requestedExtensions = extensions;
   }
 }

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -181,7 +181,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       ) {
         throw new RequestMalformedError(
           `contextId mismatch: message contextId '${incomingMessage.contextId}' ` +
-            `does not match task '${task.id}' contextId '${task.contextId}'`
+          `does not match task '${task.id}' contextId '${task.contextId}'`
         );
       }
       // Add incomingMessage to history and save the task.
@@ -226,11 +226,14 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       );
     }
 
-    // Filter client-requested extensions to only those the agent exposes.
-    // Mutate in place — the Express / gRPC transport layer holds a
-    // reference to this context and reads `activatedExtensions` off it
-    // after dispatch to echo the `A2A-Extensions` response header
-    // (§3.3.4 + §14.2.2).
+    // Narrow the client-requested set to extensions the agent actually
+    // exposes (§4.6.3: "SHOULD ignore the extension … and proceed
+    // without it"). Mutate in place — the Express / gRPC transport
+    // layer holds a reference to this context and, after dispatch,
+    // reads `activatedExtensions` off it to populate the response
+    // `A2A-Extensions` header. Replacing the reference would strand
+    // later `addActivatedExtension(...)` calls from the executor on a
+    // dead object and silently drop the header.
     if (context.requestedExtensions) {
       const exposedExtensions = new Set(agentExtensions.map((ext) => ext.uri));
       context.setRequestedExtensions(

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -227,17 +227,15 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     }
 
     // Filter client-requested extensions to only those the agent exposes.
+    // Mutate in place — the Express / gRPC transport layer holds a
+    // reference to this context and reads `activatedExtensions` off it
+    // after dispatch to echo the `A2A-Extensions` response header
+    // (§3.3.4 + §14.2.2).
     if (context.requestedExtensions) {
       const exposedExtensions = new Set(agentExtensions.map((ext) => ext.uri));
-      const validExtensions = context.requestedExtensions.filter((extension) =>
-        exposedExtensions.has(extension)
+      context.setRequestedExtensions(
+        context.requestedExtensions.filter((extension) => exposedExtensions.has(extension))
       );
-      context = new ServerCallContext({
-        requestedExtensions: validExtensions,
-        user: context.user,
-        requestedVersion: context.requestedVersion,
-        tenant: context.tenant,
-      });
     }
 
     const messageForContext = {

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -181,7 +181,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       ) {
         throw new RequestMalformedError(
           `contextId mismatch: message contextId '${incomingMessage.contextId}' ` +
-          `does not match task '${task.id}' contextId '${task.contextId}'`
+            `does not match task '${task.id}' contextId '${task.contextId}'`
         );
       }
       // Add incomingMessage to history and save the task.

--- a/test/server/context.spec.ts
+++ b/test/server/context.spec.ts
@@ -4,15 +4,15 @@ import { ServerCallContext } from '../../src/server/context.js';
 
 describe('ServerCallContext.setRequestedExtensions', () => {
   it('mutates the existing instance so an alias held elsewhere observes later activations', () => {
-    // Regression guard for the §3.3.4 / §14.2.2 echo bug:
+    // Regression guard for the response-header echo bug:
     // `_createRequestContext` previously replaced the context with a fresh
-    // instance after filtering requested extensions. The Express / gRPC
-    // transport layer held a reference to the original, so
-    // `addActivatedExtension(...)` calls from the executor landed on an
-    // orphaned object and the `A2A-Extensions` response header was never
-    // populated. `aliasHeldByTransport` simulates that retained reference —
-    // it MUST observe both the narrowed requested set and any subsequent
-    // activations.
+    // instance after narrowing requested extensions (§4.6.3 "SHOULD
+    // ignore"). The Express / gRPC transport layer held a reference to
+    // the original, so `addActivatedExtension(...)` calls from the
+    // executor landed on an orphaned object and the response-side
+    // `A2A-Extensions` echo emitted nothing. `aliasHeldByTransport` simulates that retained
+    // reference — it MUST observe both the narrowed requested set and
+    // any subsequent activations.
     const ctx = new ServerCallContext({
       requestedExtensions: ['ext-a', 'ext-b', 'ext-c'],
       tenant: 't1',

--- a/test/server/context.spec.ts
+++ b/test/server/context.spec.ts
@@ -28,4 +28,13 @@ describe('ServerCallContext.setRequestedExtensions', () => {
     expect(aliasHeldByTransport.tenant).toBe('t1');
     expect(aliasHeldByTransport.requestedVersion).toBe('1.0');
   });
+
+  it('accepts `undefined` to reset the requested set back to its initial unset state', () => {
+    // `_requestedExtensions` is `Extensions | undefined`, so the setter
+    // must accept `undefined` — otherwise a caller can never restore
+    // the field to its "no header was sent" state.
+    const ctx = new ServerCallContext({ requestedExtensions: ['ext-a'] });
+    ctx.setRequestedExtensions(undefined);
+    expect(ctx.requestedExtensions).toBeUndefined();
+  });
 });

--- a/test/server/context.spec.ts
+++ b/test/server/context.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+import { ServerCallContext } from '../../src/server/context.js';
+
+describe('ServerCallContext.setRequestedExtensions', () => {
+  it('mutates the existing instance so an alias held elsewhere observes later activations', () => {
+    // Regression guard for the §3.3.4 / §14.2.2 echo bug:
+    // `_createRequestContext` previously replaced the context with a fresh
+    // instance after filtering requested extensions. The Express / gRPC
+    // transport layer held a reference to the original, so
+    // `addActivatedExtension(...)` calls from the executor landed on an
+    // orphaned object and the `A2A-Extensions` response header was never
+    // populated. `aliasHeldByTransport` simulates that retained reference —
+    // it MUST observe both the narrowed requested set and any subsequent
+    // activations.
+    const ctx = new ServerCallContext({
+      requestedExtensions: ['ext-a', 'ext-b', 'ext-c'],
+      tenant: 't1',
+      requestedVersion: '1.0',
+    });
+    const aliasHeldByTransport = ctx;
+
+    ctx.setRequestedExtensions(['ext-a', 'ext-c']);
+    ctx.addActivatedExtension('ext-a');
+
+    expect(aliasHeldByTransport.requestedExtensions).toEqual(['ext-a', 'ext-c']);
+    expect(aliasHeldByTransport.activatedExtensions).toEqual(['ext-a']);
+    expect(aliasHeldByTransport.tenant).toBe('t1');
+    expect(aliasHeldByTransport.requestedVersion).toBe('1.0');
+  });
+});

--- a/test/server/express/extensions_echo.spec.ts
+++ b/test/server/express/extensions_echo.spec.ts
@@ -1,0 +1,217 @@
+import { describe, it, beforeEach, expect } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+
+import { jsonErrorHandler, jsonRpcHandler } from '../../../src/server/express/json_rpc_handler.js';
+import { UserBuilder } from '../../../src/server/express/common.js';
+import { DefaultRequestHandler, InMemoryTaskStore, TaskStore } from '../../../src/server/index.js';
+import { AgentCard, Role } from '../../../src/index.js';
+import { TaskState } from '../../../src/types/pb/a2a.js';
+import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
+import { AgentEvent } from '../../../src/server/events/execution_event_bus.js';
+import { RequestContext } from '../../../src/server/agent_execution/request_context.js';
+import { ExecutionEventBus } from '../../../src/server/events/execution_event_bus.js';
+import { AgentExecutor } from '../../../src/server/agent_execution/agent_executor.js';
+import { HTTP_EXTENSION_HEADER } from '../../../src/constants.js';
+
+/**
+ * End-to-end regression guard for §3.3.4 / §14.2.2 `A2A-Extensions`
+ * response-header echo: client declares `A2A-Extensions: <uri>`, executor
+ * calls `addActivatedExtension(<uri>)`, response header MUST contain
+ * `<uri>`.
+ *
+ * Pre-fix `_createRequestContext` replaced the `ServerCallContext` with
+ * a fresh instance after filtering requested extensions to the agent's
+ * exposed set. The Express transport layer held a reference to the
+ * *original* context and read `activatedExtensions` off it after
+ * dispatch — so executor mutations landed on the orphaned object and
+ * the header was never populated. This test reproduces the full path
+ * (express → jsonRpcHandler → DefaultRequestHandler → executor →
+ * response) without stubbing the transport, which is what the existing
+ * `express_app.spec.ts` "should handle extensions headers in response"
+ * test does (it spies on `JsonRpcTransportHandler.handle`, bypassing
+ * `_createRequestContext` entirely).
+ */
+describe('A2A-Extensions response header (end-to-end §3.3.4 / §14.2.2)', () => {
+  let app: Express;
+  let executor: AgentExecutor;
+  let observedContextExtensions: string[] | undefined;
+
+  const ECHOED_EXT = 'https://example.test/ext/echo';
+  const SILENT_EXT = 'https://example.test/ext/silent';
+  const UNKNOWN_EXT = 'https://example.test/ext/unknown';
+  // Activated by the executor — narrower than `requested`. Tests must
+  // distinguish `requested`, `exposed`, and `activated`; if all three
+  // overlap, a buggy implementation that echoes the wrong set passes.
+  let extensionsToActivate: string[] = [];
+
+  const agentCard: AgentCard = {
+    name: 'Extension Echo Agent',
+    description: 'Agent that exposes the echo extension.',
+    version: '1.0.0',
+    provider: undefined,
+    documentationUrl: '',
+    supportedInterfaces: [
+      {
+        url: 'http://localhost/a2a',
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+    ],
+    capabilities: {
+      extensions: [
+        { uri: ECHOED_EXT, required: false, description: '', params: {} },
+        { uri: SILENT_EXT, required: false, description: '', params: {} },
+      ],
+      streaming: false,
+      pushNotifications: false,
+    },
+    securitySchemes: {},
+    securityRequirements: [],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    signatures: [],
+  };
+
+  beforeEach(() => {
+    const taskStore: TaskStore = new InMemoryTaskStore();
+    observedContextExtensions = undefined;
+
+    executor = {
+      execute: async (ctx: RequestContext, bus: ExecutionEventBus) => {
+        observedContextExtensions = ctx.context.requestedExtensions
+          ? [...ctx.context.requestedExtensions]
+          : [];
+        // Activate only the URIs the test asked for — independent of
+        // what was requested. This is what lets the response-header
+        // assertion distinguish `activated` from `requested` /
+        // `exposed`.
+        for (const uri of extensionsToActivate) {
+          ctx.context.addActivatedExtension(uri);
+        }
+        bus.publish(
+          AgentEvent.task({
+            id: ctx.taskId,
+            contextId: ctx.contextId,
+            status: {
+              state: TaskState.TASK_STATE_COMPLETED,
+              message: undefined,
+              timestamp: undefined,
+            },
+            artifacts: [],
+            history: [],
+            metadata: {},
+          })
+        );
+        bus.finished();
+      },
+      cancelTask: async () => {},
+    };
+
+    const handler = new DefaultRequestHandler(
+      agentCard,
+      taskStore,
+      executor,
+      new DefaultExecutionEventBusManager()
+    );
+
+    app = express();
+    const router = express.Router();
+    router.use(express.json(), jsonErrorHandler);
+    router.use(
+      jsonRpcHandler({ requestHandler: handler, userBuilder: UserBuilder.noAuthentication })
+    );
+    app.use(router);
+  });
+
+  it('echoes only the activated subset, not the requested set or the exposed set', async () => {
+    // Client requests two extensions both exposed by the agent, but the
+    // executor activates only one. The response header MUST contain only
+    // the activated one — proving the header reflects `activated`, not
+    // `requested` and not the agent's exposed list.
+    extensionsToActivate = [ECHOED_EXT];
+
+    const response = await request(app)
+      .post('/')
+      .set('A2A-Version', '1.0')
+      .set(HTTP_EXTENSION_HEADER, `${ECHOED_EXT}, ${SILENT_EXT}`)
+      .send({
+        jsonrpc: '2.0',
+        id: 'req-1',
+        method: 'SendMessage',
+        params: {
+          message: {
+            messageId: 'm1',
+            role: Role.ROLE_USER,
+            parts: [{ text: 'hi' }],
+          },
+        },
+      })
+      .expect(200);
+
+    expect(observedContextExtensions).toEqual([ECHOED_EXT, SILENT_EXT]);
+    expect(response.get(HTTP_EXTENSION_HEADER)).toBe(ECHOED_EXT);
+  });
+
+  it('omits the response header entirely when the executor activates nothing', async () => {
+    // Spec §14.2.2: server only emits the header when at least one
+    // extension was activated. A client-requested-but-not-activated
+    // extension must not appear.
+    extensionsToActivate = [];
+
+    const response = await request(app)
+      .post('/')
+      .set('A2A-Version', '1.0')
+      .set(HTTP_EXTENSION_HEADER, ECHOED_EXT)
+      .send({
+        jsonrpc: '2.0',
+        id: 'req-noop',
+        method: 'SendMessage',
+        params: {
+          message: {
+            messageId: 'm-noop',
+            role: Role.ROLE_USER,
+            parts: [{ text: 'hi' }],
+          },
+        },
+      })
+      .expect(200);
+
+    expect(response.get(HTTP_EXTENSION_HEADER)).toBeUndefined();
+  });
+
+  it('drops extensions the agent does not expose before passing the context to the executor (§3.3.4)', async () => {
+    extensionsToActivate = [ECHOED_EXT, UNKNOWN_EXT];
+
+    const response = await request(app)
+      .post('/')
+      .set('A2A-Version', '1.0')
+      .set(HTTP_EXTENSION_HEADER, `${ECHOED_EXT}, ${UNKNOWN_EXT}`)
+      .send({
+        jsonrpc: '2.0',
+        id: 'req-2',
+        method: 'SendMessage',
+        params: {
+          message: {
+            messageId: 'm2',
+            role: Role.ROLE_USER,
+            parts: [{ text: 'hi' }],
+          },
+        },
+      })
+      .expect(200);
+
+    // §3.3.4: unknown extensions never reach the executor.
+    expect(observedContextExtensions).toEqual([ECHOED_EXT]);
+    // Even though the executor tried to activate `UNKNOWN_EXT`, the
+    // header echoes everything it activated (the SDK does not re-filter
+    // on the activation path — addActivatedExtension is unguarded).
+    // The §3.3.4 protection lives at the requested-set filter, not the
+    // activation set. This assertion documents that contract so a
+    // future tightening (filtering activations too) is a deliberate
+    // change with a failing test.
+    expect(response.get(HTTP_EXTENSION_HEADER)).toBe(`${ECHOED_EXT}, ${UNKNOWN_EXT}`);
+  });
+});

--- a/test/server/express/extensions_echo.spec.ts
+++ b/test/server/express/extensions_echo.spec.ts
@@ -106,7 +106,7 @@ describe('A2A-Extensions response header (end-to-end echo)', () => {
         );
         bus.finished();
       },
-      cancelTask: async () => { },
+      cancelTask: async () => {},
     };
 
     const handler = new DefaultRequestHandler(

--- a/test/server/express/extensions_echo.spec.ts
+++ b/test/server/express/extensions_echo.spec.ts
@@ -15,10 +15,9 @@ import { AgentExecutor } from '../../../src/server/agent_execution/agent_executo
 import { HTTP_EXTENSION_HEADER } from '../../../src/constants.js';
 
 /**
- * End-to-end regression guard for §3.3.4 / §14.2.2 `A2A-Extensions`
- * response-header echo: client declares `A2A-Extensions: <uri>`, executor
- * calls `addActivatedExtension(<uri>)`, response header MUST contain
- * `<uri>`.
+ * End-to-end regression guard for the `A2A-Extensions` response-header
+ * echo: client declares `A2A-Extensions: <uri>`, executor calls
+ * `addActivatedExtension(<uri>)`, response header contains `<uri>`.
  *
  * Pre-fix `_createRequestContext` replaced the `ServerCallContext` with
  * a fresh instance after filtering requested extensions to the agent's
@@ -32,7 +31,7 @@ import { HTTP_EXTENSION_HEADER } from '../../../src/constants.js';
  * test does (it spies on `JsonRpcTransportHandler.handle`, bypassing
  * `_createRequestContext` entirely).
  */
-describe('A2A-Extensions response header (end-to-end §3.3.4 / §14.2.2)', () => {
+describe('A2A-Extensions response header (end-to-end echo)', () => {
   let app: Express;
   let executor: AgentExecutor;
   let observedContextExtensions: string[] | undefined;
@@ -107,7 +106,7 @@ describe('A2A-Extensions response header (end-to-end §3.3.4 / §14.2.2)', () =>
         );
         bus.finished();
       },
-      cancelTask: async () => {},
+      cancelTask: async () => { },
     };
 
     const handler = new DefaultRequestHandler(
@@ -156,9 +155,7 @@ describe('A2A-Extensions response header (end-to-end §3.3.4 / §14.2.2)', () =>
   });
 
   it('omits the response header entirely when the executor activates nothing', async () => {
-    // Spec §14.2.2: server only emits the header when at least one
-    // extension was activated. A client-requested-but-not-activated
-    // extension must not appear.
+    // Emit the response header only when at least one extension was actually activated.
     extensionsToActivate = [];
 
     const response = await request(app)
@@ -182,7 +179,7 @@ describe('A2A-Extensions response header (end-to-end §3.3.4 / §14.2.2)', () =>
     expect(response.get(HTTP_EXTENSION_HEADER)).toBeUndefined();
   });
 
-  it('drops extensions the agent does not expose before passing the context to the executor (§3.3.4)', async () => {
+  it('drops extensions the agent does not expose before passing the context to the executor (§4.6.3)', async () => {
     extensionsToActivate = [ECHOED_EXT, UNKNOWN_EXT];
 
     const response = await request(app)
@@ -203,15 +200,16 @@ describe('A2A-Extensions response header (end-to-end §3.3.4 / §14.2.2)', () =>
       })
       .expect(200);
 
-    // §3.3.4: unknown extensions never reach the executor.
+    // §4.6.3 ("SHOULD ignore the extension … and proceed without it"):
+    // unknown extensions never reach the executor via the requested set.
     expect(observedContextExtensions).toEqual([ECHOED_EXT]);
-    // Even though the executor tried to activate `UNKNOWN_EXT`, the
-    // header echoes everything it activated (the SDK does not re-filter
-    // on the activation path — addActivatedExtension is unguarded).
-    // The §3.3.4 protection lives at the requested-set filter, not the
+    // The SDK does not re-filter on the activation path —
+    // `addActivatedExtension` is unguarded and accepts any URI. The
+    // §4.6.3 filter lives at the requested-set narrowing, not the
     // activation set. This assertion documents that contract so a
-    // future tightening (filtering activations too) is a deliberate
-    // change with a failing test.
+    // future tightening (rejecting activations outside the requested
+    // set) is a deliberate change with a failing test, not a silent
+    // behavior shift.
     expect(response.get(HTTP_EXTENSION_HEADER)).toBe(`${ECHOED_EXT}, ${UNKNOWN_EXT}`);
   });
 });


### PR DESCRIPTION
# Description

## What

`ServerCallContext` exposes a `setRequestedExtensions(...)` mutator;
`_createRequestContext` mutates the existing context in-place instead of
replacing it with a fresh instance.

## Why

Express handlers hold a reference to the original context. When
`_createRequestContext` replaced it with a fresh one, executor mutations to
`_activatedExtensions` landed on an orphaned object. The `A2A-Extensions`
response header was therefore never populated, breaking the entire extension
echo contract.

Fixes #538  🦕
