### PR TITLE
fix(version): default to legacy 0.3 when protocolVersion is missing

### DIFF
--- a/src/version_utils.ts
+++ b/src/version_utils.ts
@@ -46,13 +46,13 @@ function compareVersions(a: NumericVersion, b: NumericVersion): number {
 }
 
 /**
- * Returns `true` when `version` is a non-empty, parseable string that falls
- * inside the legacy range `[0.3, 1.0)`.
- *
- * Empty / nullish / unparseable inputs return `false`.
+ * Returns `true` when `version` is in the legacy range `[0.3, 1.0)`.
+ * Empty, whitespace-only, or nullish inputs are treated as legacy ('0.3'),
+ * matching the spec rule that clients without an explicit version are v0.3.
+ * Unparseable, non-empty inputs return `false`.
  */
 export function isLegacyVersion(version: string | null | undefined): boolean {
-  if (!version) return false;
+  if (!version || version.trim() === '') return true;
   const v = parseVersion(version);
   if (!v) return false;
 

--- a/test/client/transports/json_rpc_transport.spec.ts
+++ b/test/client/transports/json_rpc_transport.spec.ts
@@ -262,9 +262,7 @@ describe('JsonRpcTransportFactory', () => {
       expect(transport).not.toBeInstanceOf(LegacyJsonRpcTransport);
     });
 
-    // TODO: It should default to v0.3 when protocolVersion is missing and legacyCompat is enabled
-    // after https://github.com/a2aproject/a2a-js/issues/474
-    it('produces JsonRpcTransport when matched interface has empty protocolVersion', async () => {
+    it('produces LegacyJsonRpcTransport when matched interface has empty protocolVersion (defaults to 0.3)', async () => {
       const card = baseAgentCard();
       card.supportedInterfaces = [
         {
@@ -276,8 +274,7 @@ describe('JsonRpcTransportFactory', () => {
       ];
       const factory = new JsonRpcTransportFactory({ legacyCompat: { enabled: true } });
       const transport = await factory.create('https://a.example/rpc', card);
-      expect(transport).toBeInstanceOf(JsonRpcTransport);
-      expect(transport).not.toBeInstanceOf(LegacyJsonRpcTransport);
+      expect(transport).toBeInstanceOf(LegacyJsonRpcTransport);
     });
 
     it('disambiguates by URL when multiple JSON-RPC interfaces are present', async () => {

--- a/test/client/transports/rest_transport.spec.ts
+++ b/test/client/transports/rest_transport.spec.ts
@@ -546,9 +546,7 @@ describe('legacyCompat enabled', () => {
     expect(transport).not.toBeInstanceOf(LegacyRestTransport);
   });
 
-  // TODO: It should default to v0.3 when protocolVersion is missing and legacyCompat is enabled
-  // after https://github.com/a2aproject/a2a-js/issues/474
-  it('produces RestTransport when matched interface has empty protocolVersion', async () => {
+  it('produces LegacyRestTransport when matched interface has empty protocolVersion (defaults to 0.3)', async () => {
     const card = createMockAgentCard({
       supportedInterfaces: [
         {
@@ -561,8 +559,7 @@ describe('legacyCompat enabled', () => {
     });
     const factory = new RestTransportFactory({ legacyCompat: { enabled: true } });
     const transport = await factory.create('https://a.example/rest', card);
-    expect(transport).toBeInstanceOf(RestTransport);
-    expect(transport).not.toBeInstanceOf(LegacyRestTransport);
+    expect(transport).toBeInstanceOf(LegacyRestTransport);
   });
 
   it('disambiguates by URL when multiple HTTP+JSON interfaces are present', async () => {

--- a/test/compat/v0_3/translate/versions.spec.ts
+++ b/test/compat/v0_3/translate/versions.spec.ts
@@ -44,13 +44,19 @@ describe('versions', () => {
       expect(isLegacyVersion('0.0')).toBe(false);
     });
 
-    it('returns false for an empty string', () => {
-      expect(isLegacyVersion('')).toBe(false);
+    it('returns true for an empty string (defaults to 0.3)', () => {
+      expect(isLegacyVersion('')).toBe(true);
     });
 
-    it('returns false for null/undefined', () => {
-      expect(isLegacyVersion(null)).toBe(false);
-      expect(isLegacyVersion(undefined)).toBe(false);
+    it('returns true for whitespace-only strings (defaults to 0.3)', () => {
+      expect(isLegacyVersion(' ')).toBe(true);
+      expect(isLegacyVersion('   ')).toBe(true);
+      expect(isLegacyVersion('\t\n')).toBe(true);
+    });
+
+    it('returns true for null/undefined (defaults to 0.3)', () => {
+      expect(isLegacyVersion(null)).toBe(true);
+      expect(isLegacyVersion(undefined)).toBe(true);
     });
 
     it('returns false for unparseable strings', () => {


### PR DESCRIPTION
# Description

Fixes part of version checking method

Fixes #474 🦕
