### PR TITLE
fix: support GET for resubscribe route

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -27,7 +27,7 @@ exports[`TypeScript Strict Mode`] = {
       [248, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"],
       [271, 15, 4, "tsc: Expected 2 arguments, but got 1.", "2087764327"]
     ],
-    "src/server/express/rest_handler.ts:2436698925": [
+    "src/server/express/rest_handler.ts:2980194902": [
       [204, 50, 17, "tsc: Argument of type \'unknown\' is not assignable to parameter of type \'Message | Task | TaskArtifactUpdateEvent | TaskStatusUpdateEvent\'.", "3749434707"]
     ],
     "src/server/request_handler/default_request_handler.ts:1208203039": [

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -352,7 +352,7 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * @param req.params.taskId - Task identifier
    * @returns 200 OK with SSE stream of task status and artifact updates
    * @returns 404 Not Found if task doesn't exist
-   * @returns 501 Not Implemented if streaming not supported
+   * @returns 400 Bad Request if streaming is not supported
    */
   const resubscribeHandler = asyncHandler(async (req, res) => {
     const context = await buildContext(req);

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -344,30 +344,35 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * GET /v1/tasks/:taskId
+   * GET/POST /v1/tasks/:taskId:subscribe
    *
-   * Retrieves the current status and details of a task.
+   * Resubscribes to an existing task's updates via Server-Sent Events (SSE).
+   * Useful for reconnecting to long-running tasks or receiving missed updates.
+   *
+   * GET is the canonical binding per the v0.3 proto's
+   * `google.api.http` annotation:
+   *   `get: "/v1/tasks/{id=*}:subscribe"`
+   * and matches what a2a-python, a2a-go, and the v1.0 a2a-js client
+   * all issue. POST is also accepted for tolerance with clients that
+   * copy the pattern of the sibling `POST /v1/tasks/{id}:cancel`
+   * binding.
+   *
+   * Registered BEFORE the more generic `GET /v1/tasks/:taskId` route
+   * below so Express doesn't greedily match `:taskId="foo:subscribe"`
+   * and swallow the resubscribe request into `getTask`.
    *
    * @param req.params.taskId - Task identifier
-   * @param req.query.historyLength - Optional number of history messages to include
-   * @returns 200 OK with RestTask
-   * @returns 400 Bad Request if historyLength is invalid
+   * @returns 200 OK with SSE stream of task status and artifact updates
    * @returns 404 Not Found if task doesn't exist
+   * @returns 501 Not Implemented if streaming not supported
    */
-  router.get(
-    '/v1/tasks/:taskId',
-    asyncHandler(async (req, res) => {
-      const context = await buildContext(req);
-      const result = await restTransportHandler.getTask(
-        req.params.taskId,
-        context,
-        //TODO: clarify for version 1.0.0 the format of the historyLength query parameter, and if history should always be added to the returned object
-        req.query.historyLength ?? req.query.history_length
-      );
-      const protoResult = ToProto.task(result);
-      sendResponse<a2a.Task>(res, HTTP_STATUS.OK, context, protoResult, a2a.Task);
-    })
-  );
+  const resubscribeHandler = asyncHandler(async (req, res) => {
+    const context = await buildContext(req);
+    const stream = await restTransportHandler.resubscribe(req.params.taskId, context);
+    await sendStreamResponse(res, stream, context);
+  });
+  router.get('/v1/tasks/:taskId\\:subscribe', resubscribeHandler);
+  router.post('/v1/tasks/:taskId\\:subscribe', resubscribeHandler);
 
   /**
    * POST /v1/tasks/:taskId:cancel
@@ -391,22 +396,28 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   );
 
   /**
-   * POST /v1/tasks/:taskId:subscribe
+   * GET /v1/tasks/:taskId
    *
-   * Resubscribes to an existing task's updates via Server-Sent Events (SSE).
-   * Useful for reconnecting to long-running tasks or receiving missed updates.
+   * Retrieves the current status and details of a task.
    *
    * @param req.params.taskId - Task identifier
-   * @returns 200 OK with SSE stream of task status and artifact updates
+   * @param req.query.historyLength - Optional number of history messages to include
+   * @returns 200 OK with RestTask
+   * @returns 400 Bad Request if historyLength is invalid
    * @returns 404 Not Found if task doesn't exist
-   * @returns 501 Not Implemented if streaming not supported
    */
-  router.post(
-    '/v1/tasks/:taskId\\:subscribe',
+  router.get(
+    '/v1/tasks/:taskId',
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
-      const stream = await restTransportHandler.resubscribe(req.params.taskId, context);
-      await sendStreamResponse(res, stream, context);
+      const result = await restTransportHandler.getTask(
+        req.params.taskId,
+        context,
+        //TODO: clarify for version 1.0.0 the format of the historyLength query parameter, and if history should always be added to the returned object
+        req.query.historyLength ?? req.query.history_length
+      );
+      const protoResult = ToProto.task(result);
+      sendResponse<a2a.Task>(res, HTTP_STATUS.OK, context, protoResult, a2a.Task);
     })
   );
 

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -349,18 +349,6 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
    * Resubscribes to an existing task's updates via Server-Sent Events (SSE).
    * Useful for reconnecting to long-running tasks or receiving missed updates.
    *
-   * GET is the canonical binding per the v0.3 proto's
-   * `google.api.http` annotation:
-   *   `get: "/v1/tasks/{id=*}:subscribe"`
-   * and matches what a2a-python, a2a-go, and the v1.0 a2a-js client
-   * all issue. POST is also accepted for tolerance with clients that
-   * copy the pattern of the sibling `POST /v1/tasks/{id}:cancel`
-   * binding.
-   *
-   * Registered BEFORE the more generic `GET /v1/tasks/:taskId` route
-   * below so Express doesn't greedily match `:taskId="foo:subscribe"`
-   * and swallow the resubscribe request into `getTask`.
-   *
    * @param req.params.taskId - Task identifier
    * @returns 200 OK with SSE stream of task status and artifact updates
    * @returns 404 Not Found if task doesn't exist

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -24,7 +24,7 @@ import { FromProto } from '../../../src/types/converters/from_proto.js';
  * - POST /v1/message:stream - Send message with SSE streaming
  * - GET /v1/tasks/:taskId - Get task status
  * - POST /v1/tasks/:taskId:cancel - Cancel task
- * - POST /v1/tasks/:taskId:subscribe - Resubscribe to task updates
+ * - GET/POST /v1/tasks/:taskId:subscribe - Resubscribe to task updates
  * - Push notification config CRUD operations
  */
 describe('restHandler', () => {
@@ -291,8 +291,31 @@ describe('restHandler', () => {
     });
   });
 
-  describe('POST /v1/tasks/:taskId:subscribe', () => {
-    it('should resubscribe to task updates via SSE', async () => {
+  describe('/v1/tasks/:taskId:subscribe', () => {
+    it('GET should resubscribe to task updates via SSE (canonical proto binding)', async () => {
+      // The v0.3 proto's `google.api.http` annotation for
+      // `SubscribeToTask` is `get: "/v1/tasks/{id=*}:subscribe"`, so
+      // GET is the canonical binding — spec-compliant peers
+      // (a2a-python, a2a-go, v1.0 a2a-js) all issue GET here.
+      async function* mockStream() {
+        yield testTask;
+      }
+
+      (mockRequestHandler.resubscribe as Mock).mockResolvedValue(mockStream());
+
+      const response = await request(app).get('/v1/tasks/task-1:subscribe').expect(200);
+
+      assert.equal(response.headers['content-type'], 'text/event-stream');
+
+      expect(mockRequestHandler.resubscribe).toHaveBeenCalledWith(
+        { id: 'task-1' },
+        expect.anything()
+      );
+    });
+
+    it('POST should also resubscribe to task updates via SSE (tolerance)', async () => {
+      // POST is accepted for tolerance with clients that copy the
+      // sibling `POST /v1/tasks/{id}:cancel` binding pattern.
       async function* mockStream() {
         yield testTask;
       }


### PR DESCRIPTION
# Description

## Context
The v1.0 A2A spec has two normative sources — the proto file and the spec markdown (per §1.4 Normative Content (https://a2a-protocol.org/latest/specification/#14-normative-content)). They disagree on the HTTP method for SubscribeToTask:
- Proto (spec/a2a.proto): google.api.http annotation says get: "/tasks/{id=*}:subscribe"
- Spec markdown (§11.3.2 (https://a2a-protocol.org/latest/specification/#1132-task-operations)): documents it as POST

The v0.3 proto (google.api.http annotation on SubscribeToTask) also uses get:, and reference SDKs consistently followed the proto binding:
- a2a-python: ('/v1/tasks/{id}:subscribe', 'GET') in rest_adapter.py (https://github.com/a2aproject/a2a-python/blob/ead75f95b852810f1837248b9e9ffc5092c2d463/src/a2a/server/apps/rest/rest_adapter.py#L218)
- a2a-go: GET binding in its REST server
- a2a-js v1.0 (RestTransport): issues GET on the client side
- a2a-rust a2a-client-lf: issues GET on the client side

`@a2a-js/sdk@0.3.x` server was the outlier — only POST was registered. When any spec-compliant client (v0.3-native or v1.0-with-compat) sent GET, Express fell through to the more generic GET /v1/tasks/:taskId route, capturing :taskId = "<uuid>:subscribe" and throwing TaskNotFoundError: Task not found: <uuid>:subscribe — cross-SDK interop broken for resubscribe over REST.

## What this PR does
Adds a GET binding for /v1/tasks/:taskId:subscribe alongside the existing POST route:
- GET is the canonical binding per the proto's google.api.http annotation and is what the ecosystem's clients send.
- POST is retained for backward compatibility with clients that were built against the spec markdown or against previous `@a2a-js/sdk@0.3.x` behavior.
Both methods route to the same handler. The subscribe route is registered before the generic GET /v1/tasks/:taskId route so Express's greedy :taskId matcher doesn't swallow /v1/tasks/xyz:subscribe requests.
