### PR TITLE
feat: export SSE wire-format helpers from public entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,3 +25,11 @@ export {
 } from './signature.js';
 
 export type SendMessageResult = Message | Task;
+
+export {
+  SSE_HEADERS,
+  formatSSEEvent,
+  formatSSEErrorEvent,
+  parseSseStream,
+  type SseEvent,
+} from './sse_utils.js';


### PR DESCRIPTION
## Summary

`SSE_HEADERS`, `formatSSEEvent`, `formatSSEErrorEvent`, `parseSseStream`, and `SseEvent` were already defined, documented, and tested in `sse_utils.ts` — but not re-exported from `src/index.ts`. This forces anyone building a custom A2A adapter to inline these helpers rather than import them.

This PR adds a single re-export block to `src/index.ts`. No logic changes, no new tests needed.

## Changes

**`src/index.ts`**
```ts
export {
  SSE_HEADERS,
  formatSSEEvent,
  formatSSEErrorEvent,
  parseSseStream,
  type SseEvent,
} from './sse_utils.js';
```

## Testing

`npm run build` passes cleanly — ESM, CJS, and DTS all succeed.

## Related

Closes #547