### PR TITLE
feat(server)!: replace individual properties with SendMessageRequest in RequestContext

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -305,15 +305,27 @@ new ServerCallContext(requestedExtensions, user);
 new ServerCallContext({ requestedExtensions, user, tenant: 'my-tenant', requestedVersion: '1.0' });
 ```
 
-`RequestContext` constructor parameter order also changed -- `context` moved
-from last (optional) to 4th (mandatory):
+`RequestContext` now wraps the incoming `SendMessageRequest`, 
+and `context` moved from last (optional) to 4th (mandatory).
+The loose `userMessage` parameter is replaced by `request: SendMessageRequest`;
+agent executors read the message via `ctx.userMessage` (convenience accessor
+guaranteed non-null) and the full payload -- including `configuration` and
+request-level `metadata` -- via `ctx.request`:
 
 ```typescript
 // v0.3
 new RequestContext(userMessage, taskId, contextId, task, referenceTasks, context);
 // v1.0
-new RequestContext(userMessage, taskId, contextId, context, task, referenceTasks);
+new RequestContext(request, taskId, contextId, context, task, referenceTasks);
+
+// Reading from an executor:
+ctx.userMessage; // Message -- shorthand for ctx.request.message (non-null)
+ctx.request.configuration; // SendMessageConfiguration | undefined -- newly exposed
+ctx.request.metadata; // Record<string, unknown> | undefined
 ```
+
+The wrapped `request` is deep-cloned on construction so mutations inside the
+executor cannot leak back to the caller's `SendMessageRequest`.
 
 ### 3.4 `ExecutionEventBus` -- Discriminated Event Wrapper
 

--- a/src/server/agent_execution/request_context.ts
+++ b/src/server/agent_execution/request_context.ts
@@ -1,36 +1,54 @@
-import { Message, Task } from '../../index.js';
+import { Message, SendMessageRequest, Task } from '../../index.js';
 import { ServerCallContext } from '../context.js';
 
-export class RequestContext {
-  public readonly userMessage: Message;
-  public readonly taskId: string;
-  public readonly contextId: string;
-  public readonly task?: Task;
-  public readonly referenceTasks?: Task[];
-  public readonly context: ServerCallContext;
-  /**
-   * The request-level metadata from the originating `SendMessageRequest`,
-   * when provided. This is the spec's "flexible key-value map for passing
-   * additional context or parameters" and is distinct from
-   * `userMessage.metadata`.
-   */
-  public readonly metadata?: Record<string, unknown>;
+export interface RequestContextParams {
+  /** The incoming `SendMessageRequest` payload. Its `message` field MUST be set. */
+  request: SendMessageRequest;
+  /** The server call context associated with this request. */
+  context: ServerCallContext;
+  /** The resolved task ID (either from the request or server-generated). */
+  taskId: string;
+  /** The resolved context ID (either from the request or server-generated). */
+  contextId: string;
+  /** The existing `Task` object retrieved from the store, if any. */
+  task?: Task;
+  /** A list of other tasks related to the current request (e.g., for tool use). */
+  referenceTasks?: Task[];
+}
 
-  constructor(
-    userMessage: Message,
-    taskId: string,
-    contextId: string,
-    context: ServerCallContext,
-    task?: Task,
-    referenceTasks?: Task[],
-    metadata?: Record<string, unknown>
-  ) {
-    this.userMessage = userMessage;
-    this.taskId = taskId;
-    this.contextId = contextId;
-    this.context = context;
-    this.task = task;
-    this.referenceTasks = referenceTasks;
-    this.metadata = metadata ? structuredClone(metadata) : undefined;
+/**
+ * Holds information about the current request being processed by the server.
+ *
+ * Wraps the incoming {@link SendMessageRequest} so agent executors can reach
+ * the full payload (message, configuration, metadata, tenant) via `request`.
+ */
+export class RequestContext {
+  /** The incoming request payload, including `message`, `configuration`, `metadata`, and `tenant`. */
+  public readonly request: SendMessageRequest;
+  /** The server call context associated with this request. */
+  public readonly context: ServerCallContext;
+  /** The resolved task ID for this request. */
+  public readonly taskId: string;
+  /** The resolved context ID for this request. */
+  public readonly contextId: string;
+  /** The existing `Task` object retrieved from the store, if any. */
+  public readonly task?: Task;
+  /** A list of other tasks related to the current request (e.g., for tool use). */
+  public readonly referenceTasks?: Task[];
+
+  constructor(params: RequestContextParams) {
+    if (!params.request.message) {
+      throw new Error('RequestContext requires request.message to be set.');
+    }
+    this.request = params.request;
+    this.context = params.context;
+    this.taskId = params.taskId;
+    this.contextId = params.contextId;
+    this.task = params.task;
+    this.referenceTasks = params.referenceTasks;
+  }
+
+  get userMessage(): Message {
+    return this.request.message!;
   }
 }

--- a/src/server/agent_execution/request_context.ts
+++ b/src/server/agent_execution/request_context.ts
@@ -9,29 +9,29 @@ import { ServerCallContext } from '../context.js';
  */
 export class RequestContext {
   public readonly request: SendMessageRequest;
-  public readonly context: ServerCallContext;
   public readonly taskId: string;
   public readonly contextId: string;
+  public readonly context: ServerCallContext;
   public readonly task?: Task;
   public readonly referenceTasks?: Task[];
 
-  constructor(params: {
-    request: SendMessageRequest;
-    context: ServerCallContext;
-    taskId: string;
-    contextId: string;
-    task?: Task;
-    referenceTasks?: Task[];
-  }) {
-    if (!params.request.message) {
+  constructor(
+    request: SendMessageRequest,
+    taskId: string,
+    contextId: string,
+    context: ServerCallContext,
+    task?: Task,
+    referenceTasks?: Task[]
+  ) {
+    if (!request.message) {
       throw new Error('RequestContext requires request.message to be set.');
     }
-    this.request = structuredClone(params.request);
-    this.context = params.context;
-    this.taskId = params.taskId;
-    this.contextId = params.contextId;
-    this.task = params.task;
-    this.referenceTasks = params.referenceTasks;
+    this.request = structuredClone(request);
+    this.taskId = taskId;
+    this.contextId = contextId;
+    this.context = context;
+    this.task = task;
+    this.referenceTasks = referenceTasks;
   }
 
   get userMessage(): Message {

--- a/src/server/agent_execution/request_context.ts
+++ b/src/server/agent_execution/request_context.ts
@@ -40,7 +40,7 @@ export class RequestContext {
     if (!params.request.message) {
       throw new Error('RequestContext requires request.message to be set.');
     }
-    this.request = params.request;
+    this.request = structuredClone(params.request);
     this.context = params.context;
     this.taskId = params.taskId;
     this.contextId = params.contextId;

--- a/src/server/agent_execution/request_context.ts
+++ b/src/server/agent_execution/request_context.ts
@@ -1,21 +1,6 @@
 import { Message, SendMessageRequest, Task } from '../../index.js';
 import { ServerCallContext } from '../context.js';
 
-export interface RequestContextParams {
-  /** The incoming `SendMessageRequest` payload. Its `message` field MUST be set. */
-  request: SendMessageRequest;
-  /** The server call context associated with this request. */
-  context: ServerCallContext;
-  /** The resolved task ID (either from the request or server-generated). */
-  taskId: string;
-  /** The resolved context ID (either from the request or server-generated). */
-  contextId: string;
-  /** The existing `Task` object retrieved from the store, if any. */
-  task?: Task;
-  /** A list of other tasks related to the current request (e.g., for tool use). */
-  referenceTasks?: Task[];
-}
-
 /**
  * Holds information about the current request being processed by the server.
  *
@@ -23,20 +8,21 @@ export interface RequestContextParams {
  * the full payload (message, configuration, metadata, tenant) via `request`.
  */
 export class RequestContext {
-  /** The incoming request payload, including `message`, `configuration`, `metadata`, and `tenant`. */
   public readonly request: SendMessageRequest;
-  /** The server call context associated with this request. */
   public readonly context: ServerCallContext;
-  /** The resolved task ID for this request. */
   public readonly taskId: string;
-  /** The resolved context ID for this request. */
   public readonly contextId: string;
-  /** The existing `Task` object retrieved from the store, if any. */
   public readonly task?: Task;
-  /** A list of other tasks related to the current request (e.g., for tool use). */
   public readonly referenceTasks?: Task[];
 
-  constructor(params: RequestContextParams) {
+  constructor(params: {
+    request: SendMessageRequest;
+    context: ServerCallContext;
+    taskId: string;
+    contextId: string;
+    task?: Task;
+    referenceTasks?: Task[];
+  }) {
     if (!params.request.message) {
       throw new Error('RequestContext requires request.message to be set.');
     }

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -230,14 +230,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       ...request,
       message: messageForContext,
     };
-    return new RequestContext({
-      request: resolvedRequest,
-      taskId,
-      contextId,
-      context,
-      task,
-      referenceTasks,
-    });
+    return new RequestContext(resolvedRequest, taskId, contextId, context, task, referenceTasks);
   }
 
   private async _processEvents(

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -142,10 +142,13 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   }
 
   private async _createRequestContext(
-    incomingMessage: Message,
-    context: ServerCallContext,
-    requestMetadata?: Record<string, unknown>
+    request: SendMessageRequest,
+    context: ServerCallContext
   ): Promise<RequestContext> {
+    const incomingMessage = request.message;
+    if (!incomingMessage) {
+      throw new RequestMalformedError('request.message is required.');
+    }
     let task: Task | undefined;
     let referenceTasks: Task[] | undefined;
 
@@ -221,15 +224,20 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       contextId,
       taskId,
     };
-    return new RequestContext(
-      messageForContext,
+    // Rebuild the request with the enriched message so downstream
+    // consumers see the resolved task/context IDs on `userMessage`.
+    const resolvedRequest: SendMessageRequest = {
+      ...request,
+      message: messageForContext,
+    };
+    return new RequestContext({
+      request: resolvedRequest,
       taskId,
       contextId,
       context,
       task,
       referenceTasks,
-      requestMetadata
-    );
+    });
   }
 
   private async _processEvents(
@@ -571,11 +579,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     const resultManager = new ResultManager(this.taskStore, context);
     resultManager.setContext(incomingMessage);
 
-    const requestContext = await this._createRequestContext(
-      incomingMessage,
-      context,
-      params.metadata
-    );
+    const requestContext = await this._createRequestContext(params, context);
     const taskId = requestContext.taskId;
     const finalMessageForAgent = requestContext.userMessage;
 
@@ -669,11 +673,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     const resultManager = new ResultManager(this.taskStore, context);
     resultManager.setContext(incomingMessage);
 
-    const requestContext = await this._createRequestContext(
-      incomingMessage,
-      context,
-      params.metadata
-    );
+    const requestContext = await this._createRequestContext(params, context);
     const taskId = requestContext.taskId;
 
     const eventBus = this.eventBusManager.createOrGetByTaskId(taskId);

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -3654,7 +3654,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     );
 
     await handler.sendMessage(params, serverCallContext);
-    expect(capturedRequestContext?.metadata).to.deep.equal(
+    expect(capturedRequestContext?.request.metadata).to.deep.equal(
       requestMetadata,
       'sendMessage should thread request metadata into RequestContext'
     );
@@ -3667,7 +3667,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     for await (const event of handler.sendMessageStream(streamParams, serverCallContext)) {
       void event; // drain the stream
     }
-    expect(capturedRequestContext?.metadata).to.deep.equal(
+    expect(capturedRequestContext?.request.metadata).to.deep.equal(
       requestMetadata,
       'sendMessageStream should thread request metadata into RequestContext'
     );
@@ -3720,7 +3720,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     );
 
     await handler.sendMessage(params, serverCallContext);
-    expect(capturedRequestContext?.metadata).to.equal(
+    expect(capturedRequestContext?.request.metadata).to.equal(
       undefined,
       'RequestContext metadata should be undefined when the request has none'
     );


### PR DESCRIPTION
# Description

In order to simplify the interface of `RequestContext`, provide more data from the request and mimic [Python sdk](https://github.com/a2aproject/a2a-python/blob/0d82ab985ffbac381a38adb5bd160674fa05eb18/src/a2a/server/agent_execution/context.py#L32) it adds `request: SendMessageRequest` as a member of `RequestContextParams`.
