### PR TITLE
docs: ducumentation update for 1.0 stable release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,29 +23,36 @@ compatibility layer for v0.3 peers (see section 5 below).
 The project is structured into modular entry points to allow tree-shaking and separation of concerns.
 
 ### 1. Common (`src/index.ts`)
-*   **Types**: Core protocol types (`Message`, `Task`, `AgentCard`).
-*   **Constants**: Protocol constants like `AGENT_CARD_PATH`.
-*   **Errors**: Common error classes (`A2AError`).
+*   **Types**: Core protocol types (`Message`, `Task`, `AgentCard`, `Part`) generated from protobuf.
+*   **Constants**: Protocol constants (`AGENT_CARD_PATH`, `A2A_VERSION_HEADER`, `A2A_PROTOCOL_VERSION`, `A2A_CONTENT_TYPE`).
+*   **Signing**: `generateAgentCardSignature`, `verifyAgentCardSignature`, `canonicalizeAgentCard`.
 
 ### 2. Client (`src/client/index.ts`)
-*   **`ClientFactory`**: The main entry point for creating clients. Can create clients from a base URL or an `AgentCard`.
-*   **`A2AClient`**: The interface for sending messages and streams.
-*   **Transports**:
-    *   `JsonRpcTransport`: Uses JSON-RPC over HTTP.
-    *   `RestTransport`: Uses standard HTTP+JSON REST patterns.
-*   **Interceptors**: `CallInterceptor` for modifying requests/responses (e.g., adding auth headers).
-*   **Auth**: `AuthenticationHandler` and `createAuthenticatingFetchWithRetry` for handling token refresh logic.
+*   **`ClientFactory`**: The main entry point. `createFromUrl(baseUrl, path?)` fetches the agent card; `createFromAgentCard(card)` works from an in-memory card.
+*   **`Client`**: Transport-agnostic API (`sendMessage`, `sendMessageStream`, `getTask`, `cancelTask`, `listTasks`, `createTaskPushNotificationConfig`, …).
+*   **Transport factories**:
+    *   `JsonRpcTransportFactory`: JSON-RPC over HTTP (Workers-safe).
+    *   `RestTransportFactory`: HTTP+JSON/REST per spec §11.3 (Workers-safe).
+    *   `GrpcTransportFactory` (from `@a2a-js/sdk/client/grpc`): Node only.
+*   **`CallInterceptor`**: `before` / `after` hooks for header injection, metrics, A2A extensions.
+*   **Auth**: `AuthenticationHandler` and `createAuthenticatingFetchWithRetry` for token refresh + 401/403 retry.
+*   **`DefaultAgentCardResolver`**: Stand-alone card fetcher/parser; pass into `ClientFactoryOptions` (e.g. with `legacyCompat: { enabled: true }`).
 
 ### 3. Server (`src/server/index.ts`)
-*   **`AgentExecutor`**: The core interface you implement to define your agent's logic (`execute`, `cancelTask`).
-*   **`DefaultRequestHandler`**: Orchestrates request processing, task management, and event dispatching.
-*   **`ExecutionEventBus`**: Used within `AgentExecutor` to publish `Message`, `Task`, and `Artifact` updates.
-*   **`InMemoryTaskStore`**: Default in-memory storage for task state.
-*   **Push Notifications**: `PushNotificationSender` and `InMemoryPushNotificationStore` for async updates.
+*   **`AgentExecutor`**: The core interface you implement (`execute`, `cancelTask`).
+*   **`DefaultRequestHandler`**: Orchestrates request routing, task storage, version validation, cancellation, push notifications.
+*   **`ExecutionEventBus`**: Used inside `AgentExecutor` to publish events; wrap each event with `AgentEvent.message(...)` / `AgentEvent.task(...)` / `AgentEvent.statusUpdate(...)` / `AgentEvent.artifactUpdate(...)`.
+*   **`InMemoryTaskStore`**: Default tenant-scoped task store. Implements `list()` for `ListTasks`.
+*   **Push Notifications**: `PushNotificationSender`, `InMemoryPushNotificationStore`, `V1PushNotificationSerializer`, `DefaultPushNotificationSender`.
+*   **Errors**: `TaskNotFoundError`, `RequestMalformedError`, `VersionNotSupportedError`, `UnsupportedOperationError`, `PushNotificationNotSupportedError`, etc.
+*   **Version**: `validateVersion`, `getSupportedVersions`.
 
 ### 4. Server Express Integration (`src/server/express/index.ts`)
-*   **Handlers**: `agentCardHandler`, `jsonRpcHandler`, `restHandler` to easily mount A2A endpoints in an Express app.
-*   **`UserBuilder`**: Middleware for extracting user identity from requests.
+*   **Handlers**: `agentCardHandler`, `jsonRpcHandler`, `restHandler` for mounting A2A endpoints. All three accept a `legacyCompat: { enabled: boolean }` option.
+*   **`UserBuilder`**: Middleware-friendly callback for extracting user identity from requests.
+
+### 4b. Server gRPC Integration (`src/server/grpc/index.ts`)
+*   **`grpcService`** + **`A2AService`** descriptor for `grpc.Server.addService(...)`.
 
 ### 5. v0.3 Backward Compatibility (`src/compat/v0_3/`)
 The compat layer is shipped as six subpath exports off `@a2a-js/sdk`, mirroring the v1.0 layout (`server` is framework-agnostic; `server/express` and `server/grpc` carry the runtime-specific bits):
@@ -72,14 +79,21 @@ The bidirectional v0.3 ↔ v1.0 translators in `./translate/` are intentionally 
 
 ## Samples
 
-The `src/samples` directory contains practical examples:
+The `src/samples` directory contains practical examples. Each subdirectory has its own `README.md` with run instructions.
 
 *   **`agents/`**:
-    *   `movie-agent/`: A sample agent that queries movie data from TMDB.
-    *   `sample-agent/`: A basic reference agent implementation.
-*   **`authentication/`**: Examples of how to implement authentication middleware and user building.
-*   **`extensions/`**: Examples of using protocol extensions.
-*   **`cli.ts`**: A CLI tool example for interacting with agents.
+    *   `sample-agent/`: Minimal streaming agent over JSON-RPC.
+    *   `movie-agent/`: A realistic agent backed by Genkit + the TMDB API.
+    *   `multi-transport-agent/`: One agent exposed over JSON-RPC, REST, and gRPC simultaneously from a single `DefaultRequestHandler`.
+    *   `cancellable-agent/`: Implements `cancelTask` so a client can abort an in-flight task.
+    *   `push-notification-agent/`: Long-running agent that POSTs events to a client-provided webhook (server + webhook receiver + client).
+    *   `verify-signing/`: Client-side verification of signed agent cards (JWS + JWKS).
+    *   `compat-v1-server/`: v1.0-native server with `legacyCompat: { enabled: true }` on every transport.
+    *   `compat-v1-client/`: v1.0-native client driving both the compat-aware server above and an in-process mock v0.3 server.
+*   **`authentication/`**: Bearer/JWT authentication with Passport, including a `UserBuilder` that propagates the authenticated user into the agent context.
+*   **`extensions/`**: Protocol extension implemented as an `AgentExecutor` decorator that stamps metadata onto outgoing events.
+*   **`client/interceptors/`**: Client `CallInterceptor`s for header injection and request timing, plus per-call `AbortSignal.timeout(...)`.
+*   **`cli.ts`**: Multi-transport interactive CLI client (JSON-RPC / REST / gRPC) with optional Google ADC authentication.
 
 ## Development Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # A2A JavaScript SDK
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![npm](https://img.shields.io/npm/v/@a2a-js/sdk.svg)](https://www.npmjs.com/package/@a2a-js/sdk)
 
 <!-- markdownlint-disable no-inline-html -->
 
@@ -13,15 +14,25 @@
 
 <!-- markdownlint-enable no-inline-html -->
 
+`@a2a-js/sdk` is the official TypeScript / JavaScript SDK for the A2A
+Protocol. Use it to build A2A **servers** (agents exposing their capabilities
+over the protocol) and A2A **clients** (applications discovering and driving
+those agents) — one package, three wire transports (JSON-RPC,
+HTTP+JSON/REST, gRPC), and an opt-in compatibility layer for v0.3 peers.
+
+- 🚀 **Stable 1.0 release** tracking [A2A Protocol Specification v1.0](https://a2a-protocol.org/v1.0.0/specification/).
+- 🔌 **Three transports** — JSON-RPC, HTTP+JSON/REST, and gRPC (Node-only),
+  all backed by a single `DefaultRequestHandler`.
+- 🔄 **v0.3 backward compatibility** as an opt-in layer so v1.0 deployments
+  can interoperate with peers still on v0.3 during a staged migration.
+
 ## Installation
 
-You can install the latest `next` release of the A2A SDK using `npm`.
+You can install the A2A SDK using `npm`.
 
 ```bash
-npm install @a2a-js/sdk@next
+npm install @a2a-js/sdk
 ```
-
-Note that this is a `next` release. To install the latest stable release, use `npm install @a2a-js/sdk`.
 
 ### For Server Usage
 
@@ -51,6 +62,9 @@ This SDK implements the A2A Protocol Specification [`v1.0.0`](https://a2a-protoc
 | **HTTP+JSON/REST**      |   ✅   |   ✅   |
 | **GRPC** (Node.js only) |   ✅   |   ✅   |
 
+Upgrading from `0.3.x`? Read the
+[v0.3 → v1.0 migration guide](docs/migration-guide.md).
+
 ## Documentation
 
 **A2A Protocol Specification (v1.0.0):** <https://a2a-protocol.org/v1.0.0/specification/>
@@ -59,6 +73,11 @@ The protocol specification is the source of truth for message formats, task
 lifecycle states, transport bindings, push notifications, extensions, and
 authentication. This SDK provides a TypeScript implementation of that surface;
 when in doubt about behavior, consult the specification.
+
+SDK-specific guides live under [`docs/`](docs/):
+
+- [Migration guide (`v0.3` → `v1.0`)](docs/migration-guide.md)
+- [v0.3 compatibility guide](docs/compatibility-v0_3.md)
 
 ## Samples
 
@@ -240,10 +259,13 @@ compat surface is shipped as six subpath exports off `@a2a-js/sdk`:
 | `@a2a-js/sdk/compat/v0_3/client`         | `LegacyJsonRpcTransport`, `LegacyRestTransport`, and the `isLegacyAgentCard` / `parseLegacyAgentCard` helpers. Workers-safe.                                                                                                  |
 | `@a2a-js/sdk/compat/v0_3/client/grpc`    | `LegacyGrpcTransport`, instantiated by the v1.0 `GrpcTransportFactory` when the matched `AgentInterface.protocolVersion` falls in `[0.3, 1.0)`.                                                                               |
 
-See [`src/compat/v0_3/README.md`](src/compat/v0_3/README.md) for the full
-compat-layer architecture (version negotiation under §3.6.2, push-notification
-wire-version routing, agent-card synthesis, translator policy decisions) and
-the [`compat-v1-server`](src/samples/agents/compat-v1-server/) /
+See the end-user [v0.3 compatibility guide](docs/compatibility-v0_3.md) for
+opt-in mechanics and caveats (dropped fields, defaults, unavailable
+methods like `ListTasks`, push-notification routing, agent-card synthesis).
+For the architecture-level walkthrough — translators, version negotiation
+under §3.6.2, push-notification wire-version routing — see
+[`src/compat/v0_3/README.md`](src/compat/v0_3/README.md), and the
+[`compat-v1-server`](src/samples/agents/compat-v1-server/) /
 [`compat-v1-client`](src/samples/agents/compat-v1-client/) samples for an
 end-to-end demonstration across every transport.
 

--- a/docs/compatibility-v0_3.md
+++ b/docs/compatibility-v0_3.md
@@ -1,0 +1,351 @@
+# v0.3 Compatibility Guide
+
+`@a2a-js/sdk` 1.0 implements the **A2A Protocol Specification v1.0**, but
+ships an opt-in compatibility layer so that v1.0 deployments can interoperate
+with peers still on v0.3. The compat layer is the migration bridge: it lets
+operators deploy v1.0 on either side of the wire ahead of the other side,
+without forcing every client (or every server) to upgrade in lockstep.
+
+This guide is written for **end users** of the SDK — server operators
+deciding whether to turn the compat layer on, and client developers who need
+to talk to peers that haven't migrated yet. For the architecture-level
+walkthrough (translators, version negotiation internals, card synthesis
+algorithm), see [`src/compat/v0_3/README.md`](../src/compat/v0_3/README.md).
+For the protocol-level definition of v0.3 vs. v1.0 differences, see
+[Appendix A: Migration Guidance](https://a2a-protocol.org/v1.0.0/specification/#appendix-a-migration-legacy-compatibility)
+in the spec.
+
+## When to enable it
+
+Turn `legacyCompat: { enabled: true }` on when **any of these** is true:
+
+- You run a v1.0 server and need to keep accepting v0.3 clients during a
+  staged client migration.
+- You write a v1.0 client and one or more of the agents it talks to still
+  advertises v0.3 in its agent card.
+- You're rolling out v1.0 across a fleet and want a single deployable artefact
+  that handles both versions, instead of running parallel binaries.
+
+Leave it off when:
+
+- Every peer you talk to already speaks v1.0 (which keeps the v0.3 codepaths
+  out of your dependency graph and out of your test matrix).
+- You're building a brand-new v0.3-only system. The compat layer exists to
+  teach v1.0 components how to **tolerate** v0.3 traffic; it is **not** a
+  framework for building new v0.3 servers from scratch. (Build those against
+  the [v0.3 spec](https://a2a-protocol.org/v0.3.0/specification/) directly.)
+
+The opt-in is **per handler and per transport factory** — there's no
+project-level switch. You can, for example, opt a JSON-RPC server in while
+leaving REST strict.
+
+## Published entry points
+
+The compat layer is split into six subpath exports so each one carries only
+the peer dependencies (`express`, `@grpc/grpc-js`) its runtime actually needs.
+A Workers consumer that only needs the compat-aware JSON-RPC client transport
+never pulls in Node-only modules.
+
+| Subpath                                  | Use it for                                                                                                                              | Peer deps           |
+| :--------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------- | :------------------ |
+| `@a2a-js/sdk/compat/v0_3`                | v0.3 protocol constants and method-name translators.                                                                                    | none (Workers-safe) |
+| `@a2a-js/sdk/compat/v0_3/server`         | Framework-agnostic `LegacyJsonRpcTransportHandler`, `LegacyRestTransportHandler`, `createLegacyAwarePushNotificationSender`, serializer. | none (Workers-safe) |
+| `@a2a-js/sdk/compat/v0_3/server/express` | Express routers (`legacyAgentCardRouter`, `legacyRestRouter`).                                                                          | `express`           |
+| `@a2a-js/sdk/compat/v0_3/server/grpc`    | `legacyGrpcService` + `LegacyA2AService` descriptor.                                                                                    | `@grpc/grpc-js`     |
+| `@a2a-js/sdk/compat/v0_3/client`         | `LegacyJsonRpcTransport`, `LegacyRestTransport`, plus `isLegacyAgentCard` / `parseLegacyAgentCard`.                                     | none (Workers-safe) |
+| `@a2a-js/sdk/compat/v0_3/client/grpc`    | `LegacyGrpcTransport` (Node only; lazy-loaded by `GrpcTransportFactory`).                                                               | `@grpc/grpc-js`     |
+
+The bidirectional v0.3 ↔ v1.0 translators in `src/compat/v0_3/translate/` are
+intentionally internal and may change without a major-version bump.
+
+---
+
+## Server side: accepting v0.3 traffic on a v1.0 server
+
+The v1.0 server handlers all expose a `legacyCompat` option. Set
+`{ enabled: true }` on each handler whose transport should also accept
+v0.3 traffic; the rest stay strict v1.0.
+
+```ts
+import express from 'express';
+import { Server, ServerCredentials } from '@grpc/grpc-js';
+
+import {
+  AGENT_CARD_PATH,
+  DefaultRequestHandler,
+  InMemoryPushNotificationStore,
+  InMemoryTaskStore,
+} from '@a2a-js/sdk/server';
+import {
+  agentCardHandler,
+  jsonRpcHandler,
+  restHandler,
+  UserBuilder,
+} from '@a2a-js/sdk/server/express';
+import { A2AService, grpcService } from '@a2a-js/sdk/server/grpc';
+import { LegacyA2AService, legacyGrpcService } from '@a2a-js/sdk/compat/v0_3/server/grpc';
+import { createLegacyAwarePushNotificationSender } from '@a2a-js/sdk/compat/v0_3/server';
+
+// One push-notification sender pre-loaded with both v1.0 and v0.3 serializers.
+const pushStore = new InMemoryPushNotificationStore();
+const pushSender = createLegacyAwarePushNotificationSender(pushStore);
+
+const requestHandler = new DefaultRequestHandler(
+  agentCard,             // declared with v1.0 supportedInterfaces only — see below
+  new InMemoryTaskStore(),
+  myAgentExecutor,
+  undefined,             // event bus manager (default)
+  pushStore,
+  pushSender
+);
+
+const app = express();
+
+// Card: serves a v1.0 card to v1.0 clients, a hybrid card (v0.3 top-level
+// fields + embedded supportedInterfaces[]) to v0.3 clients. `Vary: A2A-Version`
+// keeps shared HTTP caches honest.
+app.use(`/${AGENT_CARD_PATH}`,
+  agentCardHandler({ agentCardProvider: requestHandler, legacyCompat: { enabled: true } })
+);
+
+// JSON-RPC: routes by body shape on a single endpoint.
+app.use('/a2a/jsonrpc',
+  jsonRpcHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication, legacyCompat: { enabled: true } })
+);
+
+// REST: mounts the v0.3 `/v1/...` routes alongside the v1.0 `/<operation>` routes.
+app.use('/a2a/rest',
+  restHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication, legacyCompat: { enabled: true } })
+);
+
+// gRPC: register both services on the same Server. The v1.0 gRPC factory
+// has no legacyCompat flag — the canonical way to serve v0.3 gRPC clients is
+// to bind `legacyGrpcService` next to `grpcService`.
+const grpcServer = new Server();
+grpcServer.addService(A2AService, grpcService({ requestHandler, userBuilder: UserBuilder.noAuthentication }));
+grpcServer.addService(LegacyA2AService, legacyGrpcService({ requestHandler, userBuilder: UserBuilder.noAuthentication }));
+```
+
+The runnable end-to-end version is the
+[`compat-v1-server`](../src/samples/agents/compat-v1-server/) sample.
+
+### How requests get routed
+
+Once a handler is opted in, the routing is automatic — your `AgentExecutor`
+never sees a v0.3 type. The compat layer translates incoming v0.3 wire bodies
+into v1.0 proto types on the way in, and translates the v1.0 events your
+executor publishes back into v0.3 shapes on the way out.
+
+| Transport     | How v0.3 is detected                                                                                                                                                                                              |
+| :------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| JSON-RPC      | The handler inspects the JSON-RPC `method` name. Kebab-style names (`message/send`, `tasks/get`, …) route to the v0.3 dispatcher; PascalCase names (`SendMessage`, `GetTask`, …) route to the v1.0 dispatcher. See the method-name translation table below. |
+| REST          | The v0.3 routes live under the `/v1/...` prefix (per the v0.3 reference proto's `google.api.http` annotations). v1.0 routes use `/<operation>` directly. Express's prefix matcher disambiguates without ambiguity. |
+| gRPC          | Each version is a separate gRPC service descriptor (`A2AService` vs. `LegacyA2AService`). The transport picks the descriptor; the SDK never needs to sniff.                                                       |
+| Agent card    | The handler reads the `A2A-Version` header (defaulting to `'0.3'` when absent, per spec §3.6.2) and emits the appropriate card shape, with `Vary: A2A-Version` set on the response.                                |
+
+### Synthesized v0.3 agent card
+
+When `legacyCompat` is enabled on `agentCardHandler`, you don't need to
+duplicate every entry of `supportedInterfaces` with a v0.3 stub. The compat
+layer:
+
+1. Reads `validateVersion` with `{ legacyCompat: true }`, which adds the
+   legacy `'0.3'` version to the supported set for any binding the card
+   already exposes at least one interface for. v0.3 (and header-less)
+   requests therefore route through the legacy handler chain even when the
+   card declares only v1.0 interfaces.
+2. Synthesizes a v0.3-shaped card on the well-known endpoint by setting
+   `protocolVersion: '0.3'` on the same interface URLs the v1.0 card
+   advertises. v0.3 clients can discover and use the agent transparently.
+
+The card returned to a v0.3 client is a *hybrid*: it carries the v0.3
+top-level fields (`url`, `preferredTransport`, `additionalInterfaces`) AND
+keeps the v1.0 `supportedInterfaces[]` array embedded. A modern client that
+encounters the hybrid card prefers `supportedInterfaces[]`, which prevents
+unnecessary downgrades — see the `compat-v1-client` sample for the receiver
+logic.
+
+---
+
+## Client side: talking to v0.3 servers from a v1.0 client
+
+The client uses the same `legacyCompat: { enabled: true }` flag, set on each
+transport factory and on the card resolver:
+
+```ts
+import {
+  ClientFactory,
+  ClientFactoryOptions,
+  DefaultAgentCardResolver,
+  JsonRpcTransportFactory,
+  RestTransportFactory,
+} from '@a2a-js/sdk/client';
+import { GrpcTransportFactory } from '@a2a-js/sdk/client/grpc';
+
+const factory = new ClientFactory(
+  ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
+    cardResolver: new DefaultAgentCardResolver({ legacyCompat: { enabled: true } }),
+    transports: [
+      new JsonRpcTransportFactory({ legacyCompat: { enabled: true } }),
+      new RestTransportFactory({ legacyCompat: { enabled: true } }),
+      new GrpcTransportFactory({ legacyCompat: { enabled: true } }),
+    ],
+  })
+);
+
+// Just works against either a v1.0 or a v0.3 server.
+const client = await factory.createFromUrl(serverUrl);
+```
+
+With those flags set:
+
+- `DefaultAgentCardResolver` inspects every fetched card. A pure v0.3 card
+  (top-level `url`, no `supportedInterfaces[]`, or a `protocolVersion` in
+  `[0.3, 1.0)`) is translated to a v1.0 representation with
+  `protocolVersion: '0.3'` stamped on each synthesized `AgentInterface`. A
+  hybrid card (v0.3 top-level fields **and** v1.0 `supportedInterfaces[]`) is
+  treated as v1.0.
+- Each transport factory's `create()` looks at the matched interface's
+  `protocolVersion`. If it falls in `[0.3, 1.0)`, the factory instantiates
+  the v0.3 compat transport (`LegacyJsonRpcTransport`, `LegacyRestTransport`,
+  or `LegacyGrpcTransport`) instead of the native v1.0 transport. With the
+  flag off, these legacy transports are never constructed at runtime.
+
+`ClientFactory` itself does not take a `legacyCompat` option — the flag is
+intentionally per transport factory and per resolver, mirroring the
+per-handler opt-in on the server side.
+
+The runnable demo (both v1.0 and mock-v0.3 peers in one process) is
+[`compat-v1-client`](../src/samples/agents/compat-v1-client/).
+
+---
+
+## Caveats: what doesn't survive the round trip
+
+Even with the compat layer enabled, the two protocol versions are not
+byte-equivalent. Some v1.0 surface area has no v0.3 representation and gets
+dropped or defaulted; the rest of this guide enumerates the cases you should
+know about before turning the flag on.
+
+### Methods with no v0.3 equivalent
+
+| v1.0 method  | Status in v0.3                | Behavior under compat                                                                                                                                                                  |
+| :----------- | :---------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ListTasks`  | Not implemented in v0.3       | A v1.0 client calling `client.listTasks(...)` against a v0.3 server fails with `UnsupportedOperationError` (JSON-RPC code `-32004`). The compat layer translates the call into a "method not implemented in v0.3" error rather than the generic invalid-request error. |
+
+Per A2A v0.3 spec §3.5.6, `tasks/list` was a gRPC/REST-only operation in v0.3
+and was never exposed over JSON-RPC. The v0.3 proto shipped here has no
+`ListTasks` RPC at all, so the compat layer treats `ListTasks` as fully
+absent on the v0.3 side — there's no degraded fallback.
+
+If you need cross-version task enumeration, gate `listTasks` calls on the
+peer's `protocolVersion` (the client's `transport.protocolVersion` exposes
+this) or use an out-of-band index.
+
+### Fields the compat layer drops or replaces
+
+These differences come from the protocol data model itself; the compat
+layer applies the documented defaults rather than failing.
+
+| v1.0 field / shape                                                                                                                                                  | What happens going v1.0 → v0.3                                                                                                                                                                                                                                |
+| :------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `OAuthFlows.deviceCode` (v1.0 only)                                                                                                                                 | **Silently dropped.** v0.3 has no representation for the device-code flow. If `deviceCode` is the only declared flow on a `SecurityScheme`, the v0.3 card receives an empty `OAuthFlows` object — callers can guard via `Object.keys(result).length === 0`.   |
+| `AuthenticationInfo.scheme` (single string) ↔ `PushNotificationAuthenticationInfo.schemes` (string array)                                                          | Going v0.3 → v1.0: only the **first** element of `schemes[]` is preserved and the rest are dropped (with a warning). Going v1.0 → v0.3: the single scheme is wrapped into a one-element array; empty becomes `[]`.                                            |
+| `TaskStatusUpdateEvent.final` (removed in v1.0)                                                                                                                     | Going v1.0 → v0.3 the `final` flag is **computed** from the status state: `true` for `completed`, `canceled`, `failed`, or `rejected`; `false` otherwise.                                                                                                     |
+| `SendMessageConfiguration.returnImmediately` ↔ `MessageSendConfiguration.blocking`                                                                                 | Inverted polarity (v1.0 `returnImmediately: true` ↔ v0.3 `blocking: false`, and vice versa).                                                                                                                                                                  |
+| `AgentCard.supportedInterfaces[]` (v1.0) ↔ `(url, preferredTransport, additionalInterfaces)` (v0.3)                                                                | In **strict mode** (default), only interfaces whose `protocolVersion` is empty or in `[0.3, 1.0)` survive the v1.0 → v0.3 translation; if none qualify, `VersionNotSupportedError` is thrown. In **synthesis mode** (used by `legacyAgentCardRouter`), every interface survives and is restamped with `protocolVersion: '0.3'`. |
+| `Part.content.$case` discriminator                                                                                                                                  | Translated to the v0.3 `kind:` discriminator on each part (`text`, `file`, `data`). File URI ↔ v0.3 `FilePart.file.uri`; file bytes ↔ v0.3 `FilePart.file.bytes`; the v1.0 flat `Part.filename` / `Part.mediaType` map back into `FilePart.file.name` / `FilePart.file.mimeType`. |
+
+### REST wire-shape gotchas
+
+Both the v0.3 and v1.0 REST surfaces speak **proto-JSON of their respective
+proto types** (per each version's `google.api.http` annotations) — they do
+**not** use the JSON-Schema bodies with `kind:` discriminators that you would
+send over v0.3 JSON-RPC. The two REST shapes look similar but have small
+field-name differences:
+
+| Aspect              | v0.3 REST                 | v1.0 REST                 |
+| :------------------ | :------------------------ | :------------------------ |
+| Path prefix         | `/v1/<operation>`         | `/<operation>`            |
+| Request body field  | `request` (a `Message`)   | `message` (a `Message`)   |
+| `Message` payload   | `content[]`               | `parts[]`                 |
+| Response shape      | proto-JSON `SendMessageResponse` (`{task: {...}}` or `{msg: {...}}`) | proto-JSON `SendMessageResponse` (same oneof, v1.0 types) |
+| Response Content-Type | `application/json`      | `application/a2a+json`    |
+| `TaskState` encoding | `TASK_STATE_COMPLETED`   | `TASK_STATE_COMPLETED`    |
+
+If you need to issue v0.3 wire shapes with JSON-Schema-style envelopes
+(`{kind: 'task', state: 'completed', parts: [{kind: 'text', ...}]}`), use the
+v0.3 JSON-RPC endpoint, not the REST endpoint.
+
+### Push notifications: routed per webhook
+
+A v1.0-only deployment delivers every push as a `StreamResponse` envelope
+with `Content-Type: application/a2a+json`. With the compat layer enabled, the
+sender (`createLegacyAwarePushNotificationSender`) routes per webhook:
+
+| Wire version the webhook was registered under | Body shape                                                          | Content-Type            |
+| :-------------------------------------------- | :------------------------------------------------------------------ | :---------------------- |
+| `1.0`                                         | `StreamResponse` envelope                                           | `application/a2a+json`  |
+| `0.3` (or absent `A2A-Version` at registration) | The bare event object (v0.3 `Task`, `TaskStatusUpdateEvent`, or `TaskArtifactUpdateEvent` discriminated by its `kind` field) | `application/json`      |
+
+Routing is anchored on the `requestedVersion` recorded **when the webhook was
+registered** (captured by `InMemoryPushNotificationStore` on `save()` and
+exposed via `loadWithMetadata`), not the version of the request that
+triggered the delivery. A v0.3-registered webhook keeps receiving v0.3 bodies
+even when the task is later driven by a v1.0 client.
+
+> **Caveat for custom `PushNotificationStore` implementations.**
+> `loadWithMetadata` is optional. If your custom store does not implement
+> it, the sender defaults each dispatch to the wire version of the request
+> that *triggered* the dispatch, falling back to `'0.3'` per spec §3.6.2
+> when the triggering context carries no version. In a deployment that
+> opts into the compat layer, this can mean a v0.3 webhook receives a v1.0
+> body (or vice versa) when the registering and triggering clients disagree.
+> Implement `loadWithMetadata` on custom stores (mirror the 3-line version
+> in `InMemoryPushNotificationStore`) to preserve the originating wire
+> version per config.
+>
+> Pure v1.0 deployments (no compat opt-in) are unaffected: every triggering
+> context carries `'1.0'` and the built-in V1 serializer handles every
+> dispatch.
+
+### Method-name translations
+
+Reference table — useful when debugging logs or sniffing traffic. The
+translators in `@a2a-js/sdk/compat/v0_3` expose this as a runtime function
+(`legacyJsonRpcToV1Method` and friends).
+
+| v0.3 JSON-RPC method                             | v1.0 method (PascalCase)              | v0.3 gRPC method                              |
+| :----------------------------------------------- | :------------------------------------ | :-------------------------------------------- |
+| `message/send`                                   | `SendMessage`                         | `SendMessage`                                 |
+| `message/stream`                                 | `SendStreamingMessage`                | `SendStreamingMessage`                        |
+| `tasks/get`                                      | `GetTask`                             | `GetTask`                                     |
+| `tasks/cancel`                                   | `CancelTask`                          | `CancelTask`                                  |
+| `tasks/resubscribe`                              | `SubscribeToTask`                     | `TaskSubscription`                            |
+| `tasks/pushNotificationConfig/set`               | `CreateTaskPushNotificationConfig`    | `CreateTaskPushNotificationConfig`            |
+| `tasks/pushNotificationConfig/get`               | `GetTaskPushNotificationConfig`       | `GetTaskPushNotificationConfig`               |
+| `tasks/pushNotificationConfig/list`              | `ListTaskPushNotificationConfigs`     | `ListTaskPushNotificationConfig`              |
+| `tasks/pushNotificationConfig/delete`            | `DeleteTaskPushNotificationConfig`    | `DeleteTaskPushNotificationConfig`            |
+| `agent/getAuthenticatedExtendedCard`             | `GetExtendedAgentCard`                | `GetAgentCard`                                |
+| *(no equivalent)*                                | `ListTasks`                           | *(no equivalent)*                             |
+
+### Transport headers
+
+| Header                | v0.3                  | v1.0                          |
+| :-------------------- | :-------------------- | :---------------------------- |
+| Extensions header     | `X-A2A-Extensions`    | `A2A-Extensions`              |
+| Version header        | *(absent → 0.3)*      | `A2A-Version: 1.0` (required) |
+| REST Content-Type     | `application/json`    | `application/a2a+json`        |
+
+---
+
+## When the compat layer reaches end-of-life
+
+The compat layer is opt-in and intended to be retired once the v0.3 client
+base has migrated. The translators in `src/compat/v0_3/translate/` are
+internal API and may change without a major-version bump; the published
+subpath exports follow the SDK's normal semver guarantees within `1.x`.
+
+If you're operating a v0.3 server and considering migration, the
+[migration guide](migration-guide.md) walks through every SDK-level breaking
+change.

--- a/docs/compatibility-v0_3.md
+++ b/docs/compatibility-v0_3.md
@@ -23,7 +23,7 @@ Turn `legacyCompat: { enabled: true }` on when **any of these** is true:
   staged client migration.
 - You write a v1.0 client and one or more of the agents it talks to still
   advertises v0.3 in its agent card.
-- You're rolling out v1.0 across a fleet and want a single deployable artefact
+- You're rolling out v1.0 across a fleet and want a single deployable artifact
   that handles both versions, instead of running parallel binaries.
 
 Leave it off when:
@@ -64,70 +64,16 @@ intentionally internal and may change without a major-version bump.
 
 The v1.0 server handlers all expose a `legacyCompat` option. Set
 `{ enabled: true }` on each handler whose transport should also accept
-v0.3 traffic; the rest stay strict v1.0.
+v0.3 traffic; the rest stay strict v1.0. Push notifications additionally
+need `createLegacyAwarePushNotificationSender(...)` from
+`@a2a-js/sdk/compat/v0_3/server` so v0.3-registered webhooks receive v0.3
+bodies; gRPC needs `legacyGrpcService` from
+`@a2a-js/sdk/compat/v0_3/server/grpc` bound next to `grpcService` (the v1.0
+gRPC factory has no `legacyCompat` flag).
 
-```ts
-import express from 'express';
-import { Server, ServerCredentials } from '@grpc/grpc-js';
-
-import {
-  AGENT_CARD_PATH,
-  DefaultRequestHandler,
-  InMemoryPushNotificationStore,
-  InMemoryTaskStore,
-} from '@a2a-js/sdk/server';
-import {
-  agentCardHandler,
-  jsonRpcHandler,
-  restHandler,
-  UserBuilder,
-} from '@a2a-js/sdk/server/express';
-import { A2AService, grpcService } from '@a2a-js/sdk/server/grpc';
-import { LegacyA2AService, legacyGrpcService } from '@a2a-js/sdk/compat/v0_3/server/grpc';
-import { createLegacyAwarePushNotificationSender } from '@a2a-js/sdk/compat/v0_3/server';
-
-// One push-notification sender pre-loaded with both v1.0 and v0.3 serializers.
-const pushStore = new InMemoryPushNotificationStore();
-const pushSender = createLegacyAwarePushNotificationSender(pushStore);
-
-const requestHandler = new DefaultRequestHandler(
-  agentCard,             // declared with v1.0 supportedInterfaces only — see below
-  new InMemoryTaskStore(),
-  myAgentExecutor,
-  undefined,             // event bus manager (default)
-  pushStore,
-  pushSender
-);
-
-const app = express();
-
-// Card: serves a v1.0 card to v1.0 clients, a hybrid card (v0.3 top-level
-// fields + embedded supportedInterfaces[]) to v0.3 clients. `Vary: A2A-Version`
-// keeps shared HTTP caches honest.
-app.use(`/${AGENT_CARD_PATH}`,
-  agentCardHandler({ agentCardProvider: requestHandler, legacyCompat: { enabled: true } })
-);
-
-// JSON-RPC: routes by body shape on a single endpoint.
-app.use('/a2a/jsonrpc',
-  jsonRpcHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication, legacyCompat: { enabled: true } })
-);
-
-// REST: mounts the v0.3 `/v1/...` routes alongside the v1.0 `/<operation>` routes.
-app.use('/a2a/rest',
-  restHandler({ requestHandler, userBuilder: UserBuilder.noAuthentication, legacyCompat: { enabled: true } })
-);
-
-// gRPC: register both services on the same Server. The v1.0 gRPC factory
-// has no legacyCompat flag — the canonical way to serve v0.3 gRPC clients is
-// to bind `legacyGrpcService` next to `grpcService`.
-const grpcServer = new Server();
-grpcServer.addService(A2AService, grpcService({ requestHandler, userBuilder: UserBuilder.noAuthentication }));
-grpcServer.addService(LegacyA2AService, legacyGrpcService({ requestHandler, userBuilder: UserBuilder.noAuthentication }));
-```
-
-The runnable end-to-end version is the
-[`compat-v1-server`](../src/samples/agents/compat-v1-server/) sample.
+See the [`compat-v1-server`](../src/samples/agents/compat-v1-server/) sample
+for the runnable wiring across all four surfaces (agent card, JSON-RPC, REST,
+gRPC).
 
 ### How requests get routed
 
@@ -138,7 +84,7 @@ executor publishes back into v0.3 shapes on the way out.
 
 | Transport     | How v0.3 is detected                                                                                                                                                                                              |
 | :------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| JSON-RPC      | The handler inspects the JSON-RPC `method` name. Kebab-style names (`message/send`, `tasks/get`, …) route to the v0.3 dispatcher; PascalCase names (`SendMessage`, `GetTask`, …) route to the v1.0 dispatcher. See the method-name translation table below. |
+| JSON-RPC      | The handler inspects the JSON-RPC `method` name. Kebab-style names (`message/send`, `tasks/get`, …) route to the v0.3 dispatcher; PascalCase names (`SendMessage`, `GetTask`, …) route to the v1.0 dispatcher. |
 | REST          | The v0.3 routes live under the `/v1/...` prefix (per the v0.3 reference proto's `google.api.http` annotations). v1.0 routes use `/<operation>` directly. Express's prefix matcher disambiguates without ambiguity. |
 | gRPC          | Each version is a separate gRPC service descriptor (`A2AService` vs. `LegacyA2AService`). The transport picks the descriptor; the SDK never needs to sniff.                                                       |
 | Agent card    | The handler reads the `A2A-Version` header (defaulting to `'0.3'` when absent, per spec §3.6.2) and emits the appropriate card shape, with `Vary: A2A-Version` set on the response.                                |
@@ -256,7 +202,7 @@ layer applies the documented defaults rather than failing.
 | `AgentCard.supportedInterfaces[]` (v1.0) ↔ `(url, preferredTransport, additionalInterfaces)` (v0.3)                                                                | In **strict mode** (default), only interfaces whose `protocolVersion` is empty or in `[0.3, 1.0)` survive the v1.0 → v0.3 translation; if none qualify, `VersionNotSupportedError` is thrown. In **synthesis mode** (used by `legacyAgentCardRouter`), every interface survives and is restamped with `protocolVersion: '0.3'`. |
 | `Part.content.$case` discriminator                                                                                                                                  | Translated to the v0.3 `kind:` discriminator on each part (`text`, `file`, `data`). File URI ↔ v0.3 `FilePart.file.uri`; file bytes ↔ v0.3 `FilePart.file.bytes`; the v1.0 flat `Part.filename` / `Part.mediaType` map back into `FilePart.file.name` / `FilePart.file.mimeType`. |
 
-### REST wire-shape gotchas
+### REST wire-shape caveats
 
 Both the v0.3 and v1.0 REST surfaces speak **proto-JSON of their respective
 proto types** (per each version's `google.api.http` annotations) — they do
@@ -309,26 +255,6 @@ even when the task is later driven by a v1.0 client.
 > context carries `'1.0'` and the built-in V1 serializer handles every
 > dispatch.
 
-### Method-name translations
-
-Reference table — useful when debugging logs or sniffing traffic. The
-translators in `@a2a-js/sdk/compat/v0_3` expose this as a runtime function
-(`legacyJsonRpcToV1Method` and friends).
-
-| v0.3 JSON-RPC method                             | v1.0 method (PascalCase)              | v0.3 gRPC method                              |
-| :----------------------------------------------- | :------------------------------------ | :-------------------------------------------- |
-| `message/send`                                   | `SendMessage`                         | `SendMessage`                                 |
-| `message/stream`                                 | `SendStreamingMessage`                | `SendStreamingMessage`                        |
-| `tasks/get`                                      | `GetTask`                             | `GetTask`                                     |
-| `tasks/cancel`                                   | `CancelTask`                          | `CancelTask`                                  |
-| `tasks/resubscribe`                              | `SubscribeToTask`                     | `TaskSubscription`                            |
-| `tasks/pushNotificationConfig/set`               | `CreateTaskPushNotificationConfig`    | `CreateTaskPushNotificationConfig`            |
-| `tasks/pushNotificationConfig/get`               | `GetTaskPushNotificationConfig`       | `GetTaskPushNotificationConfig`               |
-| `tasks/pushNotificationConfig/list`              | `ListTaskPushNotificationConfigs`     | `ListTaskPushNotificationConfig`              |
-| `tasks/pushNotificationConfig/delete`            | `DeleteTaskPushNotificationConfig`    | `DeleteTaskPushNotificationConfig`            |
-| `agent/getAuthenticatedExtendedCard`             | `GetExtendedAgentCard`                | `GetAgentCard`                                |
-| *(no equivalent)*                                | `ListTasks`                           | *(no equivalent)*                             |
-
 ### Transport headers
 
 | Header                | v0.3                  | v1.0                          |
@@ -338,13 +264,6 @@ translators in `@a2a-js/sdk/compat/v0_3` expose this as a runtime function
 | REST Content-Type     | `application/json`    | `application/a2a+json`        |
 
 ---
-
-## When the compat layer reaches end-of-life
-
-The compat layer is opt-in and intended to be retired once the v0.3 client
-base has migrated. The translators in `src/compat/v0_3/translate/` are
-internal API and may change without a major-version bump; the published
-subpath exports follow the SDK's normal semver guarantees within `1.x`.
 
 If you're operating a v0.3 server and considering migration, the
 [migration guide](migration-guide.md) walks through every SDK-level breaking

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -11,8 +11,17 @@ model changes (renamed fields, restructured types, new operations), see:
 ## Prerequisites
 
 - **Node.js >= 20** is now required (v0.3 supported Node 18).
-- Install the v1.0 SDK: `npm install @a2a-js/sdk@1.0.0-alpha.0`
-  (or `npm install @a2a-js/sdk@next` to always get the latest `@next` release)
+- Install the v1.0 SDK:
+
+  ```bash
+  npm install @a2a-js/sdk
+  ```
+
+> If you can't migrate every peer at once, you don't have to: the v1.0 SDK
+> ships an opt-in compatibility layer that lets a v1.0 server accept v0.3
+> clients (and a v1.0 client talk to v0.3 servers). See
+> [compatibility-v0_3.md](compatibility-v0_3.md) for end-user setup and
+> caveats.
 
 ---
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -17,7 +17,7 @@ model changes (renamed fields, restructured types, new operations), see:
   npm install @a2a-js/sdk
   ```
 
-> If you can't migrate every peer at once, you don't have to: the v1.0 SDK
+> Migrating all v0.3 clients to v1.0 during upgrade is not required: the v1.0 SDK
 > ships an opt-in compatibility layer that lets a v1.0 server accept v0.3
 > clients (and a v1.0 client talk to v0.3 servers). See
 > [compatibility-v0_3.md](compatibility-v0_3.md) for end-user setup and


### PR DESCRIPTION
# Description

Adds new docs and refreshes the SDK landing pages for the 1.0 stable release:
- **`docs/migration-guide.md`** — updates the install snippet from
  `@a2a-js/sdk@next` / `@1.0.0-alpha.0` to `npm install @a2a-js/sdk`, and adds
  a forward-pointer to the new compatibility guide so v0.3 users know they
  don't have to migrate every peer at once.
- **`docs/compatibility-v0_3.md`** (new) — end-user guide for the v0.3 compat
  layer: when to enable it, the six published subpath exports, server-side
  and client-side opt-in patterns (pointing at the runnable
  `compat-v1-server` / `compat-v1-client` samples for the wiring), and an
  enumeration of what doesn't survive the round trip — methods without a
  v0.3 equivalent (`ListTasks`), fields the layer drops or replaces
  (`OAuthFlows.deviceCode`, `AuthenticationInfo.scheme[s]`,
  `TaskStatusUpdateEvent.final`, `returnImmediately` ↔ `blocking`,
  `supportedInterfaces[]` ↔ `(url, preferredTransport, additionalInterfaces)`,
  the `Part.content.$case` ↔ `kind:` discriminator), REST wire-shape
  caveats, push-notification routing rules with a caveat for custom
  `PushNotificationStore` implementations, and transport headers.
- **`README.md`** — drops the `@next` install instruction, adds an npm
  badge, a 1.0-stable + transports + compat highlight block, and links to docs.
- **`AGENTS.md`** — refreshes the modular-entry-points map and the samples
  list to reflect what actually ships in 1.0 (gRPC server integration,
  signing helpers, the per-sample agent layout including the two compat
  samples).

Closes #490  🦕
