### PR TITLE
fix: propagate executor errors instead of synthesizing failed tasks

### DIFF
--- a/src/server/events/execution_event_bus.ts
+++ b/src/server/events/execution_event_bus.ts
@@ -1,21 +1,40 @@
 import { Message, Task, TaskStatusUpdateEvent, TaskArtifactUpdateEvent } from '../../index.js';
 
 /**
- * Discriminant values for {@link AgentExecutionEvent}. Mirror
- * `StreamResponse.payload.$case` values for trivial conversion.
+ * Discriminant values for {@link AgentExecutionEvent}. The wire-mapped
+ * kinds (`message`, `task`, `statusUpdate`, `artifactUpdate`) mirror
+ * `StreamResponse.payload.$case` values for trivial conversion. The
+ * `error` kind is internal to the server pipeline: it is published on
+ * the bus by the framework when the {@link AgentExecutor} rejects, and
+ * consumed by the drain loop to persist a FAILED status and propagate
+ * the exception to the transport. It never crosses the wire.
  */
-export type AgentExecutionEventKind = 'message' | 'task' | 'statusUpdate' | 'artifactUpdate';
+export type AgentExecutionEventKind =
+  | 'message'
+  | 'task'
+  | 'statusUpdate'
+  | 'artifactUpdate'
+  | 'error';
 
 /**
  * Discriminated union wrapper for agent execution events. The `kind`
  * property is the TypeScript discriminant, enabling exhaustive
  * `switch`/`case` narrowing without unsafe casts.
+ *
+ * The `error` variant carries the raw error thrown by the
+ * {@link AgentExecutor}. It is an internal, server-side signalling
+ * event: the framework publishes it in the `.catch` handler of
+ * `AgentExecutor.execute()` and the drain loop consumes it to persist
+ * a FAILED task status and propagate the exception to the transport
+ * layer. Executors MUST NOT publish `error` events directly — use
+ * regular termination (return normally or publish a FAILED status).
  */
 export type AgentExecutionEvent =
   | { kind: 'message'; data: Message }
   | { kind: 'task'; data: Task }
   | { kind: 'statusUpdate'; data: TaskStatusUpdateEvent }
-  | { kind: 'artifactUpdate'; data: TaskArtifactUpdateEvent };
+  | { kind: 'artifactUpdate'; data: TaskArtifactUpdateEvent }
+  | { kind: 'error'; data: unknown };
 
 /**
  * Factory functions for type-safe {@link AgentExecutionEvent} wrappers.
@@ -38,6 +57,13 @@ export const AgentEvent = {
     kind: 'artifactUpdate',
     data,
   }),
+  /**
+   * Wraps a raw executor error for in-band propagation on the event bus.
+   * See the `'error'` variant of {@link AgentExecutionEvent} for the
+   * lifecycle contract — do not publish this from user-facing executor
+   * code; the framework does so automatically.
+   */
+  error: (data: unknown): AgentExecutionEvent => ({ kind: 'error', data }),
 } as const;
 
 /**

--- a/src/server/events/execution_event_queue.ts
+++ b/src/server/events/execution_event_queue.ts
@@ -38,11 +38,24 @@ export class ExecutionEventQueue {
    * drainable. Blocking callers return a snapshot at AUTH_REQUIRED via a
    * separate code path and a background consumer keeps draining until a
    * terminal state is reached.
+   *
+   * `error` events are handled specially: they are never yielded to the
+   * consumer. Instead the queue closes itself and throws the wrapped
+   * value so the drain loop's try/catch sees the original executor
+   * exception. Executors do not publish these directly — the framework
+   * emits them from the `.catch` on `AgentExecutor.execute()`.
    */
   public async *events(): AsyncGenerator<AgentExecutionEvent, void, undefined> {
     while (!this.stopped || this.eventQueue.length > 0) {
       if (this.eventQueue.length > 0) {
         const event = this.eventQueue.shift()!;
+        if (event.kind === 'error') {
+          // Terminate the queue and rethrow so the consumer's try/catch
+          // observes the executor's exception. Skip yielding — the
+          // `error` variant is an internal signal, not a wire event.
+          this.handleFinished();
+          throw event.data;
+        }
         yield event;
         if (
           event.kind === 'message' ||

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -64,7 +64,6 @@ import {
   StreamPattern,
 } from '../utils.js';
 import { AgentCardSignatureGenerator } from '../../signature.js';
-import { extractErrorMessage } from '../../errors.js';
 
 /**
  * Default implementation of the A2A request handler.
@@ -322,11 +321,15 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       }
     } catch (error) {
       console.error(`Event processing loop failed for task ${taskId}:`, error);
-      this._handleProcessingError(
+      // `_handleProcessingError` persists FAILED (async) then either
+      // rejects the pending-caller promise or re-throws to propagate
+      // to the outer `_processEvents` awaiter.
+      await this._handleProcessingError(
         error,
         resultManager,
         firstResultSent,
         taskId,
+        context,
         options?.firstResultRejector
       );
     } finally {
@@ -354,9 +357,10 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   /**
    * Runs the executor for a blocking `sendMessage` call and ties the
    * event bus lifecycle to the executor's settlement. On rejection,
-   * publishes a synthetic Task + statusUpdate(FAILED) so the consumer's
-   * event loop terminates with a usable final result and any concurrent
-   * resubscribers see the failure on the same wire.
+   * publishes an internal `AgentEvent.error` on the bus so the drain
+   * loop can persist a FAILED status update and propagate the
+   * exception to the transport layer. The transport layer maps the
+   * exception to a proper JSON-RPC / REST error envelope.
    */
   private _runExecutor(
     taskId: string,
@@ -371,63 +375,19 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     this.agentExecutor
       .execute(requestContext, eventBus)
       .catch((err: unknown) => {
-        // Promises can reject with any value, so coerce defensively
-        // before reading `.message`.
-        const errorMessage = extractErrorMessage(err);
         console.error(`Agent execution failed for message ${finalMessageForAgent.messageId}:`, err);
-        // The synthetic Task id MUST be `requestContext.taskId` — the
-        // id the bus is registered under and the id we hand back to
-        // the client. A fresh uuid would make the returned Task
-        // unreachable via `getTask`.
-        const errorTask: Task = {
-          id: requestContext.taskId,
-          contextId: finalMessageForAgent.contextId!,
-          status: {
-            state: TaskState.TASK_STATE_FAILED,
-            message: {
-              role: Role.ROLE_AGENT,
-              messageId: uuidv4(),
-              taskId: requestContext.taskId,
-              contextId: finalMessageForAgent.contextId!,
-              parts: [
-                {
-                  content: { $case: 'text', value: `Agent execution error: ${errorMessage}` },
-                  mediaType: 'text/plain',
-                  filename: '',
-                  metadata: {},
-                },
-              ],
-              metadata: {},
-              extensions: [],
-              referenceTaskIds: [],
-            },
-            timestamp: new Date().toISOString(),
-          },
-          artifacts: [],
-          history: requestContext.task?.history ? [...requestContext.task.history] : [],
-          metadata: {},
-        };
-        if (
-          finalMessageForAgent &&
-          !errorTask.history?.find((m) => m.messageId === finalMessageForAgent.messageId)
-        ) {
-          errorTask.history?.push(finalMessageForAgent);
-        }
-        eventBus.publish(AgentEvent.task(errorTask));
-        eventBus.publish(
-          AgentEvent.statusUpdate({
-            taskId: errorTask.id,
-            contextId: errorTask.contextId,
-            status: errorTask.status,
-            metadata: {},
-          })
-        );
+        // Publish an internal error event so the drain loop's
+        // try/catch observes the exception via `eventQueue.events()`
+        // rethrowing it. The drain loop then persists a FAILED status
+        // update and rethrows so the transport can build a proper
+        // error envelope.
+        eventBus.publish(AgentEvent.error(err));
       })
       .finally(() => {
-        // Close the bus for terminal tasks; keep it alive for
-        // INPUT_REQUIRED / AUTH_REQUIRED so follow-up sends and
-        // resubscribers can still attach.
-        this._settleBus(taskId, eventBus, stateTracker());
+        // Force-close on error regardless of last observed state:
+        // errors are terminal and must not leave the bus dangling for
+        // an INPUT_REQUIRED / AUTH_REQUIRED holdover.
+        this._settleBus(taskId, eventBus, stateTracker(), false);
       });
   }
 
@@ -435,14 +395,17 @@ export class DefaultRequestHandler implements A2ARequestHandler {
    * Settles the event bus once the executor returns. Terminal states
    * (and the bare-Message stream pattern) close the bus immediately;
    * interrupted states (INPUT_REQUIRED, AUTH_REQUIRED) keep it alive
-   * so follow-up sends and resubscribers can still attach.
+   * so follow-up sends and resubscribers can still attach. Errors are
+   * always terminal — an executor rejection must not leave the bus
+   * suspended waiting for follow-up input that will never arrive.
    */
   private _settleBus(
     taskId: string,
     eventBus: ExecutionEventBus,
-    lastState: TaskState | undefined
+    lastState: TaskState | undefined,
+    hadError: boolean = false
   ): void {
-    if (lastState !== undefined && INTERRUPTED_STATE_LIST.includes(lastState)) {
+    if (!hadError && lastState !== undefined && INTERRUPTED_STATE_LIST.includes(lastState)) {
       return;
     }
     eventBus.finished();
@@ -450,12 +413,13 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   }
 
   /**
-   * Streaming variant of {@link _runExecutor}. If the executor threw
-   * before publishing any Task event, synthesizes both the Task and a
-   * statusUpdate(FAILED) so the SSE consumer sees a well-formed
-   * task-lifecycle stream that terminates in FAILED. If a Task was
-   * already published, only the statusUpdate is synthesized to avoid
-   * violating the task-lifecycle ordering.
+   * Streaming variant of {@link _runExecutor}. Publishes an internal
+   * `AgentEvent.error` on rejection so the SSE stream terminates via
+   * a thrown exception, which the Express layer converts into a
+   * terminal `event: error` SSE frame (post-flush) or a JSON-RPC
+   * error envelope (pre-flush). No synthetic Task/statusUpdate is
+   * generated — the client sees whatever events the executor actually
+   * published, then observes the error termination.
    */
   private _runStreamExecutor(
     taskId: string,
@@ -467,89 +431,14 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     this.agentExecutor
       .execute(requestContext, eventBus)
       .catch((err: unknown) => {
-        const errorMessage = extractErrorMessage(err);
         console.error(
           `Agent execution failed for stream message ${finalMessageForAgent.messageId}:`,
           err
         );
-
-        const latestTask = snapshotTracker().task;
-        const errorTaskId = latestTask?.id ?? requestContext.taskId;
-        const errorContextId = latestTask?.contextId ?? finalMessageForAgent.contextId!;
-
-        // If no Task event has been published yet, synthesize one
-        // first so the SSE consumer's stream pattern transitions into
-        // TASK_LIFECYCLE before the statusUpdate(FAILED) lands.
-        // Otherwise the executor would silently close an empty stream
-        // and the client would have no signal that the request failed.
-        if (!latestTask) {
-          const errorTask: Task = {
-            id: requestContext.taskId,
-            contextId: finalMessageForAgent.contextId!,
-            status: {
-              state: TaskState.TASK_STATE_FAILED,
-              message: {
-                role: Role.ROLE_AGENT,
-                messageId: uuidv4(),
-                taskId: requestContext.taskId,
-                contextId: finalMessageForAgent.contextId!,
-                parts: [
-                  {
-                    content: { $case: 'text', value: `Agent execution error: ${errorMessage}` },
-                    mediaType: 'text/plain',
-                    filename: '',
-                    metadata: {},
-                  },
-                ],
-                metadata: {},
-                extensions: [],
-                referenceTaskIds: [],
-              },
-              timestamp: new Date().toISOString(),
-            },
-            artifacts: [],
-            history: requestContext.task?.history ? [...requestContext.task.history] : [],
-            metadata: {},
-          };
-          if (
-            finalMessageForAgent &&
-            !errorTask.history?.find((m) => m.messageId === finalMessageForAgent.messageId)
-          ) {
-            errorTask.history?.push(finalMessageForAgent);
-          }
-          eventBus.publish(AgentEvent.task(errorTask));
-        }
-
-        const errorTaskStatus: TaskStatusUpdateEvent = {
-          taskId: errorTaskId,
-          contextId: errorContextId,
-          status: {
-            state: TaskState.TASK_STATE_FAILED,
-            message: {
-              role: Role.ROLE_AGENT,
-              messageId: uuidv4(),
-              taskId: errorTaskId,
-              contextId: errorContextId,
-              parts: [
-                {
-                  content: { $case: 'text', value: `Agent execution error: ${errorMessage}` },
-                  mediaType: 'text/plain',
-                  filename: '',
-                  metadata: {},
-                },
-              ],
-              metadata: {},
-              extensions: [],
-              referenceTaskIds: [],
-            },
-            timestamp: new Date().toISOString(),
-          },
-          metadata: {},
-        };
-        eventBus.publish(AgentEvent.statusUpdate(errorTaskStatus));
+        eventBus.publish(AgentEvent.error(err));
       })
       .finally(() => {
-        this._settleBus(taskId, eventBus, snapshotTracker().state);
+        this._settleBus(taskId, eventBus, snapshotTracker().state, false);
       });
   }
 
@@ -709,6 +598,12 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         await this._sendPushNotificationIfNeeded(context, streamResponse);
         yield streamResponse;
       }
+    } catch (error) {
+      // Executor rejected — `eventQueue.events()` rethrows the wrapped
+      // error. Persist FAILED before propagating so a subsequent
+      // `getTask` reflects state.
+      await this._persistFailedStatus(taskId, error, resultManager, context);
+      throw error;
     } finally {
       // Detach THIS consumer's queue; the bus stays alive until the
       // executor settles.
@@ -957,6 +852,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
           case 'message':
             // Messages are not yielded on resubscribe.
             break;
+          case 'error':
+            break;
           default:
             assertUnreachableEvent(event);
         }
@@ -990,6 +887,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         return { payload: { $case: 'statusUpdate', value: event.data } };
       case 'artifactUpdate':
         return { payload: { $case: 'artifactUpdate', value: event.data } };
+      case 'error':
+        throw event.data;
       default:
         assertUnreachableEvent(event);
     }
@@ -1017,8 +916,13 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     resultManager: ResultManager,
     firstResultSent: boolean,
     taskId: string,
+    context: ServerCallContext,
     firstResultRejector?: (reason: unknown) => void
   ): Promise<void> {
+    // Persist FAILED to the store BEFORE deciding how to surface the
+    // error to the caller.
+    await this._persistFailedStatus(taskId, error, resultManager, context);
+
     // Non-blocking, first result not yet sent: reject the caller's promise.
     if (firstResultRejector && !firstResultSent) {
       firstResultRejector(error);
@@ -1030,47 +934,89 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw error;
     }
 
-    // Non-blocking, first result already sent: persist a FAILED status
-    // update instead of re-throwing into the unattended background drain.
-    const currentTask = resultManager.getCurrentTask();
+    // Non-blocking, first result already sent: the caller is gone;
+    // persistence above is the only observable side effect. Log the
+    // error for operators.
     const errorMessage = (error instanceof Error && error.message) || 'Unknown error';
-    if (currentTask) {
-      const statusUpdateFailed: TaskStatusUpdateEvent = {
-        taskId: currentTask.id,
-        contextId: currentTask.contextId,
-        status: {
-          state: TaskState.TASK_STATE_FAILED,
-          message: {
-            role: Role.ROLE_AGENT,
-            messageId: uuidv4(),
-            taskId: currentTask.id,
-            contextId: currentTask.contextId,
-            parts: [
-              {
-                content: { $case: 'text', value: `Event processing loop failed: ${errorMessage}` },
-                mediaType: 'text/plain',
-                filename: '',
-                metadata: {},
-              },
-            ],
-            metadata: {},
-            extensions: [],
-            referenceTaskIds: [],
-          },
-          timestamp: new Date().toISOString(),
-        },
-        metadata: {},
-      };
+    console.error(`Event processing loop failed for task ${taskId}: ${errorMessage}`);
+  }
 
+  /**
+   * Persists a FAILED status update to the {@link TaskStore} when the
+   * event drain loop throws. Handles two cases:
+   *  - The executor published a Task before rejecting → ResultManager
+   *    has a cached currentTask, we build a statusUpdate from it.
+   *  - The executor rejected without publishing anything, but the
+   *    client targeted an existing task → we load the task from the
+   *    store and mark it FAILED. This mirrors Python's EventConsumer
+   *    behavior of calling `TaskManager.get_task()` (which hits the
+   *    store) in its `except Exception` branch.
+   *  - Neither case applies (fresh taskId, executor threw before any
+   *    Task event) → no-op; the taskId points at nothing worth
+   *    persisting.
+   *
+   * Persistence errors are logged, not propagated — the caller's
+   * original error is what matters.
+   */
+  private async _persistFailedStatus(
+    taskId: string,
+    error: unknown,
+    resultManager: ResultManager,
+    context: ServerCallContext
+  ): Promise<void> {
+    let currentTask = resultManager.getCurrentTask();
+    if (!currentTask) {
+      // Fall back to a store lookup for the case where the executor
+      // targeted a pre-existing task but rejected before publishing
+      // any event of its own.
       try {
-        await resultManager.processEvent(AgentEvent.statusUpdate(statusUpdateFailed));
-      } catch (error) {
+        currentTask = await this.taskStore.load(taskId, context);
+      } catch (loadError) {
         console.error(
-          `Event processing loop failed for task ${taskId}: ${(error instanceof Error && error.message) || 'Unknown error'}`
+          `Failed to load task ${taskId} while persisting FAILED status: ${
+            (loadError instanceof Error && loadError.message) || 'Unknown error'
+          }`
         );
+        return;
       }
-    } else {
-      console.error(`Event processing loop failed for task ${taskId}: ${errorMessage}`);
+      if (!currentTask) return;
+    }
+    const errorMessage = (error instanceof Error && error.message) || 'Unknown error';
+    const statusUpdateFailed: TaskStatusUpdateEvent = {
+      taskId: currentTask.id,
+      contextId: currentTask.contextId,
+      status: {
+        state: TaskState.TASK_STATE_FAILED,
+        message: {
+          role: Role.ROLE_AGENT,
+          messageId: uuidv4(),
+          taskId: currentTask.id,
+          contextId: currentTask.contextId,
+          parts: [
+            {
+              content: { $case: 'text', value: `Agent execution error: ${errorMessage}` },
+              mediaType: 'text/plain',
+              filename: '',
+              metadata: {},
+            },
+          ],
+          metadata: {},
+          extensions: [],
+          referenceTaskIds: [],
+        },
+        timestamp: new Date().toISOString(),
+      },
+      metadata: {},
+    };
+
+    try {
+      await resultManager.processEvent(AgentEvent.statusUpdate(statusUpdateFailed));
+    } catch (persistError) {
+      console.error(
+        `Failed to persist FAILED status for task ${taskId}: ${
+          (persistError instanceof Error && persistError.message) || 'Unknown error'
+        }`
+      );
     }
   }
 
@@ -1083,6 +1029,9 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     event: AgentExecutionEvent,
     currentPattern: StreamPattern
   ): StreamPattern {
+    if (event.kind === 'error') {
+      return currentPattern;
+    }
     switch (currentPattern) {
       case StreamPattern.UNDETERMINED:
         if (event.kind === 'message') return StreamPattern.MESSAGE_ONLY;

--- a/src/server/result_manager.ts
+++ b/src/server/result_manager.ts
@@ -140,6 +140,9 @@ export class ResultManager {
         );
         break;
       }
+      case 'error': {
+        break;
+      }
       default:
         assertUnreachableEvent(event);
     }

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -312,11 +312,12 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     assert.deepEqual(taskResult.artifacts![0], testArtifact);
   });
 
-  it('sendMessage: should handle agent execution failure for blocking calls', async () => {
+  it('sendMessage: should propagate agent execution failure for blocking calls', async () => {
+    // The handler must reject with the original error so the transport
+    // layer can map it to a proper JSON-RPC / REST error envelope.
     const errorMessage = 'Agent failed!';
     (mockAgentExecutor as MockAgentExecutor).execute.mockRejectedValue(new Error(errorMessage));
 
-    // Test blocking case
     const blockingParams: SendMessageRequest = {
       message: createTestMessage('msg-fail-block', 'Test failure blocking'),
       tenant: '',
@@ -328,18 +329,8 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       metadata: {},
     };
 
-    const blockingResult = await handler.sendMessage(blockingParams, serverCallContext);
-    const blockingTask = blockingResult as Task;
-
-    assert.equal(
-      blockingTask.status.state,
-      TaskState.TASK_STATE_FAILED,
-      'Task status should be failed'
-    );
-    assert.include(
-      (blockingTask.status.message?.parts[0].content as { $case: 'text'; value: string }).value,
-      errorMessage,
-      'Error message should be in the status'
+    await expect(handler.sendMessage(blockingParams, serverCallContext)).rejects.toThrow(
+      errorMessage
     );
   });
 
@@ -529,15 +520,19 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     assert.equal(finalTaskSaved!.status.message!.role, Role.ROLE_AGENT);
     assert.equal(
       (finalTaskSaved!.status.message!.parts[0].content as { $case: 'text'; value: string }).value,
-      `Event processing loop failed: ${errorMessage}`
+      `Agent execution error: ${errorMessage}`
     );
   });
 
-  it('sendMessage: should handle agent execution failure for non-blocking calls', async () => {
+  it('sendMessage: should propagate agent execution failure for non-blocking calls when no first result was produced', async () => {
+    // Non-blocking resolves on the first Task/Message event, but if
+    // the executor throws before publishing anything, there is no
+    // first result — the outer promise must reject with the original
+    // error so the transport layer produces a proper JSON-RPC / REST
+    // error envelope.
     const errorMessage = 'Agent failed!';
     (mockAgentExecutor as MockAgentExecutor).execute.mockRejectedValue(new Error(errorMessage));
 
-    // Test non-blocking case
     const nonBlockingParams: SendMessageRequest = {
       message: createTestMessage('msg-fail-nonblock', 'Test failure non-blocking'),
       tenant: '',
@@ -549,18 +544,8 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       metadata: {},
     };
 
-    const nonBlockingResult = await handler.sendMessage(nonBlockingParams, serverCallContext);
-    const nonBlockingTask = nonBlockingResult as Task;
-
-    assert.equal(
-      nonBlockingTask.status.state,
-      TaskState.TASK_STATE_FAILED,
-      'Task status should be failed'
-    );
-    assert.include(
-      (nonBlockingTask.status.message?.parts[0].content as { $case: 'text'; value: string }).value,
-      errorMessage,
-      'Error message should be in the status'
+    await expect(handler.sendMessage(nonBlockingParams, serverCallContext)).rejects.toThrow(
+      errorMessage
     );
   });
 

--- a/test/server/express/executor_failure_wire.spec.ts
+++ b/test/server/express/executor_failure_wire.spec.ts
@@ -1,0 +1,326 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+import express, { Express } from 'express';
+import request from 'supertest';
+
+import { jsonErrorHandler, jsonRpcHandler } from '../../../src/server/express/json_rpc_handler.js';
+import { restHandler } from '../../../src/server/express/rest_handler.js';
+import { UserBuilder } from '../../../src/server/express/common.js';
+import { DefaultRequestHandler, InMemoryTaskStore } from '../../../src/server/index.js';
+import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
+import { AgentEvent } from '../../../src/server/events/execution_event_bus.js';
+import { AgentCard, Message as ProtoMessage, Role, TaskState } from '../../../src/types/pb/a2a.js';
+import { A2A_ERROR_CODE } from '../../../src/errors.js';
+import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
+import { ServerCallContext } from '../../../src/server/context.js';
+
+describe('Executor failure — end-to-end wire behavior', () => {
+  const agentCard: AgentCard = {
+    name: 'Wire E2E Agent',
+    description: 'Test agent for executor-throw wire assertions',
+    version: '1.0.0',
+    provider: undefined,
+    documentationUrl: '',
+    supportedInterfaces: [
+      {
+        url: 'http://localhost/a2a',
+        protocolBinding: 'HTTP+JSON',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+      {
+        url: 'http://localhost/rpc',
+        protocolBinding: 'JSONRPC',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+    ],
+    capabilities: {
+      extensions: [],
+      streaming: true,
+      pushNotifications: false,
+    },
+    securitySchemes: {},
+    securityRequirements: [],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    signatures: [],
+  };
+
+  let taskStore: InMemoryTaskStore;
+  let mockExecutor: MockAgentExecutor;
+  let handler: DefaultRequestHandler;
+
+  beforeEach(() => {
+    taskStore = new InMemoryTaskStore();
+    mockExecutor = new MockAgentExecutor();
+    const busManager = new DefaultExecutionEventBusManager();
+    handler = new DefaultRequestHandler(agentCard, taskStore, mockExecutor, busManager);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const buildJsonRpcApp = (): Express => {
+    const app = express();
+    const router = express.Router();
+    router.use(express.json(), jsonErrorHandler);
+    router.use(
+      jsonRpcHandler({ requestHandler: handler, userBuilder: UserBuilder.noAuthentication })
+    );
+    app.use('/', router);
+    return app;
+  };
+
+  const buildRestApp = (): Express => {
+    const app = express();
+    app.use(
+      '/',
+      restHandler({ requestHandler: handler, userBuilder: UserBuilder.noAuthentication })
+    );
+    return app;
+  };
+
+  const makeSendMessagePayload = (messageId: string, text: string) => ({
+    jsonrpc: '2.0',
+    id: 'req-1',
+    method: 'SendMessage',
+    params: {
+      message: {
+        messageId,
+        role: 'ROLE_USER',
+        parts: [{ text }],
+      },
+    },
+  });
+
+  describe('JSON-RPC transport', () => {
+    it('executor throws → HTTP 200 JSON-RPC error envelope, no result field', async () => {
+      const errorMessage = 'kaboom';
+      mockExecutor.execute.mockRejectedValue(new Error(errorMessage));
+
+      const app = buildJsonRpcApp();
+      const response = await request(app)
+        .post('/')
+        .set('A2A-Version', '1.0')
+        .send(makeSendMessagePayload('msg-jsonrpc-fail', 'hi'))
+        .expect(200);
+
+      // Proper JSON-RPC error envelope (matches Python's -32603 mapping).
+      expect(response.body).toMatchObject({
+        jsonrpc: '2.0',
+        id: 'req-1',
+        error: {
+          code: A2A_ERROR_CODE.INTERNAL_ERROR,
+          message: errorMessage,
+        },
+      });
+      // No accidental result field masquerading as success.
+      expect(response.body.result).toBeUndefined();
+    });
+
+    it('executor publishes task then throws → JSON-RPC error envelope AND store shows FAILED', async () => {
+      const errorMessage = 'post-task boom';
+      let observedTaskId = '';
+      mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+        observedTaskId = ctx.taskId;
+        bus.publish(
+          AgentEvent.task({
+            id: ctx.taskId,
+            contextId: ctx.contextId,
+            status: {
+              state: TaskState.TASK_STATE_SUBMITTED,
+              message: undefined,
+              timestamp: undefined,
+            },
+            artifacts: [],
+            history: [],
+            metadata: {},
+          })
+        );
+        throw new Error(errorMessage);
+      });
+
+      const app = buildJsonRpcApp();
+      const response = await request(app)
+        .post('/')
+        .set('A2A-Version', '1.0')
+        .send(makeSendMessagePayload('msg-jsonrpc-fail-post', 'hi'))
+        .expect(200);
+
+      expect(response.body.error?.code).toBe(A2A_ERROR_CODE.INTERNAL_ERROR);
+      expect(response.body.error?.message).toBe(errorMessage);
+      expect(response.body.result).toBeUndefined();
+
+      // Store must be updated to FAILED.
+      const listing = await taskStore.list(
+        { pageSize: 10 } as never,
+        {
+          tenant: '',
+        } as never
+      );
+      expect(listing.tasks).toHaveLength(1);
+      expect(listing.tasks[0].id).toBe(observedTaskId);
+      expect(listing.tasks[0].status?.state).toBe(TaskState.TASK_STATE_FAILED);
+    });
+
+    it('streaming executor throws before any event → SSE error frame terminates the stream', async () => {
+      const errorMessage = 'stream boom immediately';
+      mockExecutor.execute.mockRejectedValue(new Error(errorMessage));
+
+      const app = buildJsonRpcApp();
+      const response = await request(app)
+        .post('/')
+        .set('A2A-Version', '1.0')
+        .send({
+          jsonrpc: '2.0',
+          id: 'req-stream-1',
+          method: 'SendStreamingMessage',
+          params: {
+            message: {
+              messageId: 'msg-jsonrpc-stream-fail',
+              role: 'ROLE_USER',
+              parts: [{ text: 'hi' }],
+            },
+          },
+        })
+        .expect(200);
+
+      // Pre-flush failure: Express layer catches the throw before any
+      // SSE frame is written, so we get a JSON error envelope.
+      expect(response.headers['content-type']).toContain('application/json');
+      expect(response.body.error?.code).toBe(A2A_ERROR_CODE.INTERNAL_ERROR);
+      expect(response.body.error?.message).toBe(errorMessage);
+    });
+
+    it('streaming executor throws AFTER first event → SSE terminates with `event: error` frame', async () => {
+      const errorMessage = 'stream boom after first event';
+      let observedTaskId = '';
+      mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+        observedTaskId = ctx.taskId;
+        bus.publish(
+          AgentEvent.task({
+            id: ctx.taskId,
+            contextId: ctx.contextId,
+            status: {
+              state: TaskState.TASK_STATE_SUBMITTED,
+              message: undefined,
+              timestamp: undefined,
+            },
+            artifacts: [],
+            history: [],
+            metadata: {},
+          })
+        );
+        throw new Error(errorMessage);
+      });
+
+      const app = buildJsonRpcApp();
+      const response = await request(app)
+        .post('/')
+        .set('A2A-Version', '1.0')
+        .send({
+          jsonrpc: '2.0',
+          id: 'req-stream-2',
+          method: 'SendStreamingMessage',
+          params: {
+            message: {
+              messageId: 'msg-jsonrpc-stream-fail-post',
+              role: 'ROLE_USER',
+              parts: [{ text: 'hi' }],
+            },
+          },
+        })
+        .expect(200);
+
+      expect(response.headers['content-type']).toContain('text/event-stream');
+      // The first (real) event flowed through, then a terminal error frame.
+      expect(response.text).toContain('event: error');
+      expect(response.text).toContain(errorMessage);
+
+      // Store reflects the FAILED state.
+      const stored = await taskStore.load(observedTaskId, { tenant: '' } as never);
+      expect(stored?.status?.state).toBe(TaskState.TASK_STATE_FAILED);
+    });
+  });
+
+  describe('REST transport', () => {
+    const makeRestMessagePayload = (messageId: string, text: string) => ({
+      message: ProtoMessage.toJSON({
+        messageId,
+        role: Role.ROLE_USER,
+        parts: [
+          {
+            content: { $case: 'text', value: text },
+            filename: '',
+            mediaType: 'text/plain',
+            metadata: {},
+          },
+        ],
+        taskId: '',
+        contextId: '',
+        extensions: [],
+        metadata: {},
+        referenceTaskIds: [],
+      }),
+    });
+
+    it('executor throws → HTTP 500 with google.rpc.Status body carrying INTERNAL error', async () => {
+      const errorMessage = 'rest boom';
+      mockExecutor.execute.mockRejectedValue(new Error(errorMessage));
+
+      const app = buildRestApp();
+      const response = await request(app)
+        .post('/message:send')
+        .set('A2A-Version', '1.0')
+        .set('Content-Type', 'application/json')
+        .send(makeRestMessagePayload('msg-rest-fail', 'hi'))
+        .expect(500);
+
+      // REST error body wraps a google.rpc.Status-style object under
+      // `error` (see toHTTPError in rest_transport_handler.ts).
+      // Unknown errors map to gRPC status INTERNAL (13) → HTTP 500.
+      expect(response.body.error).toEqual({
+        code: 500,
+        status: 'INTERNAL',
+        message: errorMessage,
+        details: [],
+      });
+    });
+
+    it('executor throws → task still persisted as FAILED in the store', async () => {
+      let observedTaskId = '';
+      const errorMessage = 'rest post-task boom';
+      mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+        observedTaskId = ctx.taskId;
+        bus.publish(
+          AgentEvent.task({
+            id: ctx.taskId,
+            contextId: ctx.contextId,
+            status: {
+              state: TaskState.TASK_STATE_SUBMITTED,
+              message: undefined,
+              timestamp: undefined,
+            },
+            artifacts: [],
+            history: [],
+            metadata: {},
+          })
+        );
+        throw new Error(errorMessage);
+      });
+
+      const app = buildRestApp();
+      await request(app)
+        .post('/message:send')
+        .set('A2A-Version', '1.0')
+        .set('Content-Type', 'application/json')
+        .send(makeRestMessagePayload('msg-rest-fail-post', 'hi'))
+        .expect(500);
+
+      const stored = await taskStore.load(observedTaskId, new ServerCallContext());
+      expect(stored?.status?.state).toBe(TaskState.TASK_STATE_FAILED);
+    });
+  });
+});

--- a/test/server/request_handler/error_envelope.spec.ts
+++ b/test/server/request_handler/error_envelope.spec.ts
@@ -14,11 +14,7 @@ import { DefaultExecutionEventBusManager } from '../../../src/server/events/exec
 import { ServerCallContext } from '../../../src/server/context.js';
 import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
 
-// Synthetic error Task from _runExecutor when the agent rejects before
-// publishing a Task event. Pre-fix the code used a fresh uuidv4() that
-// didn't match the bus key, so the client's follow-up getTask threw
-// TaskNotFoundError.
-describe('DefaultRequestHandler synthetic error Task id (blocking path)', () => {
+describe('DefaultRequestHandler executor-failure error envelope (blocking path)', () => {
   let handler: DefaultRequestHandler;
   let taskStore: TaskStore;
   let mockExecutor: MockAgentExecutor;
@@ -26,7 +22,7 @@ describe('DefaultRequestHandler synthetic error Task id (blocking path)', () => 
 
   const agentCard: AgentCard = {
     name: 'Error Envelope Agent',
-    description: 'Test agent for synthetic-error-Task id assertions',
+    description: 'Test agent for executor-throw propagation assertions',
     version: '1.0.0',
     provider: undefined,
     documentationUrl: '',
@@ -83,11 +79,10 @@ describe('DefaultRequestHandler synthetic error Task id (blocking path)', () => 
     ...overrides,
   });
 
-  it('synthetic Task id matches requestContext.taskId (handler-generated) when message has no taskId', async () => {
-    let observedRequestTaskId = '';
-    mockExecutor.execute.mockImplementation(async (ctx) => {
-      observedRequestTaskId = ctx.taskId;
-      throw new Error('boom before any Task event');
+  it('sendMessage rejects with the original error when executor throws before any Task event', async () => {
+    const errorMessage = 'boom before any Task event';
+    mockExecutor.execute.mockImplementation(async () => {
+      throw new Error(errorMessage);
     });
 
     const params: SendMessageRequest = {
@@ -97,15 +92,94 @@ describe('DefaultRequestHandler synthetic error Task id (blocking path)', () => 
       metadata: {},
     };
 
-    const result = (await handler.sendMessage(params, serverContext)) as Task;
-
-    expect(observedRequestTaskId).not.toBe('');
-    expect(result.id).toBe(observedRequestTaskId);
-    expect(result.status.state).toBe(TaskState.TASK_STATE_FAILED);
+    await expect(handler.sendMessage(params, serverContext)).rejects.toThrow(errorMessage);
   });
 
-  it('synthetic Task id matches the explicit taskId the client supplied on the incoming message', async () => {
-    // Prime the store so _createRequestContext finds the existing task.
+  it('sendMessage rejects when executor throws AFTER publishing a Task, and store reflects FAILED', async () => {
+    const errorMessage = 'boom after publishing task';
+    let observedRequestTaskId = '';
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+      observedRequestTaskId = ctx.taskId;
+      bus.publish({
+        kind: 'task',
+        data: {
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        },
+      });
+      throw new Error(errorMessage);
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-err-2', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    await expect(handler.sendMessage(params, serverContext)).rejects.toThrow(errorMessage);
+
+    // Store should now hold a FAILED task with the same id.
+    expect(observedRequestTaskId).not.toBe('');
+    const stored = await taskStore.load(observedRequestTaskId, serverContext);
+    expect(stored).toBeDefined();
+    expect(stored!.status?.state).toBe(TaskState.TASK_STATE_FAILED);
+  });
+
+  it('getTask after executor-throw reflects FAILED status persisted by the drain loop', async () => {
+    const errorMessage = 'agent blew up mid-execution';
+    let observedRequestTaskId = '';
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+      observedRequestTaskId = ctx.taskId;
+      bus.publish({
+        kind: 'task',
+        data: {
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        },
+      });
+      throw new Error(errorMessage);
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-err-3', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    await expect(handler.sendMessage(params, serverContext)).rejects.toThrow(errorMessage);
+
+    const getParams: GetTaskRequest = {
+      id: observedRequestTaskId,
+      tenant: '',
+      historyLength: undefined,
+    };
+    const loaded = await handler.getTask(getParams, serverContext);
+    expect(loaded.id).toBe(observedRequestTaskId);
+    expect(loaded.status.state).toBe(TaskState.TASK_STATE_FAILED);
+    expect(
+      (loaded.status.message?.parts[0].content as { $case: 'text'; value: string }).value
+    ).toContain(errorMessage);
+  });
+
+  it('sendMessage rejects when executor targets an existing task and throws', async () => {
     const existingTaskId = 'client-supplied-task-id';
     const existingContextId = 'client-supplied-context-id';
     await taskStore.save(
@@ -124,14 +198,11 @@ describe('DefaultRequestHandler synthetic error Task id (blocking path)', () => 
       serverContext
     );
 
-    let observedRequestTaskId = '';
-    mockExecutor.execute.mockImplementation(async (ctx) => {
-      observedRequestTaskId = ctx.taskId;
-      throw new Error('boom before any Task event');
-    });
+    const errorMessage = 'boom on existing task';
+    mockExecutor.execute.mockRejectedValue(new Error(errorMessage));
 
     const params: SendMessageRequest = {
-      message: makeMessage('msg-err-2', 'kick off', {
+      message: makeMessage('msg-err-4', 'continue', {
         taskId: existingTaskId,
         contextId: existingContextId,
       }),
@@ -140,64 +211,41 @@ describe('DefaultRequestHandler synthetic error Task id (blocking path)', () => 
       metadata: {},
     };
 
-    const result = (await handler.sendMessage(params, serverContext)) as Task;
+    await expect(handler.sendMessage(params, serverContext)).rejects.toThrow(errorMessage);
 
-    expect(observedRequestTaskId).toBe(existingTaskId);
-    expect(result.id).toBe(existingTaskId);
-    expect(result.status.state).toBe(TaskState.TASK_STATE_FAILED);
+    // The pre-existing task must be updated to FAILED (not left in
+    // INPUT_REQUIRED where the client would keep waiting for it).
+    const stored = await taskStore.load(existingTaskId, serverContext);
+    expect(stored!.status?.state).toBe(TaskState.TASK_STATE_FAILED);
   });
 
-  it('getTask(returnedId) resolves to the FAILED task — synthetic Task is reachable via its returned id', async () => {
-    // Regression: pre-fix the fabricated uuidv4() didn't match the bus key.
-    const errorMessage = 'agent blew up before publishing a Task';
-    mockExecutor.execute.mockRejectedValue(new Error(errorMessage));
-
-    const params: SendMessageRequest = {
-      message: makeMessage('msg-err-3', 'kick off'),
-      tenant: '',
-      configuration: undefined,
-      metadata: {},
-    };
-
-    const sendResult = (await handler.sendMessage(params, serverContext)) as Task;
-    expect(sendResult.status.state).toBe(TaskState.TASK_STATE_FAILED);
-
-    const getParams: GetTaskRequest = {
-      id: sendResult.id,
-      tenant: '',
-      historyLength: undefined,
-    };
-    const loaded = await handler.getTask(getParams, serverContext);
-    expect(loaded.id).toBe(sendResult.id);
-    expect(loaded.status.state).toBe(TaskState.TASK_STATE_FAILED);
-    expect(
-      (loaded.status.message?.parts[0].content as { $case: 'text'; value: string }).value
-    ).toContain(errorMessage);
-  });
-
-  it('synthetic Task carries the original user message in history so subsequent reads see what the client sent', async () => {
-    // The synthesis appends the user message to history so the FAILED task is self-describing.
-    mockExecutor.execute.mockRejectedValue(new Error('failed before publishing task'));
-
-    const userMessage = makeMessage('msg-err-4', 'please tell me a joke');
-    const params: SendMessageRequest = {
-      message: userMessage,
-      tenant: '',
-      configuration: undefined,
-      metadata: {},
-    };
-
-    const result = (await handler.sendMessage(params, serverContext)) as Task;
-    expect(result.status.state).toBe(TaskState.TASK_STATE_FAILED);
-    expect(result.history?.find((m) => m.messageId === userMessage.messageId)).toBeDefined();
-  });
-
-  it('non-blocking sendMessage path also returns the synthetic Task with id == requestContext.taskId', async () => {
-    // Non-blocking resolves on the first event — which IS the synthetic Task here.
+  it('non-blocking sendMessage: returns the initial Task, then persists FAILED in the background', async () => {
+    const errorMessage = 'non-blocking boom after first task';
     let observedRequestTaskId = '';
-    mockExecutor.execute.mockImplementation(async (ctx) => {
+    let releaseError!: () => void;
+    const errorGate = new Promise<void>((resolve) => {
+      releaseError = resolve;
+    });
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
       observedRequestTaskId = ctx.taskId;
-      throw new Error('non-blocking boom');
+      bus.publish({
+        kind: 'task',
+        data: {
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        },
+      });
+      // Wait until the non-blocking caller has resolved before throwing.
+      await errorGate;
+      throw new Error(errorMessage);
     });
 
     const params: SendMessageRequest = {
@@ -212,15 +260,20 @@ describe('DefaultRequestHandler synthetic error Task id (blocking path)', () => 
     };
 
     const result = (await handler.sendMessage(params, serverContext)) as Task;
-    expect(observedRequestTaskId).not.toBe('');
+    expect(result.status.state).toBe(TaskState.TASK_STATE_SUBMITTED);
     expect(result.id).toBe(observedRequestTaskId);
-    expect(result.status.state).toBe(TaskState.TASK_STATE_FAILED);
+
+    // Let the executor throw; give the background drain a couple of
+    // microtasks to persist FAILED.
+    releaseError();
+    for (let i = 0; i < 5; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
 
     const loaded = await handler.getTask(
       { id: result.id, tenant: '', historyLength: undefined },
       serverContext
     );
-    expect(loaded.id).toBe(result.id);
     expect(loaded.status.state).toBe(TaskState.TASK_STATE_FAILED);
   });
 });

--- a/test/server/request_handler/streaming_errors.spec.ts
+++ b/test/server/request_handler/streaming_errors.spec.ts
@@ -9,7 +9,6 @@ import {
   StreamResponse,
   Task,
   TaskState,
-  TaskStatusUpdateEvent,
 } from '../../../src/types/pb/a2a.js';
 import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
 import {
@@ -19,10 +18,13 @@ import {
 import { ServerCallContext } from '../../../src/server/context.js';
 import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
 
-// Streaming error synthesis: if the executor throws before a Task
-// event, _runStreamExecutor synthesizes Task + statusUpdate(FAILED).
-// If it throws after, only statusUpdate(FAILED) (no fresh Task).
-describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)', () => {
+// Streaming failure semantics: the executor throwing must terminate
+// the SSE stream via a THROWN exception (which the Express layer
+// converts to a terminal `event: error` SSE frame or a pre-flush
+// JSON-RPC error envelope). The stream never yields a synthetic
+// FAILED Task or FAILED statusUpdate; only the events the executor
+// actually published are yielded.
+describe('DefaultRequestHandler sendMessageStream executor-failure propagation', () => {
   let handler: DefaultRequestHandler;
   let taskStore: TaskStore;
   let mockExecutor: MockAgentExecutor;
@@ -30,7 +32,7 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
 
   const agentCard: AgentCard = {
     name: 'Streaming Errors Agent',
-    description: 'Test agent for streaming-error synthesis assertions',
+    description: 'Test agent for streaming-error propagation assertions',
     version: '1.0.0',
     provider: undefined,
     documentationUrl: '',
@@ -87,15 +89,23 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
     ...overrides,
   });
 
-  it('executor throws before any Task event: stream yields synthetic Task + statusUpdate(FAILED), not empty', async () => {
-    // This is the core regression test for PR 2's streaming half:
-    // previously the SSE consumer saw an empty stream, making
-    // production debugging impossible. Now the consumer sees a
-    // well-formed task-lifecycle terminating in FAILED.
-    let observedRequestTaskId = '';
+  const drainStream = async (
+    stream: AsyncGenerator<StreamResponse, void, undefined>
+  ): Promise<{ events: StreamResponse[]; error?: unknown }> => {
+    const events: StreamResponse[] = [];
+    try {
+      for await (const event of stream) {
+        events.push(event);
+      }
+      return { events };
+    } catch (error) {
+      return { events, error };
+    }
+  };
+
+  it('executor throws before any Task event: stream throws immediately with the original error, no events yielded', async () => {
     const errorMessage = 'pre-publish failure in streaming executor';
-    mockExecutor.execute.mockImplementation(async (ctx) => {
-      observedRequestTaskId = ctx.taskId;
+    mockExecutor.execute.mockImplementation(async () => {
       throw new Error(errorMessage);
     });
 
@@ -106,101 +116,21 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
       metadata: {},
     };
 
-    const events: StreamResponse[] = [];
-    for await (const event of handler.sendMessageStream(params, serverContext)) {
-      events.push(event);
-    }
+    const { events, error } = await drainStream(handler.sendMessageStream(params, serverContext));
 
-    // Two events: synthetic Task followed by terminal status update.
-    expect(events.length).toBe(2);
-
-    // First event: synthetic Task carrying the FAILED state, keyed by
-    // `requestContext.taskId` — the same id the bus is registered
-    // under and that the client would use for a subsequent
-    // `tasks/resubscribe` or `getTask`.
-    const taskPayload = events[0].payload as { $case: 'task'; value: Task };
-    expect(taskPayload.$case).toBe('task');
-    expect(taskPayload.value.id).toBe(observedRequestTaskId);
-    expect(taskPayload.value.status?.state).toBe(TaskState.TASK_STATE_FAILED);
-
-    // Second event: statusUpdate(FAILED) referencing the same task id.
-    const statusPayload = events[1].payload as {
-      $case: 'statusUpdate';
-      value: TaskStatusUpdateEvent;
-    };
-    expect(statusPayload.$case).toBe('statusUpdate');
-    expect(statusPayload.value.taskId).toBe(observedRequestTaskId);
-    expect(statusPayload.value.status?.state).toBe(TaskState.TASK_STATE_FAILED);
-    expect(
-      (statusPayload.value.status?.message?.parts[0].content as { $case: 'text'; value: string })
-        .value
-    ).toContain(errorMessage);
+    expect(events.length).toBe(0);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(errorMessage);
   });
 
-  it('synthetic Task is reachable via taskStore after the stream closes', async () => {
-    // The Task event is drained through ResultManager into the store
-    // exactly the same way a real executor-published Task would be, so
-    // the FAILED state is queryable via getTask afterward.
-    const errorMessage = 'reachable after failure';
-    mockExecutor.execute.mockRejectedValue(new Error(errorMessage));
-
-    const params: SendMessageRequest = {
-      message: makeMessage('msg-stream-err-2', 'kick off'),
-      tenant: '',
-      configuration: undefined,
-      metadata: {},
-    };
-
-    const events: StreamResponse[] = [];
-    for await (const event of handler.sendMessageStream(params, serverContext)) {
-      events.push(event);
-    }
-
-    const taskPayload = events[0].payload as { $case: 'task'; value: Task };
-    const taskId = taskPayload.value.id;
-
-    const stored = await taskStore.load(taskId, serverContext);
-    expect(stored).toBeDefined();
-    expect(stored!.id).toBe(taskId);
-    expect(stored!.status?.state).toBe(TaskState.TASK_STATE_FAILED);
-  });
-
-  it('synthetic Task includes the original user message in history', async () => {
-    // The stream-error synthesis appends the originating user message
-    // to the Task's history so the failed task is self-describing —
-    // matches the blocking-path synthesis in `_runExecutor`.
-    mockExecutor.execute.mockRejectedValue(new Error('boom'));
-
-    const userMessage = makeMessage('msg-stream-err-3', 'tell me a joke');
-    const params: SendMessageRequest = {
-      message: userMessage,
-      tenant: '',
-      configuration: undefined,
-      metadata: {},
-    };
-
-    const events: StreamResponse[] = [];
-    for await (const event of handler.sendMessageStream(params, serverContext)) {
-      events.push(event);
-    }
-
-    const taskPayload = events[0].payload as { $case: 'task'; value: Task };
-    expect(
-      taskPayload.value.history?.find((m) => m.messageId === userMessage.messageId)
-    ).toBeDefined();
-  });
-
-  it('executor publishes Task then throws: stream yields the original Task + a synthetic FAILED statusUpdate (no duplicate Task)', async () => {
-    // Pre-existing behaviour preserved: when the executor has already
-    // published a Task event, we must NOT publish a second Task event
-    // in the error path (would violate stream-pattern ordering); only
-    // a statusUpdate(FAILED) is appended.
+  it('executor publishes Task then throws: stream yields the Task, then throws the original error', async () => {
+    // Client sees the events the executor actually published, then
+    // observes the error via a thrown exception (which Express turns
+    // into a terminal `event: error` SSE frame post-flush).
     const errorMessage = 'post-publish failure';
     let observedRequestTaskId = '';
-    let observedContextId = '';
     mockExecutor.execute.mockImplementation(async (ctx, bus) => {
       observedRequestTaskId = ctx.taskId;
-      observedContextId = ctx.contextId;
       bus.publish(
         AgentEvent.task({
           id: ctx.taskId,
@@ -219,40 +149,69 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
     });
 
     const params: SendMessageRequest = {
-      message: makeMessage('msg-stream-err-4', 'kick off'),
+      message: makeMessage('msg-stream-err-2', 'kick off'),
       tenant: '',
       configuration: undefined,
       metadata: {},
     };
 
-    const events: StreamResponse[] = [];
-    for await (const event of handler.sendMessageStream(params, serverContext)) {
-      events.push(event);
-    }
+    const { events, error } = await drainStream(handler.sendMessageStream(params, serverContext));
 
-    expect(events.length).toBe(2);
+    // Exactly one event yielded (the SUBMITTED Task).
+    expect(events.length).toBe(1);
+    const taskPayload = events[0].payload as { $case: 'task'; value: Task };
+    expect(taskPayload.$case).toBe('task');
+    expect(taskPayload.value.id).toBe(observedRequestTaskId);
+    expect(taskPayload.value.status?.state).toBe(TaskState.TASK_STATE_SUBMITTED);
 
-    const firstTask = events[0].payload as { $case: 'task'; value: Task };
-    expect(firstTask.$case).toBe('task');
-    expect(firstTask.value.id).toBe(observedRequestTaskId);
-    // The first Task event was the SUBMITTED one published by the
-    // executor before it threw — not a second synthetic FAILED Task.
-    expect(firstTask.value.status?.state).toBe(TaskState.TASK_STATE_SUBMITTED);
-
-    const failed = events[1].payload as { $case: 'statusUpdate'; value: TaskStatusUpdateEvent };
-    expect(failed.$case).toBe('statusUpdate');
-    expect(failed.value.taskId).toBe(observedRequestTaskId);
-    expect(failed.value.contextId).toBe(observedContextId);
-    expect(failed.value.status?.state).toBe(TaskState.TASK_STATE_FAILED);
-    expect(
-      (failed.value.status?.message?.parts[0].content as { $case: 'text'; value: string }).value
-    ).toContain(errorMessage);
+    // Then the stream throws the original error — no synthetic FAILED
+    // statusUpdate is yielded as a normal frame.
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(errorMessage);
   });
 
-  it('synthetic Task uses the explicit taskId the client supplied on the incoming message', async () => {
-    // When the client targets an existing non-terminal task and the
-    // executor blows up before publishing, the synthetic Task must use
-    // the client-supplied id — same contract as the blocking path.
+  it('after streaming failure, store reflects FAILED so getTask returns the terminal state', async () => {
+    const errorMessage = 'reachable after failure';
+    let observedRequestTaskId = '';
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+      observedRequestTaskId = ctx.taskId;
+      bus.publish(
+        AgentEvent.task({
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        })
+      );
+      throw new Error(errorMessage);
+    });
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-stream-err-3', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const { error } = await drainStream(handler.sendMessageStream(params, serverContext));
+    expect(error).toBeInstanceOf(Error);
+
+    const stored = await taskStore.load(observedRequestTaskId, serverContext);
+    expect(stored).toBeDefined();
+    expect(stored!.status?.state).toBe(TaskState.TASK_STATE_FAILED);
+  });
+
+  it('streaming failure on an existing task marks that task FAILED in the store', async () => {
+    // When the client targeted an existing non-terminal task and the
+    // executor throws before publishing anything, the existing task
+    // must still be updated to FAILED so the client sees the correct
+    // state on a subsequent `getTask`.
     const existingTaskId = 'client-supplied-stream-task-id';
     const existingContextId = 'client-supplied-stream-context-id';
     await taskStore.save(
@@ -271,10 +230,11 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
       serverContext
     );
 
-    mockExecutor.execute.mockRejectedValue(new Error('stream boom on existing task'));
+    const errorMessage = 'stream boom on existing task';
+    mockExecutor.execute.mockRejectedValue(new Error(errorMessage));
 
     const params: SendMessageRequest = {
-      message: makeMessage('msg-stream-err-5', 'continue', {
+      message: makeMessage('msg-stream-err-4', 'continue', {
         taskId: existingTaskId,
         contextId: existingContextId,
       }),
@@ -283,27 +243,19 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
       metadata: {},
     };
 
-    const events: StreamResponse[] = [];
-    for await (const event of handler.sendMessageStream(params, serverContext)) {
-      events.push(event);
-    }
+    const { events, error } = await drainStream(handler.sendMessageStream(params, serverContext));
+    expect(events.length).toBe(0);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe(errorMessage);
 
-    expect(events.length).toBe(2);
-    const taskPayload = events[0].payload as { $case: 'task'; value: Task };
-    expect(taskPayload.value.id).toBe(existingTaskId);
-    expect(taskPayload.value.status?.state).toBe(TaskState.TASK_STATE_FAILED);
-
-    const statusPayload = events[1].payload as {
-      $case: 'statusUpdate';
-      value: TaskStatusUpdateEvent;
-    };
-    expect(statusPayload.value.taskId).toBe(existingTaskId);
+    const stored = await taskStore.load(existingTaskId, serverContext);
+    expect(stored!.status?.state).toBe(TaskState.TASK_STATE_FAILED);
   });
 
   it('event bus is cleaned up after the stream-error path runs', async () => {
-    // FAILED is a terminal state, so `_settleBus` must close the bus
-    // and detach it from the manager. Otherwise long-lived listeners
-    // (e.g. `trackLatestTaskState`) would leak on each failure.
+    // Errors are terminal for the bus, so `_settleBus` must close
+    // the bus and detach it from the manager even though no
+    // TASK_STATE_FAILED statusUpdate was seen by `trackLatestTaskState`.
     let observedRequestTaskId = '';
     mockExecutor.execute.mockImplementation(async (ctx) => {
       observedRequestTaskId = ctx.taskId;
@@ -311,15 +263,14 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
     });
 
     const params: SendMessageRequest = {
-      message: makeMessage('msg-stream-err-6', 'kick off'),
+      message: makeMessage('msg-stream-err-5', 'kick off'),
       tenant: '',
       configuration: undefined,
       metadata: {},
     };
 
-    for await (const _event of handler.sendMessageStream(params, serverContext)) {
-      void _event;
-    }
+    const { error } = await drainStream(handler.sendMessageStream(params, serverContext));
+    expect(error).toBeInstanceOf(Error);
 
     // Give `.finally()` a tick to call `_settleBus`.
     await new Promise<void>((resolve) => setImmediate(resolve));


### PR DESCRIPTION
# Description

Aligns JS SDK with Python SDK: when `AgentExecutor.execute()` throws, the framework now persists the task as FAILED and propagates the exception to the transport, instead of silently returning a synthesized FAILED-Task as a successful result.

Before: executor throws → framework catches → synthesizes Task{state=FAILED} → publishes on bus → returns as successful JSON-RPC result (HTTP 200).

After: executor throws → framework publishes internal AgentEvent.error(err) → ExecutionEventQueue.events() rethrows → drain loop catches → persists FAILED status to store → rethrows → transport maps to proper error envelope.

Fixes #370  🦕
