### PR TITLE
feat(compat): replace automatic v0.3 agent card synthesis with explicit per-interface advertisement

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ compat surface is shipped as six subpath exports off `@a2a-js/sdk`:
 
 See the end-user [v0.3 compatibility guide](docs/compatibility-v0_3.md) for
 opt-in mechanics and caveats (dropped fields, defaults, unavailable
-methods like `ListTasks`, push-notification routing, agent-card synthesis).
+methods like `ListTasks`, push-notification routing, per-interface v0.3 advertisement).
 For the architecture-level walkthrough — translators, version negotiation
 under §3.6.2, push-notification wire-version routing — see
 [`src/compat/v0_3/README.md`](src/compat/v0_3/README.md), and the

--- a/docs/compatibility-v0_3.md
+++ b/docs/compatibility-v0_3.md
@@ -9,8 +9,8 @@ without forcing every client (or every server) to upgrade in lockstep.
 This guide is written for **end users** of the SDK — server operators
 deciding whether to turn the compat layer on, and client developers who need
 to talk to peers that haven't migrated yet. For the architecture-level
-walkthrough (translators, version negotiation internals, card synthesis
-algorithm), see [`src/compat/v0_3/README.md`](../src/compat/v0_3/README.md).
+walkthrough (translators, version negotiation internals, card-shape
+translation), see [`src/compat/v0_3/README.md`](../src/compat/v0_3/README.md).
 For the protocol-level definition of v0.3 vs. v1.0 differences, see
 [Appendix A: Migration Guidance](https://a2a-protocol.org/v1.0.0/specification/#appendix-a-migration-legacy-compatibility)
 in the spec.
@@ -89,27 +89,37 @@ executor publishes back into v0.3 shapes on the way out.
 | gRPC          | Each version is a separate gRPC service descriptor (`A2AService` vs. `LegacyA2AService`). The transport picks the descriptor; the SDK never needs to sniff.                                                       |
 | Agent card    | The handler reads the `A2A-Version` header (defaulting to `'0.3'` when absent, per spec §3.6.2) and emits the appropriate card shape, with `Vary: A2A-Version` set on the response.                                |
 
-### Synthesized v0.3 agent card
+### Per-interface v0.3 advertisement
 
-When `legacyCompat` is enabled on `agentCardHandler`, you don't need to
-duplicate every entry of `supportedInterfaces` with a v0.3 stub. The compat
-layer:
+v0.3 advertisement is strict and per-interface: a binding is only reachable
+at v0.3 if the card lists an `AgentInterface` for it with
+`protocolVersion: '0.3'`. `validateVersion` and the agent-card synthesizer
+both key off the same declaration.
 
-1. Reads `validateVersion` with `{ legacyCompat: true }`, which adds the
-   legacy `'0.3'` version to the supported set for any binding the card
-   already exposes at least one interface for. v0.3 (and header-less)
-   requests therefore route through the legacy handler chain even when the
-   card declares only v1.0 interfaces.
-2. Synthesizes a v0.3-shaped card on the well-known endpoint by setting
-   `protocolVersion: '0.3'` on the same interface URLs the v1.0 card
-   advertises. v0.3 clients can discover and use the agent transparently.
+Use `duplicateInterfacesForLegacy` from `@a2a-js/sdk/compat/v0_3` to mirror
+each binding once at v1.0 and once at v0.3:
 
-The card returned to a v0.3 client is a *hybrid*: it carries the v0.3
-top-level fields (`url`, `preferredTransport`, `additionalInterfaces`) AND
-keeps the v1.0 `supportedInterfaces[]` array embedded. A modern client that
-encounters the hybrid card prefers `supportedInterfaces[]`, which prevents
-unnecessary downgrades — see the `compat-v1-client` sample for the receiver
-logic.
+```ts
+import { duplicateInterfacesForLegacy } from '@a2a-js/sdk/compat/v0_3';
+
+const card: AgentCard = {
+  // ...
+  supportedInterfaces: duplicateInterfacesForLegacy(
+    [
+      { url: '/jsonrpc', protocolBinding: 'JSONRPC',   tenant: '', protocolVersion: '1.0' },
+      { url: '/rest',    protocolBinding: 'HTTP+JSON', tenant: '', protocolVersion: '1.0' },
+      { url: '/grpc',    protocolBinding: 'GRPC',      tenant: '', protocolVersion: '1.0' },
+    ],
+    ['JSONRPC', 'HTTP+JSON'], // GRPC stays v1.0-only
+  ),
+};
+```
+
+The card returned to a v0.3 client is a *hybrid*: v0.3 top-level fields
+(`url`, `preferredTransport`, `additionalInterfaces`) AND the v1.0
+`supportedInterfaces[]` array embedded. A modern client that encounters
+the hybrid card prefers `supportedInterfaces[]`, which prevents unnecessary
+downgrades — see the `compat-v1-client` sample for the receiver logic.
 
 ---
 
@@ -199,7 +209,7 @@ layer applies the documented defaults rather than failing.
 | `AuthenticationInfo.scheme` (single string) ↔ `PushNotificationAuthenticationInfo.schemes` (string array)                                                          | Going v0.3 → v1.0: only the **first** element of `schemes[]` is preserved and the rest are dropped (with a warning). Going v1.0 → v0.3: the single scheme is wrapped into a one-element array; empty becomes `[]`.                                            |
 | `TaskStatusUpdateEvent.final` (removed in v1.0)                                                                                                                     | Going v1.0 → v0.3 the `final` flag is **computed** from the status state: `true` for `completed`, `canceled`, `failed`, or `rejected`; `false` otherwise.                                                                                                     |
 | `SendMessageConfiguration.returnImmediately` ↔ `MessageSendConfiguration.blocking`                                                                                 | Inverted polarity (v1.0 `returnImmediately: true` ↔ v0.3 `blocking: false`, and vice versa).                                                                                                                                                                  |
-| `AgentCard.supportedInterfaces[]` (v1.0) ↔ `(url, preferredTransport, additionalInterfaces)` (v0.3)                                                                | In **strict mode** (default), only interfaces whose `protocolVersion` is empty or in `[0.3, 1.0)` survive the v1.0 → v0.3 translation; if none qualify, `VersionNotSupportedError` is thrown. In **synthesis mode** (used by `legacyAgentCardRouter`), every interface survives and is restamped with `protocolVersion: '0.3'`. |
+| `AgentCard.supportedInterfaces[]` (v1.0) ↔ `(url, preferredTransport, additionalInterfaces)` (v0.3)                                                                | Only interfaces whose `protocolVersion` is empty or in `[0.3, 1.0)` survive the v1.0 → v0.3 translation; if none qualify, `VersionNotSupportedError` is thrown. Use `duplicateInterfacesForLegacy` to opt a v1.0 binding into v0.3 advertisement. |
 | `Part.content.$case` discriminator                                                                                                                                  | Translated to the v0.3 `kind:` discriminator on each part (`text`, `file`, `data`). File URI ↔ v0.3 `FilePart.file.uri`; file bytes ↔ v0.3 `FilePart.file.bytes`; the v1.0 flat `Part.filename` / `Part.mediaType` map back into `FilePart.file.name` / `FilePart.file.mimeType`. |
 
 ### REST wire-shape caveats

--- a/itk/itk_agent.ts
+++ b/itk/itk_agent.ts
@@ -682,14 +682,10 @@ async function main() {
       extensions: [],
       extendedAgentCard: true,
     },
-    // Only v1.0 interfaces are declared here; the agent-card endpoint
-    // serves a hybrid card that augments this list with v0.3-shaped
-    // `(url, preferredTransport, additionalInterfaces)` fields so that
-    // v0.3 SDK parsers (which don't recognize `supportedInterfaces`) can
-    // still discover the bindings. The v0.3 wire dispatch on the server
-    // side is enabled via `legacyCompat: { enabled: true }` on the
-    // JSON-RPC and REST handlers and via binding `LegacyA2AService`
-    // alongside `A2AService` on the gRPC server.
+    // Each binding declared twice — once at v1.0 and once at v0.3 — so
+    // a v0.3 baseline peer (go_v03, python_v03) can dial every binding.
+    // Strict per-interface advertisement: a binding is only reachable
+    // at v0.3 if listed here with `protocolVersion: '0.3'`.
     supportedInterfaces: [
       {
         url: `http://127.0.0.1:${httpPort}/jsonrpc`,
@@ -698,8 +694,26 @@ async function main() {
         protocolVersion: '1.0',
       },
       {
+        url: `http://127.0.0.1:${httpPort}/jsonrpc`,
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: '0.3',
+      },
+      {
         url: `127.0.0.1:${grpcPort}`,
         protocolBinding: 'GRPC',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+      {
+        url: `127.0.0.1:${grpcPort}`,
+        protocolBinding: 'GRPC',
+        tenant: '',
+        protocolVersion: '0.3',
+      },
+      {
+        url: `http://127.0.0.1:${httpPort}/rest`,
+        protocolBinding: 'HTTP+JSON',
         tenant: '',
         protocolVersion: '1.0',
       },
@@ -707,7 +721,7 @@ async function main() {
         url: `http://127.0.0.1:${httpPort}/rest`,
         protocolBinding: 'HTTP+JSON',
         tenant: '',
-        protocolVersion: '1.0',
+        protocolVersion: '0.3',
       },
     ],
     provider: {

--- a/src/compat/v0_3/README.md
+++ b/src/compat/v0_3/README.md
@@ -59,16 +59,17 @@ Notable policy decisions:
 - The v1.0 `OAuthFlows.deviceCode` flow is silently dropped going v1.0 → v0.3 (v0.3 has no equivalent).
 - `TaskStatusUpdateEvent.final` is computed from the status state going v1.0 → v0.3 (`true` for `completed`, `canceled`, `failed`, `rejected`).
 - `SendMessageConfiguration.returnImmediately` ↔ `MessageSendConfiguration.blocking` with inverted polarity.
-- `toCompatAgentCard(card)` (strict mode, default) filters `supportedInterfaces` to those whose `protocolVersion` is empty or in `[0.3, 1.0)` and throws `VersionNotSupportedError` if none qualify.
-- `toCompatAgentCard(card, { synthesize: true })` (synthesis mode) accepts every interface in `supportedInterfaces` regardless of `protocolVersion` and emits `protocolVersion: '0.3'` on the result. Used by `legacyAgentCardRouter` to serve a discoverable v0.3 card when the operator has opted into `legacyCompat` but only declared v1.0 interfaces; the same v1.0 interface URLs are presented under the v0.3 protocol version.
+- `toCompatAgentCard(card)` filters `supportedInterfaces` to those whose `protocolVersion` is empty or in `[0.3, 1.0)` and throws `VersionNotSupportedError` if none qualify.
+- `duplicateInterfacesForLegacy(interfaces, bindings)` appends a v0.3 mirror entry for each listed binding that doesn't already have one. Idempotent; use it when declaring an agent card to opt specific bindings into v0.3 advertisement.
 
 ## Version negotiation under `legacyCompat`
 
-Per A2A spec §3.6.2, clients that omit the `A2A-Version` header are treated as v0.3 requests. Without an opt-in, the SDK's strict validator rejects header-less requests against a v1.0-only agent card with `VersionNotSupportedError`. When `legacyCompat: { enabled: true }` is passed to a handler, two pieces work together to honor §3.6.2 without requiring operators to duplicate every v1.0 `supportedInterfaces` entry with a v0.3 stub:
+Per A2A spec §3.6.2, clients that omit the `A2A-Version` header are treated as v0.3 requests. v0.3 advertisement and routing are strictly per-interface: a binding is only reachable at v0.3 if the agent card declares an `AgentInterface` for it with `protocolVersion: '0.3'`.
 
-1. **Implicit v0.3 in `validateVersion`.** When called with `{ legacyCompat: true }`, the validator adds the legacy `'0.3'` version to the supported set for any binding the agent card already exposes at least one interface for. A header-less or `A2A-Version: 0.3` request therefore routes through the legacy handler chain (`LegacyJsonRpcTransportHandler`, `LegacyRestTransportHandler`, `legacyGrpcService`) even when the card declares only v1.0 interfaces. Requests for bindings the card doesn't expose at all are still rejected.
+- `validateVersion(requestedVersion, card, binding)` accepts the request iff `requestedVersion` is in the set of versions declared for `binding` in `supportedInterfaces`.
+- `legacyAgentCardRouter` calls `toCompatAgentCard(card)` (strict filter) and serves the resulting v0.3-shaped card to legacy-range requests. A v1.0-only card produces HTTP 400 on the legacy path.
 
-2. **Synthesized v0.3 card.** The `legacyAgentCardRouter` calls `toCompatAgentCard(card, { synthesize: true })` so the well-known endpoint returns a discoverable v0.3-shaped card whose `(url, preferredTransport, additionalInterfaces)` reflect the v1.0 `supportedInterfaces` entries but whose `protocolVersion` is stamped as `'0.3'`. v0.3 clients can therefore both discover and use a v1.0-only server when the operator has opted into the compat layer.
+Operators advertise a binding at v0.3 by declaring a per-interface `protocolVersion: '0.3'` — manually or via `duplicateInterfacesForLegacy`. The `compat-v1-server` sample shows the helper in use.
 
 The v1.0 gRPC service factory (`src/server/grpc/grpc_service.ts`) intentionally does **not** carry a `legacyCompat` option; v0.3 gRPC clients are served by importing `legacyGrpcService` from `@a2a-js/sdk/compat/v0_3/server/grpc` and registering it alongside the v1.0 `grpcService` on the same `Server`. (The v1.0 `@a2a-js/sdk/server/grpc` barrel does not re-export `legacyGrpcService`; the explicit compat import keeps `@grpc/grpc-js` out of the v1.0 dependency graph for operators who only deploy the v1.0 service.)
 

--- a/src/compat/v0_3/index.ts
+++ b/src/compat/v0_3/index.ts
@@ -32,3 +32,4 @@ export {
   legacyGrpcToV1Method,
   v1MethodToLegacyGrpc,
 } from './constants.js';
+export { duplicateInterfacesForLegacy } from './translate/agent_card.js';

--- a/src/compat/v0_3/server/express/agent_card_handler.ts
+++ b/src/compat/v0_3/server/express/agent_card_handler.ts
@@ -84,17 +84,12 @@ export function legacyAgentCardRouter(options: LegacyAgentCardHandlerOptions): R
       const coreCard = await provider();
       let compatCard: legacy.AgentCard;
       try {
-        // `synthesize: true` makes the legacy endpoint discoverable
-        // even when the operator only declared v1.0 interfaces — so
-        // they don't need to duplicate every v1.0 entry with a v0.3
-        // stub. `embedV1Interfaces: true` emits a "superset" card whose
-        // JSON document satisfies BOTH shapes (v0.3 top-level fields
-        // AND v1.0 `supportedInterfaces`), so a v1.0 peer that didn't
-        // negotiate `A2A-Version: 1.0` can still dial bindings without
-        // v0.3 compat. The two top-level field sets are disjoint, so
-        // the hybrid representation is unambiguous.
+        // `embedV1Interfaces: true` emits a "superset" card whose JSON
+        // satisfies both shapes (v0.3 top-level fields AND v1.0
+        // `supportedInterfaces`); the two field sets are disjoint.
+        // Operators advertise v0.3 by declaring per-interface
+        // `protocolVersion: '0.3'` (or via `duplicateInterfacesForLegacy`).
         compatCard = toCompatAgentCard(coreCard, {
-          synthesize: true,
           embedV1Interfaces: true,
         });
       } catch (error) {

--- a/src/compat/v0_3/server/express/rest_handler.ts
+++ b/src/compat/v0_3/server/express/rest_handler.ts
@@ -162,13 +162,9 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
       tenant: (req.params.tenant as string) || undefined,
     });
     const agentCard = await transportHandler.getAgentCard();
-    // This router is only mounted when `legacyCompat` is enabled, so
-    // the validator implicitly accepts '0.3' for any binding the card
-    // exposes — a v1.0-only card can still serve legacy clients without
-    // operators duplicating every entry with a v0.3 stub.
-    validateVersion(context.requestedVersion, agentCard, 'HTTP+JSON', {
-      legacyCompat: { enabled: true },
-    });
+    // Strict per-interface check: the card must declare a HTTP+JSON
+    // interface at `protocolVersion: '0.3'`.
+    validateVersion(context.requestedVersion, agentCard, 'HTTP+JSON');
     return context;
   };
 

--- a/src/compat/v0_3/server/grpc/grpc_service.ts
+++ b/src/compat/v0_3/server/grpc/grpc_service.ts
@@ -518,12 +518,10 @@ const _buildContext = async (
   });
 
   const agentCard = await requestHandler.getAgentCard();
-  // `legacyCompat` lets the validator accept '0.3' against a v1.0-only
-  // card, so operators don't have to declare a duplicate v0.3 entry in
-  // `supportedInterfaces`.
-  validateVersion(context.requestedVersion, agentCard, 'GRPC', {
-    legacyCompat: { enabled: true },
-  });
+  // Strict per-interface check: the card must declare a GRPC interface
+  // at `protocolVersion: '0.3'` (manually or via
+  // `duplicateInterfacesForLegacy`).
+  validateVersion(context.requestedVersion, agentCard, 'GRPC');
 
   return context;
 };

--- a/src/compat/v0_3/translate/agent_card.ts
+++ b/src/compat/v0_3/translate/agent_card.ts
@@ -301,7 +301,7 @@ export function toCompatAgentCard(
 
   // Hybrid-card embedding: see `embedV1Interfaces` on the options type.
   if (options?.embedV1Interfaces && allInterfaces.length > 0) {
-    result.supportedInterfaces = allInterfaces.map((intf) => ({ ...intf }));
+    result.supportedInterfaces = structuredClone(allInterfaces);
   }
 
   return result;
@@ -330,17 +330,18 @@ export function duplicateInterfacesForLegacy(
   interfaces: V1AgentInterface[],
   bindings: string[]
 ): V1AgentInterface[] {
-  const result = [...interfaces];
+  const source = interfaces ?? [];
+  const result = structuredClone(source);
   for (const binding of bindings) {
-    const hasLegacy = interfaces.some(
+    const hasLegacy = source.some(
       (intf) =>
         intf.protocolBinding === binding &&
         (!intf.protocolVersion || isLegacyVersion(intf.protocolVersion))
     );
     if (hasLegacy) continue;
-    const source = interfaces.find((intf) => intf.protocolBinding === binding);
-    if (!source) continue;
-    result.push({ ...source, protocolVersion: PROTOCOL_VERSION_0_3 });
+    const template = source.find((intf) => intf.protocolBinding === binding);
+    if (!template) continue;
+    result.push({ ...structuredClone(template), protocolVersion: PROTOCOL_VERSION_0_3 });
   }
   return result;
 }

--- a/src/compat/v0_3/translate/agent_card.ts
+++ b/src/compat/v0_3/translate/agent_card.ts
@@ -205,14 +205,6 @@ export function toCoreAgentCard(compat: legacy.AgentCard): V1AgentCard {
 
 export interface ToCompatAgentCardOptions {
   /**
-   * Accept every interface regardless of `protocolVersion` and stamp
-   * the emitted card as `'0.3'`. Lets a v1.0-only server with
-   * `legacyCompat` opted in still serve a discoverable card to v0.3
-   * clients. Default: `false` (strict — throws if no legacy-range
-   * interface exists).
-   */
-  synthesize?: boolean;
-  /**
    * Also copy the source v1.0 `supportedInterfaces[]` onto the emitted
    * card. Produces a "superset" document parseable by both v0.3 and
    * v1.0 resolvers (their top-level fields are disjoint), so a v1.0
@@ -232,24 +224,20 @@ export type CompatAgentCardResult = legacy.AgentCard & {
 };
 
 /**
- * Strict mode (default): keep only interfaces with `protocolVersion`
- * empty or in `[0.3, 1.0)`; throw `VersionNotSupportedError` if none.
- * See `ToCompatAgentCardOptions` for `synthesize` and
- * `embedV1Interfaces`.
+ * Keeps only interfaces whose `protocolVersion` is empty or in
+ * `[0.3, 1.0)`; throws `VersionNotSupportedError` if none. To advertise
+ * v0.3 on a binding currently declared at v1.0, use
+ * {@link duplicateInterfacesForLegacy} or add a dedicated v0.3 entry to
+ * `supportedInterfaces`.
  */
 export function toCompatAgentCard(
   core: V1AgentCard,
   options?: ToCompatAgentCardOptions
 ): CompatAgentCardResult {
   const allInterfaces = core.supportedInterfaces ?? [];
-  const legacyInterfaces = allInterfaces.filter(
+  const compatInterfaces = allInterfaces.filter(
     (intf) => !intf.protocolVersion || isLegacyVersion(intf.protocolVersion)
   );
-  // Synthesis only falls back to non-legacy interfaces when there are no
-  // legacy ones — dual-version deployments keep their existing v0.3
-  // primary URL.
-  const compatInterfaces =
-    options?.synthesize && legacyInterfaces.length === 0 ? allInterfaces : legacyInterfaces;
   if (compatInterfaces.length === 0) {
     throw new VersionNotSupportedError(
       'AgentCard must have at least one interface with a protocol version in [0.3, 1.0).'
@@ -277,12 +265,7 @@ export function toCompatAgentCard(
         )
       : undefined;
 
-  // Under synthesize-fallback the emitted card always presents as v0.3
-  // regardless of the underlying interface's declared version.
-  const synthesizedFallback = options?.synthesize && legacyInterfaces.length === 0;
-  const emittedProtocolVersion = synthesizedFallback
-    ? PROTOCOL_VERSION_0_3
-    : primary.protocolVersion || PROTOCOL_VERSION_0_3;
+  const emittedProtocolVersion = primary.protocolVersion || PROTOCOL_VERSION_0_3;
 
   const result: CompatAgentCardResult = {
     name: core.name,
@@ -321,5 +304,43 @@ export function toCompatAgentCard(
     result.supportedInterfaces = allInterfaces.map((intf) => ({ ...intf }));
   }
 
+  return result;
+}
+
+/**
+ * Returns `interfaces` augmented with a v0.3 mirror entry for each
+ * binding in `bindings` that does not already have one. Idempotent: a
+ * binding that already declares a legacy-range interface is left
+ * untouched. Mirror entries copy `url`/`tenant` from the first v1.0
+ * entry for the binding and stamp `protocolVersion: '0.3'`.
+ *
+ * @example
+ * ```ts
+ * supportedInterfaces: duplicateInterfacesForLegacy(
+ *   [
+ *     { url: '/jsonrpc', protocolBinding: 'JSONRPC',   tenant: '', protocolVersion: '1.0' },
+ *     { url: '/rest',    protocolBinding: 'HTTP+JSON', tenant: '', protocolVersion: '1.0' },
+ *     { url: '/grpc',    protocolBinding: 'GRPC',      tenant: '', protocolVersion: '1.0' },
+ *   ],
+ *   ['JSONRPC', 'HTTP+JSON'],
+ * )
+ * ```
+ */
+export function duplicateInterfacesForLegacy(
+  interfaces: V1AgentInterface[],
+  bindings: string[]
+): V1AgentInterface[] {
+  const result = [...interfaces];
+  for (const binding of bindings) {
+    const hasLegacy = interfaces.some(
+      (intf) =>
+        intf.protocolBinding === binding &&
+        (!intf.protocolVersion || isLegacyVersion(intf.protocolVersion))
+    );
+    if (hasLegacy) continue;
+    const source = interfaces.find((intf) => intf.protocolBinding === binding);
+    if (!source) continue;
+    result.push({ ...source, protocolVersion: PROTOCOL_VERSION_0_3 });
+  }
   return result;
 }

--- a/src/samples/agents/compat-v1-server/README.md
+++ b/src/samples/agents/compat-v1-server/README.md
@@ -1,14 +1,15 @@
 # Compat v1.0 Server
 
 A v1.0-native A2A server that accepts BOTH modern (v1.0) and legacy (v0.3) clients
-on the **same URLs**, across **all three transports**, without duplicating any
-`supportedInterfaces` entries.
+on the **same URLs**, across **all three transports**. Each binding is declared
+twice in `supportedInterfaces` — once at v1.0 and once at v0.3 — via the
+`duplicateInterfacesForLegacy` helper.
 
 This is the server half of a two-part showcase of the `@a2a-js/sdk` v0.3 compat
 layer; the client half lives next to it under
 [`../compat-v1-client/`](../compat-v1-client/). See
 [`src/compat/v0_3/README.md`](../../../compat/v0_3/README.md) for the underlying
-architecture (translators, header dispatch, hybrid agent card synthesis).
+architecture (translators, header dispatch, hybrid agent card embedding).
 
 ## What the sample demonstrates
 

--- a/src/samples/agents/compat-v1-server/index.ts
+++ b/src/samples/agents/compat-v1-server/index.ts
@@ -28,10 +28,10 @@
  *     `application/a2a+json` `StreamResponse` envelopes — on the SAME
  *     task, on the same server.
  *
- * The agent card declared below intentionally contains ONLY v1.0
- * `supportedInterfaces` entries. The compat layer synthesizes the v0.3
- * surface automatically — no operator duplication required — which is
- * the whole point of opting into `legacyCompat`.
+ * The agent card declares each binding twice — once at v1.0 and once
+ * at v0.3 — via `duplicateInterfacesForLegacy`. Strict per-interface
+ * advertisement: a binding is only reachable at v0.3 if the card says
+ * so explicitly.
  */
 
 import express from 'express';
@@ -54,6 +54,7 @@ import {
 import { A2AService, grpcService } from '../../../server/grpc/index.js';
 import { LegacyA2AService, legacyGrpcService } from '../../../compat/v0_3/server/grpc/index.js';
 import { createLegacyAwarePushNotificationSender } from '../../../compat/v0_3/server/index.js';
+import { duplicateInterfacesForLegacy } from '../../../compat/v0_3/index.js';
 import { SampleAgentExecutor } from '../sample-agent/agent_executor.js';
 
 // --- Configuration ---
@@ -63,43 +64,40 @@ const GRPC_PORT = Number(process.env.GRPC_PORT || 41252);
 
 // --- Agent Card ---
 //
-// NOTE: only v1.0 (`A2A_PROTOCOL_VERSION`) interfaces are declared. With
-// `legacyCompat: { enabled: true }` set on the well-known agent-card
-// handler, requests carrying `A2A-Version: 0.3` (or no header at all,
-// which §3.6.2 defaults to `'0.3'`) receive a HYBRID card synthesized
-// by the compat layer: the same interface URLs are re-presented under
-// the v0.3 protocol version at the card's top level (`url` /
-// `preferredTransport` / `additionalInterfaces`), AND the v1.0
-// `supportedInterfaces[]` array is left intact. See
-// `src/compat/v0_3/server/express/agent_card_handler.ts`.
+// Each binding is declared at v1.0 (`A2A_PROTOCOL_VERSION`) and mirrored
+// at v0.3 via `duplicateInterfacesForLegacy`. v0.3 advertisement is
+// strictly per-interface; a binding only reaches v0.3 clients if it
+// appears in the card with `protocolVersion: '0.3'`.
 
 const compatServerCard: AgentCard = {
   name: 'Compat v1.0 Server',
   description:
-    'A v1.0-native A2A server that opts into the v0.3 compat layer on every ' +
-    'transport (including push notifications). Accepts both modern ' +
-    '(A2A-Version: 1.0) and legacy (A2A-Version: 0.3 or absent) clients on ' +
-    'the SAME URLs without any duplication of `supportedInterfaces` entries.',
-  supportedInterfaces: [
-    {
-      url: `http://localhost:${HTTP_PORT}/a2a/jsonrpc`,
-      protocolBinding: 'JSONRPC',
-      tenant: '',
-      protocolVersion: A2A_PROTOCOL_VERSION,
-    },
-    {
-      url: `http://localhost:${HTTP_PORT}/a2a/rest`,
-      protocolBinding: 'HTTP+JSON',
-      tenant: '',
-      protocolVersion: A2A_PROTOCOL_VERSION,
-    },
-    {
-      url: `localhost:${GRPC_PORT}`,
-      protocolBinding: 'GRPC',
-      tenant: '',
-      protocolVersion: A2A_PROTOCOL_VERSION,
-    },
-  ],
+    'A v1.0-native A2A server that declares each binding at both v1.0 and ' +
+    'v0.3 so the same URLs accept both modern (A2A-Version: 1.0) and legacy ' +
+    '(A2A-Version: 0.3 or absent) clients.',
+  supportedInterfaces: duplicateInterfacesForLegacy(
+    [
+      {
+        url: `http://localhost:${HTTP_PORT}/a2a/jsonrpc`,
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: A2A_PROTOCOL_VERSION,
+      },
+      {
+        url: `http://localhost:${HTTP_PORT}/a2a/rest`,
+        protocolBinding: 'HTTP+JSON',
+        tenant: '',
+        protocolVersion: A2A_PROTOCOL_VERSION,
+      },
+      {
+        url: `localhost:${GRPC_PORT}`,
+        protocolBinding: 'GRPC',
+        tenant: '',
+        protocolVersion: A2A_PROTOCOL_VERSION,
+      },
+    ],
+    ['JSONRPC', 'HTTP+JSON', 'GRPC']
+  ),
   provider: {
     organization: 'A2A Samples',
     url: 'https://example.com/a2a-samples',

--- a/src/server/express/json_rpc_handler.ts
+++ b/src/server/express/json_rpc_handler.ts
@@ -107,9 +107,7 @@ export function jsonRpcHandler(options: JsonRpcHandlerOptions): RequestHandler {
         requestedVersion,
       });
       const agentCard = await options.requestHandler.getAgentCard();
-      validateVersion(context.requestedVersion, agentCard, 'JSONRPC', {
-        legacyCompat: options.legacyCompat,
-      });
+      validateVersion(context.requestedVersion, agentCard, 'JSONRPC');
       const transportHandler = useLegacy ? legacyJsonRpcTransportHandler : jsonRpcTransportHandler;
       const rpcResponseOrStream = await transportHandler.handle(req.body, context);
 

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -148,9 +148,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
       tenant,
     });
     const agentCard = await restTransportHandler.getAgentCard();
-    validateVersion(context.requestedVersion, agentCard, 'HTTP+JSON', {
-      legacyCompat: options.legacyCompat,
-    });
+    validateVersion(context.requestedVersion, agentCard, 'HTTP+JSON');
     return context;
   };
 

--- a/src/server/version.ts
+++ b/src/server/version.ts
@@ -1,4 +1,3 @@
-import { A2A_LEGACY_PROTOCOL_VERSION } from '../constants.js';
 import { TransportProtocolName } from '../core.js';
 import { VersionNotSupportedError } from '../errors.js';
 import { AgentCard } from '../index.js';
@@ -24,49 +23,20 @@ export function getSupportedVersions(
   return versions;
 }
 
-/** Options for {@link validateVersion}. */
-export interface ValidateVersionOptions {
-  /**
-   * Opt-in to v0.3 compatibility. When enabled, the legacy v0.3 protocol
-   * version is implicitly added to the supported set for any binding the
-   * card already exposes at least one interface for — so v0.3 (and
-   * header-less) clients succeed without operators having to duplicate
-   * every v1.0 `supportedInterfaces` entry with a v0.3 stub.
-   *
-   * Default: omitted (strict; only explicitly declared versions accepted).
-   */
-  legacyCompat?: { enabled: boolean };
-}
-
 /**
  * Validates that the requested A2A protocol version is supported by the
  * agent for the given protocol binding. Throws
- * {@link VersionNotSupportedError} if not.
- *
- * When `options.legacyCompat.enabled` is `true` AND the agent card exposes
- * at least one interface for the requested binding, the legacy v0.3
- * version is implicitly accepted.
+ * {@link VersionNotSupportedError} if not. Accepts only versions
+ * explicitly declared in `agentCard.supportedInterfaces`; to advertise
+ * v0.3 on a binding, declare a per-interface `protocolVersion: '0.3'`
+ * (manually or via `duplicateInterfacesForLegacy`).
  */
 export function validateVersion(
   requestedVersion: string,
   agentCard: AgentCard,
-  protocolBinding?: TransportProtocolName,
-  options?: ValidateVersionOptions
+  protocolBinding?: TransportProtocolName
 ): void {
   const supported = getSupportedVersions(agentCard, protocolBinding);
-
-  if (options?.legacyCompat?.enabled) {
-    // Implicit v0.3 acceptance: only if the card actually exposes the
-    // requested binding. Otherwise we'd accept v0.3 for a transport the
-    // agent doesn't serve and the failure would surface later as a
-    // less useful dispatcher error.
-    const hasBindingInterface = (agentCard.supportedInterfaces ?? []).some(
-      (intf) => !protocolBinding || intf.protocolBinding === protocolBinding
-    );
-    if (hasBindingInterface) {
-      supported.add(A2A_LEGACY_PROTOCOL_VERSION);
-    }
-  }
 
   if (!supported.has(requestedVersion)) {
     throw new VersionNotSupportedError(

--- a/tck/compat-agent/index.ts
+++ b/tck/compat-agent/index.ts
@@ -21,13 +21,12 @@
  *   - The well-known agent-card endpoint at `/.well-known/agent-card.json`
  *     with `legacyCompat: { enabled: true }` — the `A2A-Version` header
  *     (defaulting to `'0.3'` per spec §3.6.2) selects the v0.3-shaped
- *     hybrid card synthesized from the v1.0 `supportedInterfaces` by
- *     `toCompatAgentCard(card, { synthesize: true })`.
+ *     hybrid card derived from the v0.3-tagged interfaces in
+ *     `supportedInterfaces`.
  *
- * The agent card declares ONLY v1.0 `supportedInterfaces`. The compat
- * layer synthesizes the v0.3 surface (`url`, `preferredTransport`,
- * `additionalInterfaces`, top-level `protocolVersion: '0.3'`) on the
- * fly — no operator-side duplication required.
+ * Each binding is declared twice — at v1.0 and at v0.3 — via
+ * `duplicateInterfacesForLegacy`. v0.3 advertisement is strictly
+ * per-interface.
  */
 
 import express from 'express';
@@ -209,11 +208,9 @@ class SUTAgentExecutor implements AgentExecutor {
 const HTTP_PORT = Number(process.env.HTTP_PORT || 41241);
 const GRPC_PORT = Number(process.env.GRPC_PORT || 41242);
 
-// Card declares ONLY v1.0 interfaces. The compat layer synthesizes the
-// v0.3 view (top-level `url` / `preferredTransport` /
-// `additionalInterfaces`) from these entries when the well-known
-// endpoint sees `A2A-Version: 0.3` (or a missing header, which §3.6.2
-// defaults to `'0.3'`).
+// Each binding declared at both v1.0 and v0.3; v0.3 advertisement is
+// strictly per-interface so the TCK (which speaks v0.3) finds an
+// interface for every binding it probes.
 const SUTAgentCard: AgentCard = {
   name: 'SUT Agent (compat)',
   description:
@@ -228,8 +225,26 @@ const SUTAgentCard: AgentCard = {
       protocolVersion: A2A_PROTOCOL_VERSION,
     },
     {
+      url: `http://localhost:${HTTP_PORT}/a2a/jsonrpc`,
+      protocolBinding: 'JSONRPC',
+      tenant: '',
+      protocolVersion: '0.3',
+    },
+    {
       url: `http://localhost:${HTTP_PORT}/a2a/rest`,
       protocolBinding: 'HTTP+JSON',
+      tenant: '',
+      protocolVersion: A2A_PROTOCOL_VERSION,
+    },
+    {
+      url: `http://localhost:${HTTP_PORT}/a2a/rest`,
+      protocolBinding: 'HTTP+JSON',
+      tenant: '',
+      protocolVersion: '0.3',
+    },
+    {
+      url: `http://localhost:${GRPC_PORT}`,
+      protocolBinding: 'GRPC',
       tenant: '',
       protocolVersion: A2A_PROTOCOL_VERSION,
     },
@@ -237,7 +252,7 @@ const SUTAgentCard: AgentCard = {
       url: `http://localhost:${GRPC_PORT}`,
       protocolBinding: 'GRPC',
       tenant: '',
-      protocolVersion: A2A_PROTOCOL_VERSION,
+      protocolVersion: '0.3',
     },
   ],
   provider: {

--- a/test/compat/v0_3/server/express/agent_card_handler.spec.ts
+++ b/test/compat/v0_3/server/express/agent_card_handler.spec.ts
@@ -144,11 +144,9 @@ describe('agentCardHandler with legacyCompat', () => {
       const app = createApp(dualVersionCard(), { enabled: true });
       const response = await request(app).get('/.well-known/agent-card.json').expect(200);
 
-      // The legacy router emits a "superset" document: v0.3 top-level
-      // fields (url / preferredTransport / additionalInterfaces /
-      // protocolVersion) for v0.3 parsers, AND the source v1.0
-      // `supportedInterfaces[]` for v1.0 parsers that didn't send
-      // `A2A-Version: 1.0`. The two field sets are disjoint.
+      // Superset document: v0.3 top-level fields for v0.3 parsers AND
+      // the source v1.0 `supportedInterfaces[]` for v1.0 parsers that
+      // didn't send `A2A-Version: 1.0`. The two field sets are disjoint.
       assert.equal(response.body.name, 'Test Agent');
       assert.equal(response.body.url, 'https://api.example/legacy');
       assert.equal(response.body.preferredTransport, 'JSONRPC');
@@ -247,11 +245,9 @@ describe('agentCardHandler with legacyCompat', () => {
     });
 
     it('preserves an upstream Vary value on the VersionNotSupportedError (400) path', async () => {
-      // The only way the legacy router still throws
-      // VersionNotSupportedError under synthesis is when the v1.0 card
-      // has NO interfaces at all (so there's nothing to synthesize).
-      const emptyCard: AgentCard = { ...modernOnlyCard(), supportedInterfaces: [] };
-      const app = createAppWithUpstreamVary(emptyCard, { enabled: true });
+      // A v1.0-only card has no legacy-range interface; strict mode
+      // throws VersionNotSupportedError → HTTP 400.
+      const app = createAppWithUpstreamVary(modernOnlyCard(), { enabled: true });
       const response = await request(app)
         .get('/.well-known/agent-card.json')
         .set('A2A-Version', '0.3')
@@ -331,20 +327,13 @@ describe('agentCardHandler with legacyCompat', () => {
   });
 
   describe('error handling', () => {
-    it('returns 400 with a v0.3-shaped error when the v1.0 card has no interfaces at all', async () => {
-      // With synthesis enabled, a v1.0-only card normally produces a
-      // discoverable v0.3 card from the v1.0 interfaces. The only way
-      // to still trigger VersionNotSupportedError on the legacy path is
-      // a card with NO interfaces at all — there's nothing to
-      // synthesize from.
-      const emptyCard: AgentCard = { ...modernOnlyCard(), supportedInterfaces: [] };
-      const app = createApp(emptyCard, { enabled: true });
+    it('returns 400 with a v0.3-shaped error when the card declares no legacy-range interface', async () => {
+      const app = createApp(modernOnlyCard(), { enabled: true });
       const response = await request(app)
         .get('/.well-known/agent-card.json')
         .set('A2A-Version', '0.3')
         .expect(400);
 
-      // v0.3 error body: bare `{ code, message, data? }`.
       assert.isNumber(response.body.code);
       assert.isString(response.body.message);
       assert.match(response.body.message, /interface/i);
@@ -352,140 +341,12 @@ describe('agentCardHandler with legacyCompat', () => {
 
     it('falls through to the v1.0 handler for non-legacy requests against a modern-only card', async () => {
       const app = createApp(modernOnlyCard(), { enabled: true });
-      // v1.0 request should NOT get the 400 — the legacy router
-      // short-circuits via `next('router')`.
       const response = await request(app)
         .get('/.well-known/agent-card.json')
         .set('A2A-Version', '1.0')
         .expect(200);
 
       assert.isArray(response.body.supportedInterfaces);
-    });
-  });
-
-  describe('synthesized v0.3 card from a v1.0-only card', () => {
-    it('serves a synthesized hybrid card on header-less requests (server-side §3.6.2 default-to-0.3 fallback)', async () => {
-      const app = createApp(modernOnlyCard(), { enabled: true });
-
-      const response = await request(app).get('/.well-known/agent-card.json').expect(200);
-
-      // v0.3 top-level fields are present (url, preferredTransport,
-      // protocolVersion). The v1.0 source `supportedInterfaces[]` is
-      // also embedded so v1.0-only peers that didn't send the version
-      // header can still discover the native v1.0 endpoints without
-      // routing through a compat path they may not have registered.
-      assert.equal(response.body.url, 'https://api.example/v1');
-      assert.equal(response.body.preferredTransport, 'JSONRPC');
-      assert.equal(response.body.protocolVersion, '0.3');
-      assert.isArray(response.body.supportedInterfaces);
-      assert.deepEqual(response.body.supportedInterfaces, modernOnlyCard().supportedInterfaces);
-    });
-
-    it('serves a synthesized v0.3 card on explicit A2A-Version: 0.3 against a v1.0-only card', async () => {
-      const app = createApp(modernOnlyCard(), { enabled: true });
-
-      const response = await request(app)
-        .get('/.well-known/agent-card.json')
-        .set('A2A-Version', '0.3')
-        .expect(200);
-
-      assert.equal(response.body.url, 'https://api.example/v1');
-      assert.equal(response.body.protocolVersion, '0.3');
-    });
-
-    it('still serves the modern v1.0 card on explicit A2A-Version: 1.0', async () => {
-      const app = createApp(modernOnlyCard(), { enabled: true });
-
-      const response = await request(app)
-        .get('/.well-known/agent-card.json')
-        .set('A2A-Version', '1.0')
-        .expect(200);
-
-      // v1.0 shape preserved for v1.0 clients.
-      assert.isArray(response.body.supportedInterfaces);
-      assert.isUndefined(response.body.url);
-    });
-
-    it('emits Vary and ETag for synthesized cards too', async () => {
-      const app = createApp(modernOnlyCard(), { enabled: true });
-
-      const response = await request(app).get('/.well-known/agent-card.json').expect(200);
-
-      assert.equal(response.headers['vary'], 'A2A-Version');
-      assert.isDefined(response.headers['etag']);
-    });
-
-    it('passes through all v1.0 interfaces as additionalInterfaces in the synthesized card', async () => {
-      const multiBindingCard: AgentCard = {
-        ...modernOnlyCard(),
-        supportedInterfaces: [
-          {
-            url: 'https://api.example/v1/jsonrpc',
-            protocolBinding: 'JSONRPC',
-            tenant: '',
-            protocolVersion: '1.0',
-          },
-          {
-            url: 'https://api.example/v1/grpc',
-            protocolBinding: 'GRPC',
-            tenant: '',
-            protocolVersion: '1.0',
-          },
-        ],
-      };
-      const app = createApp(multiBindingCard, { enabled: true });
-
-      const response = await request(app).get('/.well-known/agent-card.json').expect(200);
-
-      // Primary is the first v1.0 interface; the rest become
-      // additionalInterfaces in v0.3 shape.
-      assert.equal(response.body.url, 'https://api.example/v1/jsonrpc');
-      assert.equal(response.body.preferredTransport, 'JSONRPC');
-      assert.equal(response.body.protocolVersion, '0.3');
-      assert.isArray(response.body.additionalInterfaces);
-      assert.equal(response.body.additionalInterfaces.length, 1);
-      assert.equal(response.body.additionalInterfaces[0].url, 'https://api.example/v1/grpc');
-      assert.equal(response.body.additionalInterfaces[0].transport, 'GRPC');
-    });
-
-    it('embeds the original v1.0 supportedInterfaces alongside v0.3 fields (hybrid card)', async () => {
-      // The single JSON document MUST satisfy both card resolvers:
-      // a v0.3 parser reads `url`/`preferredTransport`/
-      // `additionalInterfaces`/`protocolVersion`, a v1.0 parser reads
-      // `supportedInterfaces[]`. This is the mechanism that lets v1.0
-      // peers that skipped `A2A-Version: 1.0` and lack per-binding
-      // v0.3 compat (e.g. compat for JSONRPC but not gRPC) still
-      // discover the native v1.0 endpoints for those bindings.
-      const multiBindingCard: AgentCard = {
-        ...modernOnlyCard(),
-        supportedInterfaces: [
-          {
-            url: 'https://api.example/v1/jsonrpc',
-            protocolBinding: 'JSONRPC',
-            tenant: '',
-            protocolVersion: '1.0',
-          },
-          {
-            url: 'https://api.example/v1/grpc',
-            protocolBinding: 'GRPC',
-            tenant: '',
-            protocolVersion: '1.0',
-          },
-        ],
-      };
-      const app = createApp(multiBindingCard, { enabled: true });
-
-      const response = await request(app).get('/.well-known/agent-card.json').expect(200);
-
-      // v0.3 surface (synthesized).
-      assert.equal(response.body.url, 'https://api.example/v1/jsonrpc');
-      assert.equal(response.body.preferredTransport, 'JSONRPC');
-      assert.equal(response.body.protocolVersion, '0.3');
-
-      // v1.0 surface (embedded verbatim, retaining the native version
-      // stamp).
-      assert.isArray(response.body.supportedInterfaces);
-      assert.deepEqual(response.body.supportedInterfaces, multiBindingCard.supportedInterfaces);
     });
   });
 
@@ -514,16 +375,9 @@ describe('legacyAgentCardRouter (standalone)', () => {
     assert.equal(response.body.protocolVersion, '0.3');
   });
 
-  it('synthesizes a v0.3 card from a v1.0-only card when mounted directly', async () => {
-    // The standalone router uses the same `synthesize: true` mode as
-    // when it's mounted by the core agentCardHandler under
-    // `legacyCompat: { enabled: true }`.
+  it('returns 400 for a v1.0-only card (strict mode)', async () => {
     const app = createLegacyOnlyApp(modernOnlyCard());
-    const response = await request(app).get('/.well-known/agent-card.json').expect(200);
-
-    assert.equal(response.body.url, 'https://api.example/v1');
-    assert.equal(response.body.preferredTransport, 'JSONRPC');
-    assert.equal(response.body.protocolVersion, '0.3');
+    await request(app).get('/.well-known/agent-card.json').expect(400);
   });
 
   it('falls through (404) for a v1.0 request when nothing else is mounted', async () => {

--- a/test/compat/v0_3/translate/agent_card.spec.ts
+++ b/test/compat/v0_3/translate/agent_card.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  duplicateInterfacesForLegacy,
   toCompatAgentCapabilities,
   toCompatAgentCard,
   toCompatAgentCardSignature,
@@ -281,7 +282,7 @@ describe('agent_card', () => {
       expect(core.supportedInterfaces[0]!.protocolBinding).toBe('JSONRPC');
     });
 
-    describe('synthesize option', () => {
+    describe('strict mode (default)', () => {
       function v1OnlyCore(): V1AgentCard {
         return {
           name: 'Agent',
@@ -311,88 +312,17 @@ describe('agent_card', () => {
         };
       }
 
-      it('accepts a v1.0-only card without throwing', () => {
-        const core = v1OnlyCore();
-        expect(() => toCompatAgentCard(core, { synthesize: true })).not.toThrow();
+      it('throws on a v1.0-only card', () => {
+        expect(() => toCompatAgentCard(v1OnlyCore())).toThrow(VersionNotSupportedError);
       });
 
-      it('emits protocolVersion 0.3 regardless of the source version', () => {
+      it('does not crash when supportedInterfaces is undefined', () => {
         const core = v1OnlyCore();
-        const compat = toCompatAgentCard(core, { synthesize: true });
-        expect(compat.protocolVersion).toBe('0.3');
-      });
-
-      it('keeps the underlying v1.0 interface URL and binding', () => {
-        const core = v1OnlyCore();
-        const compat = toCompatAgentCard(core, { synthesize: true });
-        expect(compat.url).toBe('https://api.example/v1');
-        expect(compat.preferredTransport).toBe('JSONRPC');
-      });
-
-      it('passes through additional v1.0 interfaces as additionalInterfaces', () => {
-        const core = v1OnlyCore();
-        core.supportedInterfaces.push({
-          url: 'https://api.example/grpc',
-          protocolBinding: 'GRPC',
-          tenant: '',
-          protocolVersion: '1.0',
-        });
-        const compat = toCompatAgentCard(core, { synthesize: true });
-        expect(compat.url).toBe('https://api.example/v1');
-        expect(compat.additionalInterfaces).toHaveLength(1);
-        expect(compat.additionalInterfaces?.[0]).toEqual({
-          url: 'https://api.example/grpc',
-          transport: 'GRPC',
-        });
-      });
-
-      it('still throws when there are no interfaces at all', () => {
-        const core = v1OnlyCore();
-        core.supportedInterfaces = [];
-        expect(() => toCompatAgentCard(core, { synthesize: true })).toThrow(
-          VersionNotSupportedError
-        );
-      });
-
-      it('does not crash when supportedInterfaces is undefined (defensive)', () => {
-        const core = v1OnlyCore();
-        // Cast through unknown to satisfy the non-nullable proto type
-        // while modelling a real-world malformed input.
         (core as unknown as { supportedInterfaces?: unknown }).supportedInterfaces = undefined;
-        expect(() => toCompatAgentCard(core, { synthesize: true })).toThrow(
-          VersionNotSupportedError
-        );
         expect(() => toCompatAgentCard(core)).toThrow(VersionNotSupportedError);
       });
 
-      it('forces protocolVersion to 0.3 even when a v1.0 entry is the primary', () => {
-        // Belt-and-braces: even if the source primary interface declares
-        // a non-legacy version explicitly, the synthesized card must
-        // present itself as v0.3 to legacy clients.
-        const core = v1OnlyCore();
-        const compat = toCompatAgentCard(core, { synthesize: true });
-        // primary core interface is v1.0 but emitted version is v0.3.
-        expect(core.supportedInterfaces[0]!.protocolVersion).toBe('1.0');
-        expect(compat.protocolVersion).toBe('0.3');
-      });
-
-      it('default (no options) preserves strict filter and throws on v1.0-only', () => {
-        const core = v1OnlyCore();
-        expect(() => toCompatAgentCard(core)).toThrow(VersionNotSupportedError);
-      });
-
-      it('default (synthesize: false) preserves strict filter and throws on v1.0-only', () => {
-        const core = v1OnlyCore();
-        expect(() => toCompatAgentCard(core, { synthesize: false })).toThrow(
-          VersionNotSupportedError
-        );
-      });
-
-      it('synthesize: true still prefers a declared v0.3 interface when present (dual card)', () => {
-        // Synthesis is a fallback for cards with NO legacy interface.
-        // When a v0.3 entry is declared explicitly it MUST still be
-        // picked as the primary, so dual-version deployments don't
-        // observe a URL change after the synthesize option is added.
+      it('picks the declared v0.3 entry as primary in a dual-version card', () => {
         const core: V1AgentCard = {
           ...v1OnlyCore(),
           supportedInterfaces: [
@@ -410,42 +340,14 @@ describe('agent_card', () => {
             },
           ],
         };
-        const compat = toCompatAgentCard(core, { synthesize: true });
+        const compat = toCompatAgentCard(core);
         expect(compat.url).toBe('https://api.example/legacy');
         expect(compat.protocolVersion).toBe('0.3');
-      });
-
-      it('synthesize: true with mixed versions (no legacy entry) falls back to the first interface', () => {
-        // No legacy-range entry -> the fallback kicks in and the
-        // first non-legacy entry becomes the primary, with emitted
-        // protocolVersion stamped as 0.3.
-        const core: V1AgentCard = {
-          ...v1OnlyCore(),
-          supportedInterfaces: [
-            {
-              url: 'https://api.example/v1',
-              protocolBinding: 'JSONRPC',
-              tenant: '',
-              protocolVersion: '1.0',
-            },
-            {
-              url: 'https://api.example/v2',
-              protocolBinding: 'JSONRPC',
-              tenant: '',
-              protocolVersion: '2.0',
-            },
-          ],
-        };
-        const compat = toCompatAgentCard(core, { synthesize: true });
-        expect(compat.url).toBe('https://api.example/v1');
-        expect(compat.protocolVersion).toBe('0.3');
-        expect(compat.additionalInterfaces).toHaveLength(1);
-        expect(compat.additionalInterfaces?.[0]?.url).toBe('https://api.example/v2');
       });
     });
 
     describe('embedV1Interfaces option', () => {
-      function v1OnlyCoreLocal(): V1AgentCard {
+      function dualVersionCore(): V1AgentCard {
         return {
           name: 'Agent',
           description: 'desc',
@@ -456,6 +358,12 @@ describe('agent_card', () => {
               protocolBinding: 'JSONRPC',
               tenant: '',
               protocolVersion: '1.0',
+            },
+            {
+              url: 'https://api.example/v1',
+              protocolBinding: 'JSONRPC',
+              tenant: '',
+              protocolVersion: '0.3',
             },
             {
               url: 'https://api.example/grpc',
@@ -480,21 +388,14 @@ describe('agent_card', () => {
         };
       }
 
-      it('omits supportedInterfaces by default (back-compat with pure v0.3 output)', () => {
-        const core = v1OnlyCoreLocal();
-        const compat = toCompatAgentCard(core, { synthesize: true });
+      it('omits supportedInterfaces by default', () => {
+        const compat = toCompatAgentCard(dualVersionCore());
         expect((compat as { supportedInterfaces?: unknown[] }).supportedInterfaces).toBeUndefined();
       });
 
       it('embeds the source supportedInterfaces verbatim when enabled', () => {
-        const core = v1OnlyCoreLocal();
-        const compat = toCompatAgentCard(core, {
-          synthesize: true,
-          embedV1Interfaces: true,
-        });
-        // The emitted hybrid card carries BOTH the v0.3 top-level
-        // surface AND the original v1.0 supportedInterfaces array, so
-        // both card resolvers can read it from the same JSON document.
+        const core = dualVersionCore();
+        const compat = toCompatAgentCard(core, { embedV1Interfaces: true });
         expect(compat.url).toBe('https://api.example/v1');
         expect(compat.preferredTransport).toBe('JSONRPC');
         expect(compat.protocolVersion).toBe('0.3');
@@ -502,71 +403,55 @@ describe('agent_card', () => {
       });
 
       it('emits a defensive copy (does not alias the source array)', () => {
-        // Mutating the emitted card MUST NOT mutate the input card the
-        // caller passed in.
-        const core = v1OnlyCoreLocal();
-        const compat = toCompatAgentCard(core, {
-          synthesize: true,
-          embedV1Interfaces: true,
-        });
+        const core = dualVersionCore();
+        const compat = toCompatAgentCard(core, { embedV1Interfaces: true });
         expect(compat.supportedInterfaces).not.toBe(core.supportedInterfaces);
         expect(compat.supportedInterfaces![0]).not.toBe(core.supportedInterfaces[0]);
         compat.supportedInterfaces![0]!.url = 'https://mutated';
         expect(core.supportedInterfaces[0]!.url).toBe('https://api.example/v1');
       });
 
-      it('works without synthesize when at least one legacy interface qualifies', () => {
-        // embedV1Interfaces is orthogonal to synthesize: it just copies
-        // the source supportedInterfaces onto the emitted card.
-        const core: V1AgentCard = {
-          ...v1OnlyCoreLocal(),
-          supportedInterfaces: [
-            {
-              url: 'https://api.example/legacy',
-              protocolBinding: 'JSONRPC',
-              tenant: '',
-              protocolVersion: '0.3',
-            },
-            {
-              url: 'https://api.example/v1',
-              protocolBinding: 'JSONRPC',
-              tenant: '',
-              protocolVersion: '1.0',
-            },
-          ],
-        };
-        const compat = toCompatAgentCard(core, { embedV1Interfaces: true });
-        // Strict filtering picked the v0.3 entry as primary; the
-        // v1.0 entry survives only because embedV1Interfaces carries
-        // the full source array through.
-        expect(compat.url).toBe('https://api.example/legacy');
-        expect(compat.supportedInterfaces).toEqual(core.supportedInterfaces);
+      it('throws on an empty supportedInterfaces array', () => {
+        const empty: V1AgentCard = { ...dualVersionCore(), supportedInterfaces: [] };
+        expect(() => toCompatAgentCard(empty, { embedV1Interfaces: true })).toThrow(
+          VersionNotSupportedError
+        );
+      });
+    });
+
+    describe('duplicateInterfacesForLegacy helper', () => {
+      const v1 = (binding: string, url = `/${binding.toLowerCase()}`) => ({
+        url,
+        protocolBinding: binding,
+        tenant: '',
+        protocolVersion: '1.0',
       });
 
-      it('omits supportedInterfaces when the source array is empty', () => {
-        // Defensive guard: never emit an empty `supportedInterfaces`
-        // field that would confuse downstream parsers expecting it to
-        // either be absent or non-empty.
-        const core: V1AgentCard = {
-          ...v1OnlyCoreLocal(),
-          supportedInterfaces: [
-            {
-              url: 'https://api.example/legacy',
-              protocolBinding: 'JSONRPC',
-              tenant: '',
-              protocolVersion: '0.3',
-            },
-          ],
-        };
-        // Build a card with the property explicitly set to [] without
-        // breaking the existing primary-interface lookup.
-        const empty: V1AgentCard = { ...core, supportedInterfaces: [] };
-        // Strict filter throws on empty supportedInterfaces (no
-        // primary), but with embedV1Interfaces we should still not
-        // crash before that point.
-        expect(() =>
-          toCompatAgentCard(empty, { synthesize: true, embedV1Interfaces: true })
-        ).toThrow(VersionNotSupportedError);
+      it('appends a v0.3 mirror for each listed binding', () => {
+        const out = duplicateInterfacesForLegacy(
+          [v1('JSONRPC'), v1('HTTP+JSON'), v1('GRPC')],
+          ['JSONRPC', 'HTTP+JSON']
+        );
+        expect(out).toHaveLength(5);
+        expect(out[3]).toEqual({ ...v1('JSONRPC'), protocolVersion: '0.3' });
+        expect(out[4]).toEqual({ ...v1('HTTP+JSON'), protocolVersion: '0.3' });
+      });
+
+      it('is idempotent when a binding already has a v0.3 entry', () => {
+        const input = [v1('JSONRPC'), { ...v1('JSONRPC'), protocolVersion: '0.3' }];
+        const out = duplicateInterfacesForLegacy(input, ['JSONRPC']);
+        expect(out).toHaveLength(2);
+      });
+
+      it('skips bindings not present in interfaces', () => {
+        const out = duplicateInterfacesForLegacy([v1('JSONRPC')], ['GRPC']);
+        expect(out).toEqual([v1('JSONRPC')]);
+      });
+
+      it('treats empty protocolVersion as legacy-compatible (no mirror added)', () => {
+        const input = [{ ...v1('JSONRPC'), protocolVersion: '' }];
+        const out = duplicateInterfacesForLegacy(input, ['JSONRPC']);
+        expect(out).toEqual(input);
       });
     });
   });

--- a/test/compat/v0_3/translate/agent_card.spec.ts
+++ b/test/compat/v0_3/translate/agent_card.spec.ts
@@ -17,7 +17,10 @@ import {
   toCoreAgentSkill,
 } from '../../../../src/compat/v0_3/translate/agent_card.js';
 import { VersionNotSupportedError } from '../../../../src/errors.js';
-import type { AgentCard as V1AgentCard } from '../../../../src/types/pb/a2a.js';
+import type {
+  AgentCard as V1AgentCard,
+  AgentInterface as V1AgentInterface,
+} from '../../../../src/types/pb/a2a.js';
 import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
 
 describe('agent_card', () => {
@@ -452,6 +455,21 @@ describe('agent_card', () => {
         const input = [{ ...v1('JSONRPC'), protocolVersion: '' }];
         const out = duplicateInterfacesForLegacy(input, ['JSONRPC']);
         expect(out).toEqual(input);
+      });
+
+      it('returns a deep copy so caller mutations do not bleed into the source', () => {
+        const input = [v1('JSONRPC')];
+        const out = duplicateInterfacesForLegacy(input, ['JSONRPC']);
+        expect(out[0]).not.toBe(input[0]);
+        out[0]!.url = 'https://mutated';
+        expect(input[0]!.url).toBe('/jsonrpc');
+      });
+
+      it('tolerates a nullish interfaces input', () => {
+        const out = duplicateInterfacesForLegacy(undefined as unknown as V1AgentInterface[], [
+          'JSONRPC',
+        ]);
+        expect(out).toEqual([]);
       });
     });
   });

--- a/test/server/express/express_app.spec.ts
+++ b/test/server/express/express_app.spec.ts
@@ -762,42 +762,29 @@ describe('A2AExpressApp', () => {
       expect(legacyHandleStub).toHaveBeenCalledTimes(1);
     });
 
-    it('accepts header-less legacy requests against a v1.0-only card when legacyCompat is enabled', async () => {
-      // legacyCompat implicitly accepts the default-to-'0.3' fallback for
-      // any binding the card already exposes — no duplicate v0.3 stubs needed.
+    it('rejects header-less legacy requests against a v1.0-only card (strict)', async () => {
+      // legacyCompat is strict: card must declare a v0.3 interface for
+      // the binding. A v1.0-only card → VersionNotSupportedError → 500.
       (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(testAgentCard);
-      legacyHandleStub.mockResolvedValue({
-        jsonrpc: '2.0',
-        id: 'req-4',
-        result: { kind: 'task' },
-      });
 
       await request(expressApp)
         .post('/')
         .send(createRpcRequest('req-4', 'message/send'))
-        .expect(200);
+        .expect(500);
 
-      expect(legacyHandleStub).toHaveBeenCalledTimes(1);
-      expect(handleStub).not.toHaveBeenCalled();
+      expect(legacyHandleStub).not.toHaveBeenCalled();
     });
 
-    it('accepts explicit A2A-Version: 0.3 against a v1.0-only card when legacyCompat is enabled', async () => {
-      // Same as above but with the header set explicitly.
+    it('rejects explicit A2A-Version: 0.3 against a v1.0-only card (strict)', async () => {
       (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(testAgentCard);
-      legacyHandleStub.mockResolvedValue({
-        jsonrpc: '2.0',
-        id: 'req-explicit-03',
-        result: { kind: 'task' },
-      });
 
       await request(expressApp)
         .post('/')
         .set('A2A-Version', '0.3')
         .send(createRpcRequest('req-explicit-03', 'message/send'))
-        .expect(200);
+        .expect(500);
 
-      expect(legacyHandleStub).toHaveBeenCalledTimes(1);
-      expect(handleStub).not.toHaveBeenCalled();
+      expect(legacyHandleStub).not.toHaveBeenCalled();
     });
 
     it('streams SSE responses on the legacy path', async () => {

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -874,7 +874,7 @@ describe('restHandler', () => {
       assert.include(response.body.error.message, '9.9');
     });
 
-    it('should accept header-less requests against a v1.0-only card when legacyCompat is enabled', async () => {
+    it('should reject header-less requests against a v1.0-only card even when legacyCompat is enabled (strict)', async () => {
       (mockRequestHandler.getTask as Mock).mockResolvedValue(testTask);
       const compatApp = express();
       compatApp.use(
@@ -885,10 +885,10 @@ describe('restHandler', () => {
         })
       );
 
-      await request(compatApp).get('/tasks/task-1').expect(200);
+      await request(compatApp).get('/tasks/task-1').expect(400);
     });
 
-    it('should accept explicit A2A-Version: 0.3 against a v1.0-only card when legacyCompat is enabled', async () => {
+    it('should reject explicit A2A-Version: 0.3 against a v1.0-only card even when legacyCompat is enabled (strict)', async () => {
       (mockRequestHandler.getTask as Mock).mockResolvedValue(testTask);
       const compatApp = express();
       compatApp.use(
@@ -899,9 +899,9 @@ describe('restHandler', () => {
         })
       );
 
-      // /tasks/:taskId is a v1.0 path (legacy router only owns /v1/...),
-      // but the v1.0 validator accepts '0.3' under legacyCompat.
-      await request(compatApp).get('/tasks/task-1').set('A2A-Version', '0.3').expect(200);
+      // The v1.0 validator no longer adds '0.3' implicitly; the card
+      // must declare an HTTP+JSON interface at protocolVersion '0.3'.
+      await request(compatApp).get('/tasks/task-1').set('A2A-Version', '0.3').expect(400);
     });
 
     it('should still reject unsupported versions (e.g. 9.9) when legacyCompat is enabled', async () => {
@@ -1092,24 +1092,14 @@ describe('restHandler', () => {
       expect(legacySendMessageStub).toHaveBeenCalledTimes(1);
     });
 
-    it('accepts legacy requests against a v1.0-only card when legacyCompat is enabled', async () => {
-      // Card declares no v0.3 HTTP+JSON, but legacyCompat lets the legacy router handle it.
+    it('rejects legacy requests against a v1.0-only card (strict)', async () => {
+      // Strict mode: legacyCompat no longer adds '0.3' implicitly — the
+      // card must declare an HTTP+JSON interface at protocolVersion '0.3'.
       (mockRequestHandler.getAgentCard as Mock).mockResolvedValue(testAgentCard);
-      legacySendMessageStub.mockResolvedValue({
-        kind: 'task',
-        id: 'legacy-task-v1card',
-        contextId: 'ctx',
-        status: { state: 'working' },
-      });
 
-      const response = await request(dualApp)
-        .post('/v1/message:send')
-        .send(legacyMessageBody)
-        .expect(201);
+      await request(dualApp).post('/v1/message:send').send(legacyMessageBody).expect(400);
 
-      assert.equal(response.body.task.id, 'legacy-task-v1card');
-      expect(legacySendMessageStub).toHaveBeenCalledTimes(1);
-      expect(v1SendMessageStub).not.toHaveBeenCalled();
+      expect(legacySendMessageStub).not.toHaveBeenCalled();
     });
 
     it('streams SSE responses on the legacy path', async () => {

--- a/test/server/version.spec.ts
+++ b/test/server/version.spec.ts
@@ -169,61 +169,32 @@ describe('protocolBinding filtering', () => {
   });
 });
 
-describe('validateVersion with legacyCompat option', () => {
-  it('accepts 0.3 against a v1.0-only card for the requested binding', () => {
+describe('validateVersion strict v0.3 acceptance', () => {
+  it('rejects 0.3 against a v1.0-only card for the requested binding', () => {
     const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
-    expect(() =>
-      validateVersion('0.3', card, 'JSONRPC', { legacyCompat: { enabled: true } })
-    ).not.toThrow();
+    expect(() => validateVersion('0.3', card, 'JSONRPC')).toThrow(VersionNotSupportedError);
   });
 
-  it('still rejects 0.3 when the card has no interface for the binding at all', () => {
-    // Card serves only HTTP+JSON, so a JSONRPC request must not slip through legacyCompat.
-    const card = createAgentCard([{ protocolBinding: 'HTTP+JSON', protocolVersion: '1.0' }]);
-    expect(() =>
-      validateVersion('0.3', card, 'JSONRPC', { legacyCompat: { enabled: true } })
-    ).toThrow(VersionNotSupportedError);
+  it('accepts 0.3 when the card declares it explicitly for the binding', () => {
+    const card = createAgentCard([
+      { protocolBinding: 'JSONRPC', protocolVersion: '1.0' },
+      { protocolBinding: 'JSONRPC', protocolVersion: '0.3' },
+    ]);
+    expect(() => validateVersion('0.3', card, 'JSONRPC')).not.toThrow();
   });
 
-  it('still rejects 0.3 when the card has no interfaces at all', () => {
-    const card = createAgentCard([]);
-    expect(() =>
-      validateVersion('0.3', card, 'JSONRPC', { legacyCompat: { enabled: true } })
-    ).toThrow(VersionNotSupportedError);
+  it('rejects 0.3 for a different binding even when another binding declares it', () => {
+    const card = createAgentCard([
+      { protocolBinding: 'JSONRPC', protocolVersion: '0.3' },
+      { protocolBinding: 'HTTP+JSON', protocolVersion: '1.0' },
+    ]);
+    expect(() => validateVersion('0.3', card, 'HTTP+JSON')).toThrow(VersionNotSupportedError);
   });
 
-  it('still rejects unsupported versions (e.g. 9.9) with legacyCompat enabled', () => {
-    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
-    expect(() =>
-      validateVersion('9.9', card, 'JSONRPC', { legacyCompat: { enabled: true } })
-    ).toThrow(VersionNotSupportedError);
-  });
-
-  it('accepts 0.3 even when protocolBinding is omitted, as long as some interface exists', () => {
-    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
-    expect(() =>
-      validateVersion('0.3', card, undefined, { legacyCompat: { enabled: true } })
-    ).not.toThrow();
-  });
-
-  it('continues to accept declared v1.0 versions when legacyCompat is enabled', () => {
-    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
-    expect(() =>
-      validateVersion('1.0', card, 'JSONRPC', { legacyCompat: { enabled: true } })
-    ).not.toThrow();
-  });
-
-  it('legacyCompat: { enabled: false } behaves identically to omitted option', () => {
-    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
-    expect(() =>
-      validateVersion('0.3', card, 'JSONRPC', { legacyCompat: { enabled: false } })
-    ).toThrow(VersionNotSupportedError);
-  });
-
-  it('does not modify the agent card when synthesizing the v0.3 entry', () => {
-    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '1.0' }]);
-    validateVersion('0.3', card, 'JSONRPC', { legacyCompat: { enabled: true } });
-    expect(getSupportedVersions(card).has('0.3')).toBe(false);
+  it('does not modify the agent card', () => {
+    const card = createAgentCard([{ protocolBinding: 'JSONRPC', protocolVersion: '0.3' }]);
+    validateVersion('0.3', card, 'JSONRPC');
+    expect(getSupportedVersions(card).has('1.0')).toBe(false);
   });
 });
 


### PR DESCRIPTION
# Description

v0.3 advertisement and request routing are now driven entirely by per-interface protocolVersion declarations in the agent card. The SDK no longer auto-promotes v1.0 interfaces to v0.3 when legacyCompat: { enabled: true } is set. This aligns JS with the Python and Go SDKs and fixes a issue where the card claimed v0.3 support for bindings (e.g. gRPC) that the actual strict-v1.0 handlers would reject at the wire.

## Motivation
Before this change, legacyCompat: { enabled: true } on agentCardHandler called toCompatAgentCard(card, { synthesize: true }), which restamped every declared AgentInterface as v0.3-reachable regardless of its real protocolVersion. Combined with validateVersion's implicit v0.3 add, the SDK advertised and accepted v0.3 on bindings the operator never opted into v0.3 for.

Card shape under the new model:
```ts
supportedInterfaces: [
  { url: '/jsonrpc', protocolBinding: 'JSONRPC',   protocolVersion: '1.0' },
  { url: '/jsonrpc', protocolBinding: 'JSONRPC',   protocolVersion: '0.3' },
  { url: '/rest',    protocolBinding: 'HTTP+JSON', protocolVersion: '1.0' },
  { url: '/grpc',    protocolBinding: 'GRPC',      protocolVersion: '1.0' },
]
```

→ v0.3 clients reach only JSON-RPC; REST and gRPC v0.3 calls return VersionNotSupportedError. Symmetric across card-serving and routing.

Closes #559  🦕
