### PR TITLE
fix: v0.3 compatibility error handling, method classification, and add TCK compat agent workflow

### DIFF
--- a/.github/workflows/run-tck-compat.yaml
+++ b/.github/workflows/run-tck-compat.yaml
@@ -1,0 +1,124 @@
+name: Run TCK (v0.3 compat)
+
+# Drives the a2a-tck v0.3 suite against the v1.0-native SUT in
+# `tck/compat-agent/` (built on the v1.0 SDK with the v0.3 compat layer
+# enabled on every transport).
+
+on:
+  push:
+    branches: ['main', 'epic/**']
+  pull_request:
+    branches: ['main', 'epic/**']
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.github/CODEOWNERS'
+      - 'test/**'
+      - 'src/samples/**'
+
+env:
+  # Tag of the TCK.
+  TCK_VERSION: 0.3.0.beta5
+  # Tells uv to not need a venv, and instead use system
+  UV_SYSTEM_PYTHON: 1
+  # Base URL for the SUT agent
+  SUT_BASE_URL: http://localhost:41241
+  # Base URL for the SUT agent JSON-RPC transport
+  SUT_JSONRPC_URL: http://localhost:41241/a2a/jsonrpc
+  # Slow system on CI
+  TCK_STREAMING_TIMEOUT: 5.0
+
+# Only run the latest job
+concurrency:
+  group: '${{ github.workflow }} @ ${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  tck-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+      - name: Checkout a2a-js
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+      - run: |
+          npm ci
+          npm run build
+      - name: Checkout a2a-tck
+        uses: actions/checkout@v4
+        with:
+          repository: a2aproject/a2a-tck
+          path: tck/a2a-tck
+          ref: ${{ env.TCK_VERSION }}
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: 'tck/a2a-tck/pyproject.toml'
+      - name: Install uv and Python dependencies
+        run: |
+          pip install uv
+          uv pip install -e .
+        working-directory: tck/a2a-tck
+      - name: Start SUT (v1.0 SDK + v0.3 compat layer)
+        run: |
+          cd tck
+          npm run tck:compat-sut-agent &
+      - name: Wait for SUT to start
+        run: |
+          URL="${{ env.SUT_BASE_URL }}/.well-known/agent-card.json"
+          EXPECTED_STATUS=200
+          TIMEOUT=120
+          RETRY_INTERVAL=2
+          START_TIME=$(date +%s)
+
+          while true; do
+            # Calculate elapsed time
+            CURRENT_TIME=$(date +%s)
+            ELAPSED_TIME=$((CURRENT_TIME - START_TIME))
+
+            # Check for timeout
+            if [ "$ELAPSED_TIME" -ge "$TIMEOUT" ]; then
+                echo "❌ Timeout: Server did not respond with status $EXPECTED_STATUS within $TIMEOUT seconds."
+                exit 1
+            fi
+
+            # Get HTTP status code. || true is to reporting a failure to connect as an error
+            HTTP_STATUS=$(curl --output /dev/null --silent --write-out "%{http_code}" "$URL") || true
+            echo "STATUS: ${HTTP_STATUS}"
+
+            # Check if we got the correct status code
+            if [ "$HTTP_STATUS" -eq "$EXPECTED_STATUS" ]; then
+                echo "✅ Server is up! Received status $HTTP_STATUS after $ELAPSED_TIME seconds."
+                break;
+            fi
+
+            # Wait before retrying
+            echo "⏳ Server not ready (status: $HTTP_STATUS). Retrying in $RETRY_INTERVAL seconds..."
+            sleep "$RETRY_INTERVAL"
+          done
+
+      - name: Run TCK (mandatory)
+        id: run-tck-mandatory
+        timeout-minutes: 5
+        run: |
+          ./run_tck.py --sut-url ${{ env.SUT_JSONRPC_URL }} --category mandatory --transports jsonrpc,rest,grpc
+        working-directory: tck/a2a-tck
+      - name: Run TCK (capabilities)
+        id: run-tck-capabilities
+        timeout-minutes: 5
+        run: |
+          ./run_tck.py --sut-url ${{ env.SUT_JSONRPC_URL }} --category capabilities --transports jsonrpc,rest,grpc
+        working-directory: tck/a2a-tck
+      - name: Stop SUT
+        if: always()
+        run: |
+          # Find and kill the SUT process
+          pkill -f "npm run tck:compat-sut-agent" || true
+          sleep 2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ The project is structured into modular entry points to allow tree-shaking and se
 ### 5. v0.3 Backward Compatibility (`src/compat/v0_3/`)
 The compat layer is shipped as six subpath exports off `@a2a-js/sdk`, mirroring the v1.0 layout (`server` is framework-agnostic; `server/express` and `server/grpc` carry the runtime-specific bits):
 
-*   **`@a2a-js/sdk/compat/v0_3`** — v0.3 protocol constants and method-name translators. Workers-safe (no Node-only peer deps).
+*   **`@a2a-js/sdk/compat/v0_3`** — v0.3 protocol constants and method-name translators (`isLegacyJsonRpcMethod`, `isV1JsonRpcMethod`). Workers-safe (no Node-only peer deps).
 *   **`@a2a-js/sdk/compat/v0_3/server`** — Framework-agnostic transport handlers (`LegacyJsonRpcTransportHandler`, `LegacyRestTransportHandler`) and the push-notification factory (`createLegacyAwarePushNotificationSender`). Workers-safe.
 *   **`@a2a-js/sdk/compat/v0_3/server/express`** — Express routers (`legacyAgentCardRouter`, `legacyRestRouter`); mount alongside or under the v1.0 `agentCardHandler` / `restHandler` to negotiate v0.3 by `A2A-Version` header.
 *   **`@a2a-js/sdk/compat/v0_3/server/grpc`** — v0.3 gRPC service (`legacyGrpcService`, `LegacyA2AService`); register alongside the v1.0 `grpcService` on the same `Server`.

--- a/docs/compatibility-v0_3.md
+++ b/docs/compatibility-v0_3.md
@@ -84,7 +84,7 @@ executor publishes back into v0.3 shapes on the way out.
 
 | Transport     | How v0.3 is detected                                                                                                                                                                                              |
 | :------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| JSON-RPC      | The handler inspects the JSON-RPC `method` name. Kebab-style names (`message/send`, `tasks/get`, …) route to the v0.3 dispatcher; PascalCase names (`SendMessage`, `GetTask`, …) route to the v1.0 dispatcher. |
+| JSON-RPC      | The handler inspects the JSON-RPC `method` name. v1.0 PascalCase names matching `isV1JsonRpcMethod` (`SendMessage`, `GetTask`, `ListTasks`, …) route to the v1.0 dispatcher; everything else — kebab-style v0.3 names (`message/send`, `tasks/get`), unknown method strings, and bodies with no `method` field — routes to the v0.3 dispatcher so malformed/unknown requests surface v0.3-shaped errors (spec §3.6.2 default-to-v0.3). |
 | REST          | The v0.3 routes live under the `/v1/...` prefix (per the v0.3 reference proto's `google.api.http` annotations). v1.0 routes use `/<operation>` directly. Express's prefix matcher disambiguates without ambiguity. |
 | gRPC          | Each version is a separate gRPC service descriptor (`A2AService` vs. `LegacyA2AService`). The transport picks the descriptor; the SDK never needs to sniff.                                                       |
 | Agent card    | The handler reads the `A2A-Version` header (defaulting to `'0.3'` when absent, per spec §3.6.2) and emits the appropriate card shape, with `Vary: A2A-Version` set on the response.                                |
@@ -215,13 +215,31 @@ field-name differences:
 | Path prefix         | `/v1/<operation>`         | `/<operation>`            |
 | Request body field  | `request` (a `Message`)   | `message` (a `Message`)   |
 | `Message` payload   | `content[]`               | `parts[]`                 |
+| Field-name casing   | **snake_case** on output (`context_id`, `task_id`, `message_id`, …) to match the v0.3 reference proto's canonical proto-JSON. Input accepts both casings. | **lowerCamelCase** per proto3 JSON canonical form. |
 | Response shape      | proto-JSON `SendMessageResponse` (`{task: {...}}` or `{msg: {...}}`) | proto-JSON `SendMessageResponse` (same oneof, v1.0 types) |
 | Response Content-Type | `application/json`      | `application/a2a+json`    |
 | `TaskState` encoding | `TASK_STATE_COMPLETED`   | `TASK_STATE_COMPLETED`    |
+| Error → HTTP status | `LegacyA2AError` mapped to proper 4xx (e.g. `-32602` → 400, `-32001` → 404) via `mapErrorToStatus`. | A2A error classes mapped to 4xx by the v1.0 helper. |
 
 If you need to issue v0.3 wire shapes with JSON-Schema-style envelopes
 (`{kind: 'task', state: 'completed', parts: [{kind: 'text', ...}]}`), use the
 v0.3 JSON-RPC endpoint, not the REST endpoint.
+
+### `tasks/resubscribe` always responds with SSE
+
+The legacy `tasks/resubscribe` JSON-RPC method always responds with
+`Content-Type: text/event-stream` and HTTP 200, even when the underlying call
+fails immediately (e.g. the task does not exist). Pre-stream errors are
+emitted as an SSE error event on the open stream instead of as a plain
+JSON-RPC 200 error envelope. Strict v0.3 clients reject anything other than
+`text/event-stream` on this method, so the SSE headers are committed before
+the first iterator pull.
+
+Other streaming methods (`message/stream`, v1.0 `SubscribeToTask`) keep their
+peek-then-flush behaviour: a synchronous invalid-params or task-not-found
+error returned by the first iterator step is surfaced as a JSON 200 error
+envelope, and the SSE headers are only committed once the first event
+succeeds.
 
 ### Push notifications: routed per webhook
 

--- a/src/compat/v0_3/README.md
+++ b/src/compat/v0_3/README.md
@@ -77,7 +77,7 @@ The v1.0 gRPC service factory (`src/server/grpc/grpc_service.ts`) intentionally 
 `jsonRpcHandler({ legacyCompat: { enabled: true } })` routes each request body based on its `method` field:
 
 - Method matches a v1.0 PascalCase name (`isV1JsonRpcMethod` → `true`, e.g. `SendMessage`, `ListTasks`) → v1.0 dispatcher.
-- Anything else — kebab-style v0.3 names (`message/send`, `tasks/get`), unknown strings, or bodies with no `method` field at all — → v0.3 dispatcher.
+- Anything else — kebab-style v0.3 names (`message/send`, `tasks/get`), unknown strings, or bodies with no `method` field at all → v0.3 dispatcher.
 
 The fallback exists so malformed and unknown requests surface v0.3-shaped errors (`-32600 Invalid Request` for missing `method`, `-32602` for bad params) instead of the v1.0 path's blanket `-32602`, which is what header-less v0.3 clients expect per spec §3.6.2.
 

--- a/src/compat/v0_3/README.md
+++ b/src/compat/v0_3/README.md
@@ -8,7 +8,7 @@ The compat layer is shipped as six subpath exports off `@a2a-js/sdk`. Each subpa
 
 | Subpath                                  | What it exports                                                                                                                                                                                                                                                                                                                                                                         | Peer deps           |
 | :--------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------------ |
-| `@a2a-js/sdk/compat/v0_3`                | v0.3 protocol constants (`A2A_LEGACY_PROTOCOL_VERSION`, `LEGACY_HTTP_EXTENSION_HEADER`, `LEGACY_JSON_CONTENT_TYPE`, the `LEGACY_METHOD_*` literals) and method-name translators (`legacyJsonRpcToV1Method`, `v1MethodToLegacyJsonRpc`, `legacyJsonRpcToLegacyGrpcMethod`, `legacyGrpcToLegacyJsonRpcMethod`, `legacyGrpcToV1Method`, `v1MethodToLegacyGrpc`, `isLegacyJsonRpcMethod`).  | none (Workers-safe) |
+| `@a2a-js/sdk/compat/v0_3`                | v0.3 protocol constants (`A2A_LEGACY_PROTOCOL_VERSION`, `LEGACY_HTTP_EXTENSION_HEADER`, `LEGACY_JSON_CONTENT_TYPE`, the `LEGACY_METHOD_*` literals) and method-name translators (`legacyJsonRpcToV1Method`, `v1MethodToLegacyJsonRpc`, `legacyJsonRpcToLegacyGrpcMethod`, `legacyGrpcToLegacyJsonRpcMethod`, `legacyGrpcToV1Method`, `v1MethodToLegacyGrpc`, `isLegacyJsonRpcMethod`, `isV1JsonRpcMethod`).  | none (Workers-safe) |
 | `@a2a-js/sdk/compat/v0_3/server`         | Framework-agnostic transport handlers (`LegacyJsonRpcTransportHandler`, `LegacyRestTransportHandler`, `toLegacyHTTPError`), push-notification factory (`createLegacyAwarePushNotificationSender`) and serializer (`V03PushNotificationSerializer`), and the `LegacyA2AError` class. Mount the transport handlers from any HTTP runtime (Express, Fastify, Hono, Cloudflare Workers, …). | none (Workers-safe) |
 | `@a2a-js/sdk/compat/v0_3/server/express` | Express routers (`legacyAgentCardRouter`, `legacyRestRouter`) that wrap the handlers above with the v0.3 well-known agent-card and REST endpoint paths. Header-based dispatch on `A2A-Version`.                                                                                                                                                                                         | `express`           |
 | `@a2a-js/sdk/compat/v0_3/server/grpc`    | v0.3 gRPC service factory (`legacyGrpcService`), service descriptor (`LegacyA2AService`), and options type. Register alongside the v1.0 `grpcService` on the same gRPC `Server`.                                                                                                                                                                                                        | `@grpc/grpc-js`     |
@@ -71,6 +71,25 @@ Per A2A spec §3.6.2, clients that omit the `A2A-Version` header are treated as 
 2. **Synthesized v0.3 card.** The `legacyAgentCardRouter` calls `toCompatAgentCard(card, { synthesize: true })` so the well-known endpoint returns a discoverable v0.3-shaped card whose `(url, preferredTransport, additionalInterfaces)` reflect the v1.0 `supportedInterfaces` entries but whose `protocolVersion` is stamped as `'0.3'`. v0.3 clients can therefore both discover and use a v1.0-only server when the operator has opted into the compat layer.
 
 The v1.0 gRPC service factory (`src/server/grpc/grpc_service.ts`) intentionally does **not** carry a `legacyCompat` option; v0.3 gRPC clients are served by importing `legacyGrpcService` from `@a2a-js/sdk/compat/v0_3/server/grpc` and registering it alongside the v1.0 `grpcService` on the same `Server`. (The v1.0 `@a2a-js/sdk/server/grpc` barrel does not re-export `legacyGrpcService`; the explicit compat import keeps `@grpc/grpc-js` out of the v1.0 dependency graph for operators who only deploy the v1.0 service.)
+
+### JSON-RPC method dispatch
+
+`jsonRpcHandler({ legacyCompat: { enabled: true } })` routes each request body based on its `method` field:
+
+- Method matches a v1.0 PascalCase name (`isV1JsonRpcMethod` → `true`, e.g. `SendMessage`, `ListTasks`) → v1.0 dispatcher.
+- Anything else — kebab-style v0.3 names (`message/send`, `tasks/get`), unknown strings, or bodies with no `method` field at all — → v0.3 dispatcher.
+
+The fallback exists so malformed and unknown requests surface v0.3-shaped errors (`-32600 Invalid Request` for missing `method`, `-32602` for bad params) instead of the v1.0 path's blanket `-32602`, which is what header-less v0.3 clients expect per spec §3.6.2.
+
+### REST wire format
+
+`legacyRestRouter` / `LegacyRestTransportHandler` emit JSON with **snake_case** field names (`context_id`, `task_id`, `message_id`, `protocol_version`, …) to match the v0.3 reference proto's canonical proto-JSON wire form. Input handlers accept both casings (proto3 JSON parsers tolerate either), so v0.3 clients that send camelCase still work.
+
+This deviates from the v1.0 REST handler (`src/server/express/rest_handler.ts`), which emits lowerCamelCase per proto3 JSON canonical form. The split is intentional: each handler matches the on-the-wire conventions of its respective spec version.
+
+### `tasks/resubscribe` streaming contract
+
+The legacy `tasks/resubscribe` handler always responds with `Content-Type: text/event-stream` and HTTP 200, even when the underlying call fails immediately (e.g. the task does not exist). Pre-stream errors are emitted as SSE error events on the open stream rather than as a plain JSON-RPC error response. Strict v0.3 clients reject anything other than `text/event-stream` on this method, so the header is committed before the first iterator pull. Other streaming methods (`message/stream`, `SubscribeToTask`) keep the peek-then-flush behaviour so a synchronous invalid-params error still surfaces as a JSON 200 error envelope.
 
 ## Push Notifications
 

--- a/src/compat/v0_3/constants.ts
+++ b/src/compat/v0_3/constants.ts
@@ -154,6 +154,16 @@ export function isLegacyJsonRpcMethod(method: unknown): boolean {
 }
 
 /**
+ * Returns `true` if `method` is a known v1.0 JSON-RPC (PascalCase)
+ * method name. Includes both {@link V1_TO_LEGACY_JSONRPC} and the
+ * v1.0-only methods in {@link V1_METHODS_WITHOUT_LEGACY_EQUIVALENT}.
+ */
+export function isV1JsonRpcMethod(method: unknown): boolean {
+  if (typeof method !== 'string') return false;
+  return method in V1_TO_LEGACY_JSONRPC || V1_METHODS_WITHOUT_LEGACY_EQUIVALENT.has(method);
+}
+
+/**
  * Translate a v1.0 method name to its v0.3 JSON-RPC equivalent. Throws
  * `A2AError.unsupportedOperation` for v1.0 names with no v0.3 equivalent
  * (e.g. `ListTasks`); throws `A2AError.invalidRequest` for unknown names.

--- a/src/compat/v0_3/index.ts
+++ b/src/compat/v0_3/index.ts
@@ -24,6 +24,7 @@ export {
   LEGACY_METHOD_PUSH_NOTIFICATION_CONFIG_DELETE,
   LEGACY_METHOD_GET_AUTHENTICATED_EXTENDED_CARD,
   isLegacyJsonRpcMethod,
+  isV1JsonRpcMethod,
   legacyJsonRpcToV1Method,
   v1MethodToLegacyJsonRpc,
   legacyJsonRpcToLegacyGrpcMethod,

--- a/src/compat/v0_3/server/express/rest_handler.ts
+++ b/src/compat/v0_3/server/express/rest_handler.ts
@@ -69,6 +69,30 @@ const legacyRestErrorHandler: ErrorRequestHandler = (
 type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
 
 /**
+ * Recursively convert object keys from `lowerCamelCase` to `snake_case`.
+ *
+ * `ts-proto`'s `toJSON` emits proto3 canonical lowerCamelCase, but the
+ * v0.3 REST reference stack and the a2a-tck REST client only parse
+ * snake_case (`context_id`, `task_id`, `message_id`). proto3 JSON
+ * accepts both on input — we deviate from the canonical output form to
+ * stay readable for v0.3 clients.
+ *
+ * Keys only; values pass through. Non-plain objects (Buffer, Date, …)
+ * are returned as-is.
+ */
+function toSnakeCaseKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(toSnakeCaseKeys);
+  if (value === null || typeof value !== 'object') return value;
+  if (Object.getPrototypeOf(value) !== Object.prototype) return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+    const snakeKey = key.replace(/[A-Z]/g, (m) => `_${m.toLowerCase()}`);
+    out[snakeKey] = toSnakeCaseKeys(val);
+  }
+  return out;
+}
+
+/**
  * Creates an Express router exposing the v0.3 HTTP+JSON/REST endpoints
  * at the canonical v0.3 reference URLs (`/v1/card`, `/v1/message:send`,
  * etc.). Dispatch is header-based: requests whose `A2A-Version` is not
@@ -170,28 +194,32 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
     if (!protoResult) {
       throw LegacyA2AError.internalError('sendMessage produced no result.');
     }
-    return LegacyProtoSendMessageResponse.toJSON(protoResult);
+    return toSnakeCaseKeys(LegacyProtoSendMessageResponse.toJSON(protoResult));
   };
 
   const encodeTask = (task: legacy.Task): unknown => {
-    return LegacyProtoTask.toJSON(ToProto.task(task));
+    return toSnakeCaseKeys(LegacyProtoTask.toJSON(ToProto.task(task)));
   };
 
   const encodeTaskPushNotificationConfig = (cfg: legacy.TaskPushNotificationConfig): unknown => {
-    return LegacyProtoTaskPushNotificationConfig.toJSON(ToProto.taskPushNotificationConfig(cfg));
+    return toSnakeCaseKeys(
+      LegacyProtoTaskPushNotificationConfig.toJSON(ToProto.taskPushNotificationConfig(cfg))
+    );
   };
 
   const encodeAgentCard = (card: legacy.AgentCard): unknown => {
-    return LegacyProtoAgentCard.toJSON(ToProto.agentCard(card));
+    return toSnakeCaseKeys(LegacyProtoAgentCard.toJSON(ToProto.agentCard(card)));
   };
 
   const encodeListTaskPushNotificationConfigs = (
     configs: legacy.TaskPushNotificationConfig[]
   ): unknown => {
-    return LegacyProtoListTaskPushNotificationConfigResponse.toJSON({
-      configs: configs.map((c) => ToProto.taskPushNotificationConfig(c)),
-      nextPageToken: '',
-    });
+    return toSnakeCaseKeys(
+      LegacyProtoListTaskPushNotificationConfigResponse.toJSON({
+        configs: configs.map((c) => ToProto.taskPushNotificationConfig(c)),
+        nextPageToken: '',
+      })
+    );
   };
 
   const decodeSendMessageRequest = (rawBody: unknown): legacy.MessageSendParams => {
@@ -213,7 +241,7 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
     if (!proto) {
       throw LegacyA2AError.internalError('Stream produced an unrepresentable event.');
     }
-    return LegacyProtoStreamResponse.toJSON(proto);
+    return toSnakeCaseKeys(LegacyProtoStreamResponse.toJSON(proto));
   };
 
   /**

--- a/src/compat/v0_3/server/express/rest_handler.ts
+++ b/src/compat/v0_3/server/express/rest_handler.ts
@@ -81,7 +81,14 @@ type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
  * ISO-8601 strings (matching `JSON.stringify`'s default for Date). Plain
  * objects with a `null` prototype are recursed; other non-plain objects
  * (Buffer, Map, …) are returned as-is.
+ *
+ * Field names listed in `PASSTHROUGH_KEYS` carry arbitrary user-supplied
+ * maps (proto `Struct` / `map<string, Value>` fields like `metadata` and
+ * `DataPart.data`) and MUST NOT be recursed into — snake-casing their
+ * keys would corrupt application data.
  */
+const PASSTHROUGH_KEYS: ReadonlySet<string> = new Set(['metadata', 'data']);
+
 function toSnakeCaseKeys(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(toSnakeCaseKeys);
   if (value === null || typeof value !== 'object') return value;
@@ -91,7 +98,7 @@ function toSnakeCaseKeys(value: unknown): unknown {
   const out: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
     const snakeKey = key.replace(/[A-Z]/g, (m) => `_${m.toLowerCase()}`);
-    out[snakeKey] = toSnakeCaseKeys(val);
+    out[snakeKey] = PASSTHROUGH_KEYS.has(key) ? val : toSnakeCaseKeys(val);
   }
   return out;
 }

--- a/src/compat/v0_3/server/express/rest_handler.ts
+++ b/src/compat/v0_3/server/express/rest_handler.ts
@@ -77,13 +77,17 @@ type AsyncRouteHandler = (req: Request, res: Response) => Promise<void>;
  * accepts both on input — we deviate from the canonical output form to
  * stay readable for v0.3 clients.
  *
- * Keys only; values pass through. Non-plain objects (Buffer, Date, …)
- * are returned as-is.
+ * Keys only; values pass through. `Date` instances are serialized to
+ * ISO-8601 strings (matching `JSON.stringify`'s default for Date). Plain
+ * objects with a `null` prototype are recursed; other non-plain objects
+ * (Buffer, Map, …) are returned as-is.
  */
 function toSnakeCaseKeys(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(toSnakeCaseKeys);
   if (value === null || typeof value !== 'object') return value;
-  if (Object.getPrototypeOf(value) !== Object.prototype) return value;
+  if (value instanceof Date) return value.toISOString();
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return value;
   const out: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
     const snakeKey = key.replace(/[A-Z]/g, (m) => `_${m.toLowerCase()}`);

--- a/src/compat/v0_3/server/grpc/grpc_service.ts
+++ b/src/compat/v0_3/server/grpc/grpc_service.ts
@@ -55,6 +55,7 @@ import {
 import { validateVersion } from '../../../../server/version.js';
 import { FromProto } from '../../types/converters/from_proto.js';
 import { ToProto } from '../../types/converters/to_proto.js';
+import { A2AError as LegacyA2AError } from '../error.js';
 import {
   extractTaskAndPushNotificationConfigId,
   extractTaskId,
@@ -436,12 +437,31 @@ function _serializeListTaskPushNotificationConfigResponse(
 
 // Error mapping.
 
+// JSON-RPC error code -> gRPC status, used to translate `LegacyA2AError`
+// (which carries a JSON-RPC code, not a class identity).
+const LEGACY_CODE_TO_GRPC_STATUS: Readonly<Record<number, grpc.status>> = {
+  [-32700]: grpc.status.INVALID_ARGUMENT, // Parse error
+  [-32600]: grpc.status.INVALID_ARGUMENT, // Invalid Request
+  [-32601]: grpc.status.UNIMPLEMENTED, // Method not found
+  [-32602]: grpc.status.INVALID_ARGUMENT, // Invalid params
+  [-32603]: grpc.status.INTERNAL, // Internal error
+  [-32001]: grpc.status.NOT_FOUND, // Task not found
+  [-32002]: grpc.status.FAILED_PRECONDITION, // Task not cancelable
+  [-32003]: grpc.status.FAILED_PRECONDITION, // Push notification not supported
+  [-32004]: grpc.status.FAILED_PRECONDITION, // Unsupported operation
+  [-32005]: grpc.status.INVALID_ARGUMENT, // Content-Type not supported
+  [-32006]: grpc.status.INTERNAL, // Invalid agent response
+  [-32007]: grpc.status.FAILED_PRECONDITION, // Extended card not configured
+};
+
 // `instanceof` chain so user-defined subclasses of A2A error types resolve
 // to the correct gRPC status of the nearest base class. Also attaches a
 // `google.rpc.ErrorInfo` detail for v1.0-aware clients.
 const mapToError = (error: unknown): Partial<grpc.ServiceError> => {
   let code = grpc.status.UNKNOWN;
-  if (error instanceof TaskNotFoundError) code = grpc.status.NOT_FOUND;
+  if (error instanceof LegacyA2AError) {
+    code = LEGACY_CODE_TO_GRPC_STATUS[error.code] ?? grpc.status.UNKNOWN;
+  } else if (error instanceof TaskNotFoundError) code = grpc.status.NOT_FOUND;
   else if (error instanceof TaskNotCancelableError) code = grpc.status.FAILED_PRECONDITION;
   else if (error instanceof PushNotificationNotSupportedError)
     code = grpc.status.FAILED_PRECONDITION;

--- a/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
+++ b/src/compat/v0_3/server/transports/rest/rest_transport_handler.ts
@@ -8,7 +8,7 @@ import type { ServerCallContext } from '../../../../../server/context.js';
 import type { A2ARequestHandler } from '../../../../../server/request_handler/a2a_request_handler.js';
 import {
   HTTP_STATUS,
-  mapErrorToStatus,
+  mapErrorToStatus as mapV1ErrorToStatus,
 } from '../../../../../server/transports/rest/rest_transport_handler.js';
 import type {
   AgentCard as V1AgentCard,
@@ -30,9 +30,38 @@ import { A2AError as LegacyA2AError } from '../../error.js';
 
 // Numeric A2A error codes and HTTP semantics are identical between v0.3
 // and v1.0, so we reuse the v1.0 mapping helpers as-is.
-export { HTTP_STATUS, mapErrorToStatus };
+export { HTTP_STATUS };
 
 export type { LegacyRestErrorBody };
+
+/** JSON-RPC error code -> HTTP status. */
+const LEGACY_CODE_TO_HTTP_STATUS: Readonly<Record<number, number>> = {
+  [-32700]: HTTP_STATUS.BAD_REQUEST, // Parse error
+  [-32600]: HTTP_STATUS.BAD_REQUEST, // Invalid Request
+  [-32601]: HTTP_STATUS.NOT_IMPLEMENTED, // Method not found
+  [-32602]: HTTP_STATUS.BAD_REQUEST, // Invalid params
+  [-32603]: HTTP_STATUS.INTERNAL_SERVER_ERROR, // Internal error
+  [-32001]: HTTP_STATUS.NOT_FOUND, // Task not found
+  [-32002]: HTTP_STATUS.BAD_REQUEST, // Task not cancelable
+  [-32003]: HTTP_STATUS.BAD_REQUEST, // Push notification not supported
+  [-32004]: HTTP_STATUS.BAD_REQUEST, // Unsupported operation
+  [-32005]: HTTP_STATUS.BAD_REQUEST, // Content-Type not supported
+  [-32006]: HTTP_STATUS.INTERNAL_SERVER_ERROR, // Invalid agent response
+  [-32007]: HTTP_STATUS.BAD_REQUEST, // Extended card not configured
+};
+
+/**
+ * Maps an error to its HTTP status code with v0.3-compat awareness.
+ * `LegacyA2AError` carries a JSON-RPC code rather than a class identity,
+ * so it bypasses the v1.0 class-based mapping; everything else defers
+ * to the v1.0 mapper.
+ */
+export function mapErrorToStatus(error: unknown): number {
+  if (error instanceof LegacyA2AError) {
+    return LEGACY_CODE_TO_HTTP_STATUS[error.code] ?? HTTP_STATUS.INTERNAL_SERVER_ERROR;
+  }
+  return mapV1ErrorToStatus(error);
+}
 
 /** Converts any error to a v0.3-shaped HTTP error body. */
 export function toLegacyHTTPError(error: unknown): LegacyRestErrorBody {

--- a/src/compat/v0_3/translate/messages.ts
+++ b/src/compat/v0_3/translate/messages.ts
@@ -25,8 +25,8 @@ export function toCoreMessage(compatMsg: legacy.Message): V1Message {
   if (typeof compatMsg.messageId !== 'string' || compatMsg.messageId === '') {
     throw A2AError.invalidParams('message.messageId is required');
   }
-  if (typeof compatMsg.role !== 'string') {
-    throw A2AError.invalidParams('message.role is required');
+  if (compatMsg.role !== 'user' && compatMsg.role !== 'agent') {
+    throw A2AError.invalidParams('message.role must be "user" or "agent"');
   }
   if (!Array.isArray(compatMsg.parts)) {
     throw A2AError.invalidParams('message.parts must be an array');

--- a/src/compat/v0_3/translate/messages.ts
+++ b/src/compat/v0_3/translate/messages.ts
@@ -5,6 +5,7 @@
 
 import { toCompatRole, toCoreRole } from './enums.js';
 import { toCompatPart, toCorePart } from './parts.js';
+import { A2AError } from '../server/error.js';
 import type { Message as V1Message } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
 import { deepCloneMetadata } from './_clone.js';
@@ -18,6 +19,18 @@ function nonEmptyArray<T>(value: T[]): T[] | undefined {
 }
 
 export function toCoreMessage(compatMsg: legacy.Message): V1Message {
+  if (typeof compatMsg !== 'object' || compatMsg === null) {
+    throw A2AError.invalidParams('message must be an object');
+  }
+  if (typeof compatMsg.messageId !== 'string' || compatMsg.messageId === '') {
+    throw A2AError.invalidParams('message.messageId is required');
+  }
+  if (typeof compatMsg.role !== 'string') {
+    throw A2AError.invalidParams('message.role is required');
+  }
+  if (!Array.isArray(compatMsg.parts)) {
+    throw A2AError.invalidParams('message.parts must be an array');
+  }
   return {
     messageId: compatMsg.messageId,
     contextId: compatMsg.contextId ?? '',

--- a/src/compat/v0_3/translate/parts.ts
+++ b/src/compat/v0_3/translate/parts.ts
@@ -38,6 +38,9 @@ function isCompatWrappableDataValue(
 }
 
 export function toCorePart(compatPart: legacy.Part): V1Part {
+  if (typeof compatPart !== 'object' || compatPart === null) {
+    throw A2AError.invalidParams('Each part must be an object');
+  }
   if (compatPart.kind === 'text') {
     return {
       content: { $case: 'text', value: compatPart.text },

--- a/src/compat/v0_3/translate/parts.ts
+++ b/src/compat/v0_3/translate/parts.ts
@@ -38,7 +38,7 @@ function isCompatWrappableDataValue(
 }
 
 export function toCorePart(compatPart: legacy.Part): V1Part {
-  if (typeof compatPart !== 'object' || compatPart === null) {
+  if (typeof compatPart !== 'object' || compatPart === null || Array.isArray(compatPart)) {
     throw A2AError.invalidParams('Each part must be an object');
   }
   if (compatPart.kind === 'text') {

--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -14,10 +14,15 @@ import { A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER, JSON_CONTENT_TYPE } from '..
 import { UserBuilder, delegateAsyncIterator } from './common.js';
 import { SSE_HEADERS, formatSSEEvent, formatSSEErrorEvent } from '../../sse_utils.js';
 import { Extensions } from '../../extensions.js';
-import { ContentTypeNotSupportedError, RequestMalformedError } from '../../errors.js';
+import { A2A_ERROR_CODE, ContentTypeNotSupportedError } from '../../errors.js';
 import { validateVersion } from '../version.js';
 import { LegacyJsonRpcTransportHandler } from '../../compat/v0_3/server/index.js';
-import { LEGACY_HTTP_EXTENSION_HEADER, isLegacyJsonRpcMethod } from '../../compat/v0_3/index.js';
+import {
+  LEGACY_HTTP_EXTENSION_HEADER,
+  LEGACY_METHOD_TASKS_RESUBSCRIBE,
+  isLegacyJsonRpcMethod,
+  isV1JsonRpcMethod,
+} from '../../compat/v0_3/index.js';
 
 export interface JsonRpcHandlerOptions {
   requestHandler: A2ARequestHandler;
@@ -46,6 +51,16 @@ function isLegacyRequest(body: unknown): boolean {
 }
 
 /**
+ * Returns `true` for bodies that should fall through to the v0.3
+ * dispatcher when `legacyCompat` is enabled: missing or unknown
+ * `method`.
+ */
+function shouldUseLegacyFallback(body: unknown): boolean {
+  if (typeof body !== 'object' || body === null) return false;
+  return !isV1JsonRpcMethod((body as { method?: unknown }).method);
+}
+
+/**
  * Creates Express.js middleware handling A2A JSON-RPC requests.
  *
  * @example
@@ -71,7 +86,9 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
   router.use(express.json(), jsonErrorHandler);
 
   router.post('/', async (req: Request, res: Response) => {
-    const useLegacy = legacyJsonRpcTransportHandler !== undefined && isLegacyRequest(req.body);
+    const useLegacy =
+      legacyJsonRpcTransportHandler !== undefined &&
+      (isLegacyRequest(req.body) || shouldUseLegacyFallback(req.body));
     const mapToError = useLegacy
       ? LegacyJsonRpcTransportHandler.mapToLegacyJSONRPCError
       : JsonRpcTransportHandler.mapToJSONRPCError;
@@ -106,6 +123,36 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
       }
       if (typeof (rpcResponseOrStream as AsyncGenerator)?.[Symbol.asyncIterator] === 'function') {
         const stream = rpcResponseOrStream as AsyncGenerator<JSONRPCResponse, void, undefined>;
+
+        const alwaysStreamSse =
+          useLegacy &&
+          (req.body as { method?: unknown })?.method === LEGACY_METHOD_TASKS_RESUBSCRIBE;
+        if (alwaysStreamSse) {
+          Object.entries(SSE_HEADERS).forEach(([key, value]) => {
+            res.setHeader(key, value);
+          });
+          res.flushHeaders();
+          try {
+            for await (const event of stream) {
+              res.write(formatSSEEvent(event));
+            }
+          } catch (streamError) {
+            console.error(`Error during SSE streaming (request ${req.body?.id}):`, streamError);
+            const errorResponse: JSONRPCErrorResponse = {
+              jsonrpc: '2.0',
+              id: req.body?.id || null,
+              error: mapToError(streamError),
+            };
+            if (!res.writableEnded) {
+              res.write(formatSSEErrorEvent(errorResponse));
+            }
+          } finally {
+            if (!res.writableEnded) {
+              res.end();
+            }
+          }
+          return;
+        }
 
         // Peek the first event BEFORE flushing SSE headers so an early
         // failure (e.g. `resubscribe` on a terminal task, which throws
@@ -224,9 +271,10 @@ export const jsonErrorHandler: ErrorRequestHandler = (
     const errorResponse: JSONRPCErrorResponse = {
       jsonrpc: '2.0',
       id: null,
-      error: JsonRpcTransportHandler.mapToJSONRPCError(
-        new RequestMalformedError('Invalid JSON payload.')
-      ),
+      error: {
+        code: A2A_ERROR_CODE.PARSE_ERROR,
+        message: 'Invalid JSON payload.',
+      },
     };
     return res.status(400).json(errorResponse);
   }

--- a/tck/compat-agent/README.md
+++ b/tck/compat-agent/README.md
@@ -1,0 +1,19 @@
+# SUT Agent (v0.3 compat)
+
+A v1.0-native SUT for the [a2a-tck](https://github.com/a2aproject/a2a-tck) v0.3 suite. Built on the same v1.0 SDK as the production server samples but with the v0.3 backward-compatibility layer (`@a2a-js/sdk/compat/v0_3/...`) enabled on every transport, so the TCK can drive this agent unchanged while the SDK runs in its modern shape.
+
+To run:
+
+```bash
+npm run tck:compat-sut-agent
+```
+
+Endpoints (defaults — override with `HTTP_PORT` / `GRPC_PORT` env vars):
+
+| Transport  | URL                                                  | Versions accepted                              |
+| ---------- | ---------------------------------------------------- | ---------------------------------------------- |
+| JSON-RPC   | `http://localhost:41241/a2a/jsonrpc`                 | v1.0 + v0.3                                    |
+| REST v1.0  | `http://localhost:41241/a2a/rest`                    | v1.0                                           |
+| REST v0.3  | `http://localhost:41241/a2a/rest/v1`                 | v0.3                                           |
+| Agent card | `http://localhost:41241/.well-known/agent-card.json` | shape depends on `A2A-Version` header          |
+| gRPC       | `localhost:41242`                                    | v1.0 + v0.3 (services registered side-by-side) |

--- a/tck/compat-agent/index.ts
+++ b/tck/compat-agent/index.ts
@@ -67,13 +67,15 @@ import { LegacyA2AService, legacyGrpcService } from '../../src/compat/v0_3/serve
  */
 class SUTAgentExecutor implements AgentExecutor {
   private runningTask: Set<string> = new Set();
-  private lastContextId?: string;
+  private taskContexts: Map<string, string> = new Map();
 
   public cancelTask = async (taskId: string, eventBus: ExecutionEventBus): Promise<void> => {
     this.runningTask.delete(taskId);
+    const contextId = this.taskContexts.get(taskId) ?? uuidv4();
+    this.taskContexts.delete(taskId);
     const cancelledUpdate: TaskStatusUpdateEvent = {
       taskId: taskId,
-      contextId: this.lastContextId ?? uuidv4(),
+      contextId: contextId,
       status: {
         state: TaskState.TASK_STATE_CANCELED,
         timestamp: new Date().toISOString(),
@@ -91,7 +93,7 @@ class SUTAgentExecutor implements AgentExecutor {
     const taskId = requestContext.taskId;
     const contextId = requestContext.contextId;
 
-    this.lastContextId = contextId;
+    this.taskContexts.set(taskId, contextId);
     this.runningTask.add(taskId);
 
     console.log(

--- a/tck/compat-agent/index.ts
+++ b/tck/compat-agent/index.ts
@@ -1,0 +1,341 @@
+/**
+ * SUT agent for the a2a-tck `0.3.0.beta5` test suite — built on the
+ * v1.0 SDK with the v0.3 compatibility layer enabled across every
+ * transport. The TCK speaks v0.3 on the wire; the compat layer
+ * translates v0.3 ↔ v1.0 inside the SDK so the agent executor only ever
+ * sees v1.0 types.
+ *
+ * This is the canonical wiring:
+ *
+ *   - JSON-RPC over HTTP at `/a2a/jsonrpc` with
+ *     `legacyCompat: { enabled: true }`.
+ *   - HTTP+JSON/REST mounted at `/a2a/rest` with
+ *     `legacyCompat: { enabled: true }` — the legacy router exposes
+ *     v0.3 reference routes under `/a2a/rest/v1/...` while v1.0 routes
+ *     stay at `/a2a/rest/...`.
+ *   - gRPC at `localhost:41242` with both the v1.0 `A2AService` and the
+ *     v0.3 `LegacyA2AService` registered on the same `grpc.Server`. The
+ *     v1.0 gRPC service factory deliberately has no `legacyCompat`
+ *     opt-in — v0.3 gRPC clients are served by registering
+ *     `legacyGrpcService` alongside.
+ *   - The well-known agent-card endpoint at `/.well-known/agent-card.json`
+ *     with `legacyCompat: { enabled: true }` — the `A2A-Version` header
+ *     (defaulting to `'0.3'` per spec §3.6.2) selects the v0.3-shaped
+ *     hybrid card synthesized from the v1.0 `supportedInterfaces` by
+ *     `toCompatAgentCard(card, { synthesize: true })`.
+ *
+ * The agent card declares ONLY v1.0 `supportedInterfaces`. The compat
+ * layer synthesizes the v0.3 surface (`url`, `preferredTransport`,
+ * `additionalInterfaces`, top-level `protocolVersion: '0.3'`) on the
+ * fly — no operator-side duplication required.
+ */
+
+import express from 'express';
+import { Server, ServerCredentials } from '@grpc/grpc-js';
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  A2A_PROTOCOL_VERSION,
+  AgentCard,
+  Task,
+  TaskStatusUpdateEvent,
+  Message,
+  TaskState,
+  Role,
+} from '../../src/index.js';
+import {
+  InMemoryTaskStore,
+  TaskStore,
+  AgentExecutor,
+  RequestContext,
+  ExecutionEventBus,
+  DefaultRequestHandler,
+  AgentEvent,
+} from '../../src/server/index.js';
+import {
+  jsonRpcHandler,
+  agentCardHandler,
+  restHandler,
+  UserBuilder,
+} from '../../src/server/express/index.js';
+import { grpcService, A2AService } from '../../src/server/grpc/index.js';
+import { LegacyA2AService, legacyGrpcService } from '../../src/compat/v0_3/server/grpc/index.js';
+
+/**
+ * SUTAgentExecutor implements the agent's core logic. Kept in lockstep
+ * with `tck/agent/index.ts` so both SUTs answer the TCK identically.
+ */
+class SUTAgentExecutor implements AgentExecutor {
+  private runningTask: Set<string> = new Set();
+  private lastContextId?: string;
+
+  public cancelTask = async (taskId: string, eventBus: ExecutionEventBus): Promise<void> => {
+    this.runningTask.delete(taskId);
+    const cancelledUpdate: TaskStatusUpdateEvent = {
+      taskId: taskId,
+      contextId: this.lastContextId ?? uuidv4(),
+      status: {
+        state: TaskState.TASK_STATE_CANCELED,
+        timestamp: new Date().toISOString(),
+        message: undefined,
+      },
+      metadata: {},
+    };
+    eventBus.publish(AgentEvent.statusUpdate(cancelledUpdate));
+  };
+
+  async execute(requestContext: RequestContext, eventBus: ExecutionEventBus): Promise<void> {
+    const userMessage = requestContext.userMessage;
+    const existingTask = requestContext.task;
+
+    const taskId = requestContext.taskId;
+    const contextId = requestContext.contextId;
+
+    this.lastContextId = contextId;
+    this.runningTask.add(taskId);
+
+    console.log(
+      `[SUTAgentExecutor] Processing message ${userMessage.messageId} for task ${taskId} (context: ${contextId})`
+    );
+
+    if (!existingTask) {
+      const initialTask: Task = {
+        id: taskId,
+        contextId: contextId,
+        status: {
+          state: TaskState.TASK_STATE_SUBMITTED,
+          timestamp: new Date().toISOString(),
+          message: undefined,
+        },
+        artifacts: [],
+        history: [userMessage],
+        metadata: userMessage.metadata,
+      };
+      eventBus.publish(AgentEvent.task(initialTask));
+    }
+
+    const workingStatusUpdate: TaskStatusUpdateEvent = {
+      taskId: taskId,
+      contextId: contextId,
+      status: {
+        state: TaskState.TASK_STATE_WORKING,
+        message: {
+          role: Role.ROLE_AGENT,
+          messageId: uuidv4(),
+          parts: [
+            {
+              content: { $case: 'text', value: 'Processing your question' },
+              metadata: undefined,
+              filename: '',
+              mediaType: 'text/plain',
+            },
+          ],
+          taskId: taskId,
+          contextId: contextId,
+          extensions: [],
+          metadata: {},
+          referenceTaskIds: [],
+        },
+        timestamp: new Date().toISOString(),
+      },
+      metadata: {},
+    };
+    eventBus.publish(AgentEvent.statusUpdate(workingStatusUpdate));
+
+    const agentReplyText = this.parseInputMessage(userMessage);
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    if (!this.runningTask.has(taskId)) {
+      console.log(
+        `[SUTAgentExecutor] Task ${taskId} was cancelled before processing could complete.`
+      );
+      return;
+    }
+    console.info(`[SUTAgentExecutor] Prompt response: ${agentReplyText}`);
+
+    const agentMessage: Message = {
+      role: Role.ROLE_AGENT,
+      messageId: uuidv4(),
+      parts: [
+        {
+          content: { $case: 'text', value: agentReplyText },
+          metadata: undefined,
+          filename: '',
+          mediaType: 'text/plain',
+        },
+      ],
+      taskId: taskId,
+      contextId: contextId,
+      extensions: [],
+      metadata: {},
+      referenceTaskIds: [],
+    };
+
+    const finalUpdate: TaskStatusUpdateEvent = {
+      taskId: taskId,
+      contextId: contextId,
+      status: {
+        state: TaskState.TASK_STATE_INPUT_REQUIRED,
+        message: agentMessage,
+        timestamp: new Date().toISOString(),
+      },
+      metadata: {},
+    };
+    eventBus.publish(AgentEvent.statusUpdate(finalUpdate));
+  }
+
+  parseInputMessage(message: Message): string {
+    const textPart = message.parts.find((part) => part.content?.$case === 'text');
+    const query = textPart?.content?.$case === 'text' ? textPart.content.value.trim() : '';
+
+    if (!query) {
+      return 'Hello! Please provide a message for me to respond to.';
+    }
+
+    const queryLower = query.toLowerCase();
+    if (queryLower.includes('hello') || queryLower.includes('hi')) {
+      return 'Hello World! How are you?';
+    } else if (queryLower.includes('how are you')) {
+      return "I'm doing great! Thanks for asking. How can I help you today?";
+    } else {
+      return `Hello World! You said: '${query}'. Please, send me a new message.`;
+    }
+  }
+}
+
+// --- Server Setup ---
+
+const HTTP_PORT = Number(process.env.HTTP_PORT || 41241);
+const GRPC_PORT = Number(process.env.GRPC_PORT || 41242);
+
+// Card declares ONLY v1.0 interfaces. The compat layer synthesizes the
+// v0.3 view (top-level `url` / `preferredTransport` /
+// `additionalInterfaces`) from these entries when the well-known
+// endpoint sees `A2A-Version: 0.3` (or a missing header, which §3.6.2
+// defaults to `'0.3'`).
+const SUTAgentCard: AgentCard = {
+  name: 'SUT Agent (compat)',
+  description:
+    'v1.0-native SUT agent for the a2a-tck v0.3 suite. The v0.3 compat ' +
+    'layer is enabled on every transport, so the TCK can drive this ' +
+    'agent unchanged.',
+  supportedInterfaces: [
+    {
+      url: `http://localhost:${HTTP_PORT}/a2a/jsonrpc`,
+      protocolBinding: 'JSONRPC',
+      tenant: '',
+      protocolVersion: A2A_PROTOCOL_VERSION,
+    },
+    {
+      url: `http://localhost:${HTTP_PORT}/a2a/rest`,
+      protocolBinding: 'HTTP+JSON',
+      tenant: '',
+      protocolVersion: A2A_PROTOCOL_VERSION,
+    },
+    {
+      url: `http://localhost:${GRPC_PORT}`,
+      protocolBinding: 'GRPC',
+      tenant: '',
+      protocolVersion: A2A_PROTOCOL_VERSION,
+    },
+  ],
+  provider: {
+    organization: 'A2A Samples',
+    url: 'https://example.com/a2a-samples',
+  },
+  documentationUrl: 'https://example.com/docs',
+  securitySchemes: {},
+  signatures: [],
+  securityRequirements: [],
+  version: '1.0.0',
+  capabilities: {
+    streaming: true,
+    pushNotifications: false,
+    extensions: [],
+    extendedAgentCard: false,
+  },
+  defaultInputModes: ['text'],
+  defaultOutputModes: ['text', 'task-status'],
+  skills: [
+    {
+      id: 'sut_agent',
+      name: 'SUT Agent',
+      description: 'Simulate the general flow of a streaming agent.',
+      tags: ['sut'],
+      examples: ['hi', 'hello world', 'how are you', 'goodbye'],
+      inputModes: ['text'],
+      outputModes: ['text', 'task-status'],
+      securityRequirements: [],
+    },
+  ],
+};
+
+async function main() {
+  const taskStore: TaskStore = new InMemoryTaskStore();
+  const agentExecutor: AgentExecutor = new SUTAgentExecutor();
+  const requestHandler = new DefaultRequestHandler(SUTAgentCard, taskStore, agentExecutor);
+
+  const expressApp = express();
+
+  // Agent card with compat: serves a hybrid v0.3 + v1.0 card for v0.3
+  // clients (header missing or 0.3) and the v1.0 card for v1.0 clients.
+  expressApp.use(
+    '/.well-known/agent-card.json',
+    agentCardHandler({
+      agentCardProvider: requestHandler,
+      legacyCompat: { enabled: true },
+    })
+  );
+
+  // JSON-RPC with compat: same endpoint accepts both v1.0 and v0.3 bodies.
+  expressApp.use(
+    '/a2a/jsonrpc',
+    jsonRpcHandler({
+      requestHandler,
+      userBuilder: UserBuilder.noAuthentication,
+      legacyCompat: { enabled: true },
+    })
+  );
+
+  // REST with compat: v1.0 routes at `/a2a/rest/...` AND v0.3 reference
+  // routes at `/a2a/rest/v1/...` share the same mount point.
+  expressApp.use(
+    '/a2a/rest',
+    restHandler({
+      requestHandler,
+      userBuilder: UserBuilder.noAuthentication,
+      legacyCompat: { enabled: true },
+    })
+  );
+
+  expressApp.listen(HTTP_PORT, (err) => {
+    if (err) {
+      throw err;
+    }
+    console.log(`[SUTAgent] HTTP server started on http://localhost:${HTTP_PORT}`);
+    console.log(`[SUTAgent] Agent Card: http://localhost:${HTTP_PORT}/.well-known/agent-card.json`);
+    console.log(`[SUTAgent] JSON-RPC  : http://localhost:${HTTP_PORT}/a2a/jsonrpc  (v1.0 + v0.3)`);
+    console.log(`[SUTAgent] REST v1.0 : http://localhost:${HTTP_PORT}/a2a/rest`);
+    console.log(`[SUTAgent] REST v0.3 : http://localhost:${HTTP_PORT}/a2a/rest/v1`);
+    console.log('[SUTAgent] Press Ctrl+C to stop the server');
+  });
+
+  // gRPC: BOTH the v1.0 and v0.3 services on a single Server.
+  const grpcServer = new Server();
+  grpcServer.addService(
+    A2AService,
+    grpcService({ requestHandler, userBuilder: UserBuilder.noAuthentication })
+  );
+  grpcServer.addService(
+    LegacyA2AService,
+    legacyGrpcService({ requestHandler, userBuilder: UserBuilder.noAuthentication })
+  );
+  grpcServer.bindAsync(`localhost:${GRPC_PORT}`, ServerCredentials.createInsecure(), (err) => {
+    if (err) {
+      console.error('[SUTAgent] gRPC bind failed:', err);
+      return;
+    }
+    console.log(`[SUTAgent] gRPC server running at localhost:${GRPC_PORT}  (v1.0 + v0.3)`);
+  });
+}
+
+main().catch(console.error);

--- a/tck/package.json
+++ b/tck/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "SUT agent for tck tests CI",
   "scripts": {
-    "tck:sut-agent": "tsx agent/index.ts"
-
+    "tck:sut-agent": "tsx agent/index.ts",
+    "tck:compat-sut-agent": "tsx compat-agent/index.ts"
   }
 }

--- a/test/compat/v0_3/constants.spec.ts
+++ b/test/compat/v0_3/constants.spec.ts
@@ -26,6 +26,8 @@ import {
   legacyJsonRpcToV1Method,
   v1MethodToLegacyGrpc,
   v1MethodToLegacyJsonRpc,
+  isLegacyJsonRpcMethod,
+  isV1JsonRpcMethod,
 } from '../../../src/compat/v0_3/constants.js';
 import { A2AError } from '../../../src/compat/v0_3/server/error.js';
 
@@ -265,5 +267,55 @@ describe('compat/v0_3/constants - divergent-name spot checks', () => {
     expect(legacyGrpcToV1Method('ListTaskPushNotificationConfig')).toBe(
       'ListTaskPushNotificationConfigs'
     );
+  });
+});
+
+describe('compat/v0_3/constants - method classification predicates', () => {
+  describe('isLegacyJsonRpcMethod', () => {
+    it('returns true for every known v0.3 JSON-RPC method', () => {
+      for (const method of ALL_LEGACY_METHODS) {
+        expect(isLegacyJsonRpcMethod(method)).toBe(true);
+      }
+    });
+
+    it('returns false for v1.0 PascalCase methods', () => {
+      expect(isLegacyJsonRpcMethod('SendMessage')).toBe(false);
+      expect(isLegacyJsonRpcMethod('ListTasks')).toBe(false);
+    });
+
+    it('returns false for non-string inputs and unknown strings', () => {
+      expect(isLegacyJsonRpcMethod(undefined)).toBe(false);
+      expect(isLegacyJsonRpcMethod(null)).toBe(false);
+      expect(isLegacyJsonRpcMethod(42)).toBe(false);
+      expect(isLegacyJsonRpcMethod('nonexistent/method')).toBe(false);
+    });
+  });
+
+  describe('isV1JsonRpcMethod', () => {
+    it('returns true for every v1.0 method present in V1_TO_LEGACY_JSONRPC', () => {
+      for (const v1Name of Object.keys(V1_TO_LEGACY_JSONRPC)) {
+        expect(isV1JsonRpcMethod(v1Name)).toBe(true);
+      }
+    });
+
+    it('returns true for v1.0-only methods (e.g. ListTasks)', () => {
+      for (const v1Name of V1_METHODS_WITHOUT_LEGACY_EQUIVALENT) {
+        expect(isV1JsonRpcMethod(v1Name)).toBe(true);
+      }
+    });
+
+    it('returns false for v0.3 method names', () => {
+      for (const method of ALL_LEGACY_METHODS) {
+        expect(isV1JsonRpcMethod(method)).toBe(false);
+      }
+    });
+
+    it('returns false for non-string inputs and unknown strings', () => {
+      expect(isV1JsonRpcMethod(undefined)).toBe(false);
+      expect(isV1JsonRpcMethod(null)).toBe(false);
+      expect(isV1JsonRpcMethod(42)).toBe(false);
+      expect(isV1JsonRpcMethod('')).toBe(false);
+      expect(isV1JsonRpcMethod('FakeMethodName')).toBe(false);
+    });
   });
 });

--- a/test/compat/v0_3/server/express/rest_handler.spec.ts
+++ b/test/compat/v0_3/server/express/rest_handler.spec.ts
@@ -1,0 +1,182 @@
+import express from 'express';
+import request from 'supertest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { legacyRestRouter } from '../../../../../src/compat/v0_3/server/express/rest_handler.js';
+import { UserBuilder } from '../../../../../src/server/express/common.js';
+import { Role, TaskState } from '../../../../../src/types/pb/a2a.js';
+import type { A2ARequestHandler } from '../../../../../src/server/request_handler/a2a_request_handler.js';
+import type { AgentCard as V1AgentCard, Task as V1Task } from '../../../../../src/types/pb/a2a.js';
+
+const agentCard: V1AgentCard = {
+  name: 'Test',
+  description: '',
+  version: '1.0.0',
+  capabilities: { streaming: false, pushNotifications: false, extensions: [] },
+  defaultInputModes: [],
+  defaultOutputModes: [],
+  skills: [],
+  securityRequirements: [],
+  securitySchemes: {},
+  provider: undefined,
+  signatures: [],
+  supportedInterfaces: [
+    { url: 'http://x', protocolBinding: 'HTTP+JSON', tenant: '', protocolVersion: '0.3' },
+  ],
+  documentationUrl: '',
+  iconUrl: '',
+};
+
+function makeApp(handler: A2ARequestHandler) {
+  const app = express();
+  app.use(legacyRestRouter({ requestHandler: handler, userBuilder: UserBuilder.noAuthentication }));
+  return app;
+}
+
+function newMockHandler(): A2ARequestHandler {
+  return {
+    getAgentCard: vi.fn().mockResolvedValue(agentCard),
+    getAuthenticatedExtendedAgentCard: vi.fn(),
+    sendMessage: vi.fn(),
+    sendMessageStream: vi.fn(),
+    getTask: vi.fn(),
+    cancelTask: vi.fn(),
+    createTaskPushNotificationConfig: vi.fn(),
+    getTaskPushNotificationConfig: vi.fn(),
+    listTaskPushNotificationConfigs: vi.fn(),
+    deleteTaskPushNotificationConfig: vi.fn(),
+    resubscribe: vi.fn(),
+    listTasks: vi.fn(),
+  };
+}
+
+const validSendBody = {
+  message: {
+    message_id: 'm-1',
+    role: 'ROLE_USER',
+    content: [{ text: 'hi' }],
+  },
+};
+
+describe('legacyRestRouter wire format', () => {
+  let handler: A2ARequestHandler;
+
+  beforeEach(() => {
+    handler = newMockHandler();
+  });
+
+  it('emits top-level proto fields as snake_case', async () => {
+    const task: V1Task = {
+      id: 't-1',
+      contextId: 'ctx-abc',
+      status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
+      artifacts: [],
+      history: [],
+      metadata: undefined,
+    };
+    (handler.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue(task);
+
+    const response = await request(makeApp(handler))
+      .post('/v1/message:send')
+      .set('Content-Type', 'application/json')
+      .send(validSendBody)
+      .expect(201);
+
+    // Wire contract: snake_case keys, not camelCase.
+    expect(response.body).toHaveProperty('task');
+    expect(response.body.task).toHaveProperty('id', 't-1');
+    expect(response.body.task).toHaveProperty('context_id', 'ctx-abc');
+    expect(response.body.task).not.toHaveProperty('contextId');
+  });
+
+  it('passes user-supplied keys inside Task.metadata through untouched', async () => {
+    // Arbitrary app-level metadata with camelCase keys the user authored.
+    // Snake-casing these would corrupt their data.
+    const task: V1Task = {
+      id: 't-1',
+      contextId: 'ctx-abc',
+      status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
+      artifacts: [],
+      history: [],
+      metadata: { myCustomField: 'value', anotherKey: 42, nestedObj: { keepAsIs: true } },
+    };
+    (handler.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue(task);
+
+    const response = await request(makeApp(handler))
+      .post('/v1/message:send')
+      .set('Content-Type', 'application/json')
+      .send(validSendBody)
+      .expect(201);
+
+    expect(response.body.task.metadata).toEqual({
+      myCustomField: 'value',
+      anotherKey: 42,
+      nestedObj: { keepAsIs: true },
+    });
+  });
+
+  it('passes user-supplied keys inside DataPart.data through untouched', async () => {
+    // Returns a Message whose part is a DataPart carrying a user-keyed object.
+    // v1.0 Part.content.$case='data' value is the user map directly.
+    (handler.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messageId: 'm-resp',
+      contextId: '',
+      taskId: '',
+      role: Role.ROLE_AGENT,
+      parts: [
+        {
+          content: {
+            $case: 'data',
+            value: { userKey: 1, nested: { keepCamelCase: true } },
+          },
+          metadata: undefined,
+          filename: '',
+          mediaType: 'application/json',
+        },
+      ],
+      metadata: undefined,
+      extensions: [],
+      referenceTaskIds: [],
+    });
+
+    const response = await request(makeApp(handler))
+      .post('/v1/message:send')
+      .set('Content-Type', 'application/json')
+      .send(validSendBody)
+      .expect(201);
+
+    expect(response.body).toHaveProperty('message');
+    expect(response.body.message.content).toHaveLength(1);
+    // Wire shape: `content[0].data` is the proto oneof discriminator for
+    // DataPart; `.data.data` is the DataPart.data field (the user map).
+    // The inner map's camelCase keys MUST round-trip unchanged.
+    expect(response.body.message.content[0].data.data).toEqual({
+      userKey: 1,
+      nested: { keepCamelCase: true },
+    });
+  });
+
+  it('passes user-supplied keys inside Message.metadata through untouched', async () => {
+    (handler.sendMessage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      messageId: 'm-resp',
+      contextId: '',
+      taskId: '',
+      role: Role.ROLE_AGENT,
+      parts: [],
+      metadata: { fooBar: 'baz', anotherCamelKey: [1, 2, 3] },
+      extensions: [],
+      referenceTaskIds: [],
+    });
+
+    const response = await request(makeApp(handler))
+      .post('/v1/message:send')
+      .set('Content-Type', 'application/json')
+      .send(validSendBody)
+      .expect(201);
+
+    expect(response.body.message.metadata).toEqual({
+      fooBar: 'baz',
+      anotherCamelKey: [1, 2, 3],
+    });
+  });
+});

--- a/test/compat/v0_3/server/grpc/grpc_service.spec.ts
+++ b/test/compat/v0_3/server/grpc/grpc_service.spec.ts
@@ -6,6 +6,7 @@ import {
   TaskNotCancelableError,
   TaskNotFoundError,
 } from '../../../../../src/errors.js';
+import { A2AError as LegacyA2AError } from '../../../../../src/compat/v0_3/server/error.js';
 import { A2A_VERSION_HEADER, HTTP_EXTENSION_HEADER } from '../../../../../src/constants.js';
 import type { A2ARequestHandler } from '../../../../../src/server/request_handler/a2a_request_handler.js';
 import {
@@ -191,6 +192,64 @@ describe('legacyGrpcService', () => {
       expect(status.details.length).toBeGreaterThan(0);
       const errorInfo = decodeErrorInfo(status.details[0]!.value as unknown as Buffer);
       expect(errorInfo.reason).toBe('TASK_NOT_FOUND');
+    });
+
+    it('maps a thrown LegacyA2AError.invalidParams (-32602) to INVALID_ARGUMENT', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockRejectedValue(
+        LegacyA2AError.invalidParams('Invalid role: 0')
+      );
+      const call = createMockUnaryCall({
+        request: { messageId: 'm1', role: V1Role.ROLE_USER, content: [] },
+      });
+      const callback = vi.fn();
+
+      await handler.sendMessage(call, callback);
+
+      const [err] = callback.mock.calls[0];
+      expect(err.code).toBe(grpc.status.INVALID_ARGUMENT);
+      expect(err.details).toBe('Invalid role: 0');
+    });
+
+    it('maps LegacyA2AError.taskNotFound (-32001) to NOT_FOUND', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockRejectedValue(
+        LegacyA2AError.taskNotFound('t-1')
+      );
+      const call = createMockUnaryCall({
+        request: { messageId: 'm1', role: V1Role.ROLE_USER, content: [] },
+      });
+      const callback = vi.fn();
+
+      await handler.sendMessage(call, callback);
+
+      expect(callback.mock.calls[0][0].code).toBe(grpc.status.NOT_FOUND);
+    });
+
+    it('maps LegacyA2AError.methodNotFound (-32601) to UNIMPLEMENTED', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockRejectedValue(
+        LegacyA2AError.methodNotFound('whatever')
+      );
+      const call = createMockUnaryCall({
+        request: { messageId: 'm1', role: V1Role.ROLE_USER, content: [] },
+      });
+      const callback = vi.fn();
+
+      await handler.sendMessage(call, callback);
+
+      expect(callback.mock.calls[0][0].code).toBe(grpc.status.UNIMPLEMENTED);
+    });
+
+    it('maps LegacyA2AError.internalError (-32603) to INTERNAL', async () => {
+      (mockRequestHandler.sendMessage as Mock).mockRejectedValue(
+        LegacyA2AError.internalError('boom')
+      );
+      const call = createMockUnaryCall({
+        request: { messageId: 'm1', role: V1Role.ROLE_USER, content: [] },
+      });
+      const callback = vi.fn();
+
+      await handler.sendMessage(call, callback);
+
+      expect(callback.mock.calls[0][0].code).toBe(grpc.status.INTERNAL);
     });
   });
 

--- a/test/compat/v0_3/server/transports/rest/rest_transport_handler.spec.ts
+++ b/test/compat/v0_3/server/transports/rest/rest_transport_handler.spec.ts
@@ -163,6 +163,29 @@ describe('LegacyRestTransportHandler', () => {
     it('maps unknown errors to 500', () => {
       expect(mapErrorToStatus(new Error('???'))).toBe(HTTP_STATUS.INTERNAL_SERVER_ERROR);
     });
+
+    it('maps LegacyA2AError.invalidParams (-32602) to 400', () => {
+      expect(mapErrorToStatus(LegacyA2AError.invalidParams('bad'))).toBe(HTTP_STATUS.BAD_REQUEST);
+    });
+    it('maps LegacyA2AError.invalidRequest (-32600) to 400', () => {
+      expect(mapErrorToStatus(LegacyA2AError.invalidRequest('bad'))).toBe(HTTP_STATUS.BAD_REQUEST);
+    });
+    it('maps LegacyA2AError.parseError (-32700) to 400', () => {
+      expect(mapErrorToStatus(LegacyA2AError.parseError('bad'))).toBe(HTTP_STATUS.BAD_REQUEST);
+    });
+    it('maps LegacyA2AError.methodNotFound (-32601) to 501', () => {
+      expect(mapErrorToStatus(LegacyA2AError.methodNotFound('x'))).toBe(
+        HTTP_STATUS.NOT_IMPLEMENTED
+      );
+    });
+    it('maps LegacyA2AError.taskNotFound (-32001) to 404', () => {
+      expect(mapErrorToStatus(LegacyA2AError.taskNotFound('t'))).toBe(HTTP_STATUS.NOT_FOUND);
+    });
+    it('maps LegacyA2AError.internalError (-32603) to 500', () => {
+      expect(mapErrorToStatus(LegacyA2AError.internalError('x'))).toBe(
+        HTTP_STATUS.INTERNAL_SERVER_ERROR
+      );
+    });
   });
 
   // ==========================================================================

--- a/test/compat/v0_3/translate/messages.spec.ts
+++ b/test/compat/v0_3/translate/messages.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { toCompatMessage, toCoreMessage } from '../../../../src/compat/v0_3/translate/messages.js';
+import { A2AError } from '../../../../src/compat/v0_3/server/error.js';
 import { Role } from '../../../../src/types/pb/a2a.js';
 import type { Message as V1Message } from '../../../../src/types/pb/a2a.js';
 import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
@@ -126,6 +127,52 @@ describe('messages', () => {
         referenceTaskIds: ['t2'],
       };
       expect(toCompatMessage(toCoreMessage(compat))).toEqual(compat);
+    });
+  });
+
+  describe('input validation', () => {
+    it('rejects a non-object message with invalidParams', () => {
+      expect(() => toCoreMessage(undefined as unknown as legacy.Message)).toThrowError(A2AError);
+      expect(() => toCoreMessage(undefined as unknown as legacy.Message)).toThrow(/object/);
+    });
+
+    it('rejects a message missing messageId with invalidParams', () => {
+      const bad = { kind: 'message', role: 'user', parts: [] } as unknown as legacy.Message;
+      expect(() => toCoreMessage(bad)).toThrowError(A2AError);
+      expect(() => toCoreMessage(bad)).toThrow(/messageId/);
+    });
+
+    it('rejects a message missing role with invalidParams', () => {
+      const bad = { kind: 'message', messageId: 'm', parts: [] } as unknown as legacy.Message;
+      expect(() => toCoreMessage(bad)).toThrowError(A2AError);
+      expect(() => toCoreMessage(bad)).toThrow(/role/);
+    });
+
+    it('rejects a message whose parts field is not an array', () => {
+      const bad = {
+        kind: 'message',
+        messageId: 'm',
+        role: 'user',
+        parts: 'invalid',
+      } as unknown as legacy.Message;
+      expect(() => toCoreMessage(bad)).toThrowError(A2AError);
+      expect(() => toCoreMessage(bad)).toThrow(/parts/);
+    });
+
+    it('rejects a message whose parts field is missing', () => {
+      const bad = { kind: 'message', messageId: 'm', role: 'user' } as unknown as legacy.Message;
+      expect(() => toCoreMessage(bad)).toThrowError(A2AError);
+      expect(() => toCoreMessage(bad)).toThrow(/parts/);
+    });
+
+    it('thrown errors carry the JSON-RPC invalid-params code', () => {
+      try {
+        toCoreMessage({ kind: 'message' } as unknown as legacy.Message);
+        expect.fail('toCoreMessage should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(A2AError);
+        expect((err as A2AError).code).toBe(-32602);
+      }
     });
   });
 

--- a/test/compat/v0_3/translate/messages.spec.ts
+++ b/test/compat/v0_3/translate/messages.spec.ts
@@ -148,6 +148,17 @@ describe('messages', () => {
       expect(() => toCoreMessage(bad)).toThrow(/role/);
     });
 
+    it('rejects a message whose role is not "user" or "agent"', () => {
+      const bad = {
+        kind: 'message',
+        messageId: 'm',
+        role: 'system',
+        parts: [],
+      } as unknown as legacy.Message;
+      expect(() => toCoreMessage(bad)).toThrowError(A2AError);
+      expect(() => toCoreMessage(bad)).toThrow(/"user" or "agent"/);
+    });
+
     it('rejects a message whose parts field is not an array', () => {
       const bad = {
         kind: 'message',

--- a/test/compat/v0_3/translate/parts.spec.ts
+++ b/test/compat/v0_3/translate/parts.spec.ts
@@ -124,6 +124,12 @@ describe('parts', () => {
       const compat = { kind: 'unknown' } as unknown as legacy.Part;
       expect(() => toCorePart(compat)).toThrow(A2AError);
     });
+
+    it('rejects a non-object entry (typeof [] === "object")', () => {
+      expect(() => toCorePart(null as unknown as legacy.Part)).toThrow(/object/);
+      expect(() => toCorePart('text' as unknown as legacy.Part)).toThrow(/object/);
+      expect(() => toCorePart([] as unknown as legacy.Part)).toThrow(/object/);
+    });
   });
 
   describe('toCompatPart', () => {

--- a/test/server/express/express_app.spec.ts
+++ b/test/server/express/express_app.spec.ts
@@ -626,19 +626,13 @@ describe('A2AExpressApp', () => {
         .send(requestBody)
         .expect(400);
 
+      // JSON-RPC 2.0 §4.2: parse errors use code -32700.
       const expectedErrorResponse: JSONRPCErrorResponse = {
         jsonrpc: '2.0',
         id: null,
         error: {
-          code: A2A_ERROR_CODE.INVALID_PARAMS,
+          code: A2A_ERROR_CODE.PARSE_ERROR,
           message: 'Invalid JSON payload.',
-          data: [
-            {
-              '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
-              reason: 'INVALID_PARAMS',
-              domain: 'a2a-protocol.org',
-            },
-          ],
         },
       };
       assert.deepEqual(response.body, expectedErrorResponse);


### PR DESCRIPTION
# Description

Adds a CI workflow (run-tck-compat.yaml) that drives the upstream a2a-tck@0.3.0.beta5 suite against a new SUT (tck/compat-agent/) — a v1.0-native server with legacyCompat: { enabled: true } on every transport. Triggers on main and epic/**, exercises JSON-RPC, REST, and gRPC.

Fixes v0.3 compat-layer bugs the TCK surfaced:
- JSON-RPC error codes — parse errors now emit -32700 (was -32602); bodies with missing/unknown method route through the v0.3 dispatcher and surface -32600 per §3.6.2 default-to-v0.3 (new isV1JsonRpcMethod helper drives the fallback).
- Translator input validation — toCoreMessage / toCorePart reject malformed v0.3 messages with -32602 Invalid params instead of crashing into -32603 Internal error.
- gRPC + REST error mapping — LegacyA2AError now translates to the right grpc.status and HTTP 4xx via LEGACY_CODE_TO_GRPC_STATUS and a compat-aware mapErrorToStatus (was falling through to UNKNOWN / 500).
- tasks/resubscribe always SSE — opens text/event-stream before peeking the first event and emits errors as SSE events; strict v0.3 clients reject anything else.
- REST output casing — v0.3 REST emits snake_case (context_id, message_id, …) to match the v0.3 reference proto; input still accepts both forms.