### PR TITLE
fix(server): validate push-notification webhook URLs against SSRF per…

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -32,6 +32,8 @@ export { DefaultPushNotificationSender } from './push_notification/default_push_
 export type { DefaultPushNotificationSenderOptions } from './push_notification/default_push_notification_sender.js';
 export type { PushNotificationStore } from './push_notification/push_notification_store.js';
 export { InMemoryPushNotificationStore } from './push_notification/push_notification_store.js';
+export { validateWebhookUrl, UrlValidationError } from './push_notification/url_validator.js';
+export type { UrlValidationOptions } from './push_notification/url_validator.js';
 
 export type { User } from './authentication/user.js';
 export { UnauthenticatedUser } from './authentication/user.js';

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -1,6 +1,7 @@
 import { Task, PushNotificationConfig } from '../../types.js';
 import { PushNotificationSender } from './push_notification_sender.js';
 import { PushNotificationStore } from './push_notification_store.js';
+import { validateWebhookUrl, UrlValidationOptions } from './url_validator.js';
 
 export interface DefaultPushNotificationSenderOptions {
   /**
@@ -11,12 +12,24 @@ export interface DefaultPushNotificationSenderOptions {
    * Custom header name for the token. Defaults to 'X-A2A-Notification-Token'.
    */
   tokenHeaderName?: string;
+  /**
+   * URL validation options to prevent SSRF per A2A Spec §13.2.
+   * By default, rejects private IP ranges, loopback/localhost, link-local addresses, and non-HTTP(S) schemes.
+   */
+  urlValidationOptions?: UrlValidationOptions;
+  /**
+   * Custom validator function to validate webhook URLs.
+   */
+  urlValidator?: (url: string) => void;
 }
 
 export class DefaultPushNotificationSender implements PushNotificationSender {
   private readonly pushNotificationStore: PushNotificationStore;
   private notificationChain: Map<string, Promise<unknown>>;
-  private readonly options: Required<DefaultPushNotificationSenderOptions>;
+  private readonly options: DefaultPushNotificationSenderOptions & {
+    timeout: number;
+    tokenHeaderName: string;
+  };
 
   constructor(
     pushNotificationStore: PushNotificationStore,
@@ -69,6 +82,14 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     pushConfig: PushNotificationConfig
   ): Promise<void> {
     const url = pushConfig.url;
+
+    // Validate URL per A2A spec §13.2 before sending request
+    if (this.options.urlValidator) {
+      this.options.urlValidator(url);
+    } else {
+      validateWebhookUrl(url, this.options.urlValidationOptions);
+    }
+
     const controller = new AbortController();
     // Abort the request if it takes longer than the configured timeout.
     const timeoutId = setTimeout(() => controller.abort(), this.options.timeout);
@@ -87,6 +108,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
         headers,
         body: JSON.stringify(task),
         signal: controller.signal,
+        redirect: 'error',
       });
 
       if (!response.ok) {

--- a/src/server/push_notification/url_validator.ts
+++ b/src/server/push_notification/url_validator.ts
@@ -1,0 +1,163 @@
+import net from 'net';
+
+export interface UrlValidationOptions {
+  /**
+   * Whether to allow loopback addresses (localhost, 127.0.0.0/8, ::1).
+   * Defaults to false.
+   */
+  allowLoopback?: boolean;
+
+  /**
+   * Whether to allow private IP networks (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, site-local IPv6).
+   * Defaults to false.
+   */
+  allowPrivateNetworks?: boolean;
+
+  /**
+   * List of allowed hostnames or patterns (allowlist).
+   * If specified and host matches any entry, validation succeeds regardless of IP restrictions.
+   */
+  allowedHosts?: (string | RegExp)[];
+
+  /**
+   * Allowed protocols/schemes (with trailing colon).
+   * Defaults to ['http:', 'https:'].
+   */
+  allowedProtocols?: string[];
+}
+
+export class UrlValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UrlValidationError';
+  }
+}
+
+/**
+ * Validates a webhook URL to prevent SSRF (Server-Side Request Forgery) per A2A Spec §13.2.
+ */
+export function validateWebhookUrl(urlString: string, options: UrlValidationOptions = {}): void {
+  const {
+    allowLoopback = false,
+    allowPrivateNetworks = false,
+    allowedHosts = [],
+    allowedProtocols = ['http:', 'https:'],
+  } = options;
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(urlString);
+  } catch {
+    throw new UrlValidationError(`Invalid URL format: ${urlString}`);
+  }
+
+  // Validate protocol
+  if (!allowedProtocols.includes(parsedUrl.protocol)) {
+    throw new UrlValidationError(
+      `Invalid URL scheme '${parsedUrl.protocol}'. Allowed schemes: ${allowedProtocols.join(', ')}`
+    );
+  }
+
+  const hostname = parsedUrl.hostname.toLowerCase();
+
+  // Strip enclosing square brackets for IPv6
+  const cleanHost =
+    hostname.startsWith('[') && hostname.endsWith(']') ? hostname.slice(1, -1) : hostname;
+
+  // Check explicit allowlist
+  if (allowedHosts.length > 0) {
+    const isAllowed = allowedHosts.some((pattern) => {
+      if (typeof pattern === 'string') {
+        return pattern.toLowerCase() === hostname || pattern.toLowerCase() === cleanHost;
+      }
+      return pattern.test(hostname) || pattern.test(cleanHost);
+    });
+    if (isAllowed) {
+      return;
+    }
+  }
+
+  // Check localhost / domain loopback
+  if (!allowLoopback) {
+    if (cleanHost === 'localhost' || cleanHost.endsWith('.localhost')) {
+      throw new UrlValidationError(
+        `Webhook URL hostname '${hostname}' resolves to loopback/localhost`
+      );
+    }
+  }
+
+  const ipType = net.isIP(cleanHost);
+
+  if (ipType === 4) {
+    validateIPv4(cleanHost, allowLoopback, allowPrivateNetworks);
+  } else if (ipType === 6) {
+    validateIPv6(cleanHost, allowLoopback, allowPrivateNetworks);
+  }
+}
+
+function validateIPv4(ip: string, allowLoopback: boolean, allowPrivateNetworks: boolean): void {
+  const parts = ip.split('.').map((part) => parseInt(part, 10));
+  if (parts.length !== 4 || parts.some((p) => isNaN(p) || p < 0 || p > 255)) {
+    throw new UrlValidationError(`Invalid IPv4 address format: ${ip}`);
+  }
+
+  const [p0, p1] = parts;
+
+  // 0.0.0.0/8 (unspecified)
+  if (p0 === 0) {
+    throw new UrlValidationError(`Webhook URL IP '${ip}' is an unspecified address (0.0.0.0/8)`);
+  }
+
+  // 127.0.0.0/8 (loopback)
+  if (p0 === 127 && !allowLoopback) {
+    throw new UrlValidationError(`Webhook URL IP '${ip}' is in loopback range (127.0.0.0/8)`);
+  }
+
+  // 169.254.0.0/16 (link-local / cloud metadata)
+  if (p0 === 169 && p1 === 254) {
+    throw new UrlValidationError(`Webhook URL IP '${ip}' is in link-local range (169.254.0.0/16)`);
+  }
+
+  if (!allowPrivateNetworks) {
+    // 10.0.0.0/8
+    if (p0 === 10) {
+      throw new UrlValidationError(`Webhook URL IP '${ip}' is in private range (10.0.0.0/8)`);
+    }
+    // 172.16.0.0/12
+    if (p0 === 172 && p1 >= 16 && p1 <= 31) {
+      throw new UrlValidationError(`Webhook URL IP '${ip}' is in private range (172.16.0.0/12)`);
+    }
+    // 192.168.0.0/16
+    if (p0 === 192 && p1 === 168) {
+      throw new UrlValidationError(`Webhook URL IP '${ip}' is in private range (192.168.0.0/16)`);
+    }
+  }
+}
+
+function validateIPv6(ip: string, allowLoopback: boolean, allowPrivateNetworks: boolean): void {
+  const lowerIp = ip.toLowerCase();
+
+  // IPv6 loopback: ::1 or 0:0:0:0:0:0:0:1
+  if ((lowerIp === '::1' || lowerIp === '0:0:0:0:0:0:0:1') && !allowLoopback) {
+    throw new UrlValidationError(`Webhook URL IP '${ip}' is loopback address (::1)`);
+  }
+
+  // IPv4-mapped IPv6 (e.g. ::ffff:127.0.0.1 or ::ffff:10.0.0.1)
+  if (lowerIp.startsWith('::ffff:')) {
+    const ipv4Part = lowerIp.substring(7);
+    if (net.isIPv4(ipv4Part)) {
+      validateIPv4(ipv4Part, allowLoopback, allowPrivateNetworks);
+      return;
+    }
+  }
+
+  // IPv6 link-local: fe80::/10 (fe8, fe9, fea, feb)
+  if (/^fe[89ab]/i.test(lowerIp)) {
+    throw new UrlValidationError(`Webhook URL IP '${ip}' is in link-local range (fe80::/10)`);
+  }
+
+  // IPv6 ULA / Unique Local / Site-Local: fc00::/7 (fc, fd)
+  if (/^f[cd]/i.test(lowerIp) && !allowPrivateNetworks) {
+    throw new UrlValidationError(`Webhook URL IP '${ip}' is in private range (fc00::/7)`);
+  }
+}

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -33,6 +33,11 @@ import {
 } from '../push_notification/push_notification_store.js';
 import { PushNotificationSender } from '../push_notification/push_notification_sender.js';
 import { DefaultPushNotificationSender } from '../push_notification/default_push_notification_sender.js';
+import {
+  validateWebhookUrl,
+  UrlValidationOptions,
+  UrlValidationError,
+} from '../push_notification/url_validator.js';
 import { ServerCallContext } from '../context.js';
 
 const terminalStates: TaskState[] = ['completed', 'failed', 'canceled', 'rejected'];
@@ -45,6 +50,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   private readonly pushNotificationStore?: PushNotificationStore;
   private readonly pushNotificationSender?: PushNotificationSender;
   private readonly extendedAgentCardProvider?: AgentCard | ExtendedAgentCardProvider;
+  private readonly urlValidationOptions?: UrlValidationOptions;
 
   constructor(
     agentCard: AgentCard,
@@ -53,20 +59,36 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     eventBusManager: ExecutionEventBusManager = new DefaultExecutionEventBusManager(),
     pushNotificationStore?: PushNotificationStore,
     pushNotificationSender?: PushNotificationSender,
-    extendedAgentCardProvider?: AgentCard | ExtendedAgentCardProvider
+    extendedAgentCardProvider?: AgentCard | ExtendedAgentCardProvider,
+    urlValidationOptions?: UrlValidationOptions
   ) {
     this.agentCard = agentCard;
     this.taskStore = taskStore;
     this.agentExecutor = agentExecutor;
     this.eventBusManager = eventBusManager;
     this.extendedAgentCardProvider = extendedAgentCardProvider;
+    this.urlValidationOptions = urlValidationOptions;
 
     // If push notifications are supported, use the provided store and sender.
     // Otherwise, use the default in-memory store and sender.
     if (agentCard.capabilities.pushNotifications) {
       this.pushNotificationStore = pushNotificationStore || new InMemoryPushNotificationStore();
       this.pushNotificationSender =
-        pushNotificationSender || new DefaultPushNotificationSender(this.pushNotificationStore);
+        pushNotificationSender ||
+        new DefaultPushNotificationSender(this.pushNotificationStore, {
+          urlValidationOptions: this.urlValidationOptions,
+        });
+    }
+  }
+
+  private validatePushNotificationConfigUrl(url: string): void {
+    try {
+      validateWebhookUrl(url, this.urlValidationOptions);
+    } catch (error) {
+      if (error instanceof UrlValidationError) {
+        throw A2AError.invalidParams(`Invalid push notification webhook URL: ${error.message}`);
+      }
+      throw error;
     }
   }
 
@@ -225,11 +247,12 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     // Use the (potentially updated) contextId from requestContext
     const finalMessageForAgent = requestContext.userMessage;
 
-    // If push notification config is provided, save it to the store.
+    // If push notification config is provided, validate and save it to the store.
     if (
       params.configuration?.pushNotificationConfig &&
       this.agentCard.capabilities.pushNotifications
     ) {
+      this.validatePushNotificationConfigUrl(params.configuration.pushNotificationConfig.url);
       await this.pushNotificationStore?.save(taskId, params.configuration.pushNotificationConfig);
     }
 
@@ -327,11 +350,12 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     const eventBus = this.eventBusManager.createOrGetByTaskId(taskId);
     const eventQueue = new ExecutionEventQueue(eventBus);
 
-    // If push notification config is provided, save it to the store.
+    // If push notification config is provided, validate and save it to the store.
     if (
       params.configuration?.pushNotificationConfig &&
       this.agentCard.capabilities.pushNotifications
     ) {
+      this.validatePushNotificationConfigUrl(params.configuration.pushNotificationConfig.url);
       await this.pushNotificationStore?.save(taskId, params.configuration.pushNotificationConfig);
     }
 
@@ -459,6 +483,9 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     }
 
     const { taskId, pushNotificationConfig } = params;
+
+    // Validate webhook URL per A2A spec §13.2
+    this.validatePushNotificationConfigUrl(pushNotificationConfig.url);
 
     // Default the config ID to the task ID if not provided for backward compatibility.
     if (!pushNotificationConfig.id) {

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -118,7 +118,9 @@ describe('Push Notification Integration Tests', () => {
     mockAgentExecutor = new MockAgentExecutor();
     const executionEventBusManager = new DefaultExecutionEventBusManager();
     pushNotificationStore = new InMemoryPushNotificationStore();
-    pushNotificationSender = new DefaultPushNotificationSender(pushNotificationStore);
+    pushNotificationSender = new DefaultPushNotificationSender(pushNotificationStore, {
+      urlValidationOptions: { allowLoopback: true },
+    });
     pushNotificationSenderSpy = vi.spyOn(pushNotificationSender, 'send');
 
     handler = new DefaultRequestHandler(
@@ -127,7 +129,9 @@ describe('Push Notification Integration Tests', () => {
       mockAgentExecutor,
       executionEventBusManager,
       pushNotificationStore,
-      pushNotificationSender
+      pushNotificationSender,
+      undefined,
+      { allowLoopback: true }
     );
   });
 
@@ -449,6 +453,7 @@ describe('Push Notification Integration Tests', () => {
         pushNotificationStore,
         {
           tokenHeaderName: 'X-Custom-Auth-Token',
+          urlValidationOptions: { allowLoopback: true },
         }
       );
       const customSenderSpy = vi.spyOn(customPushNotificationSender, 'send');
@@ -459,7 +464,9 @@ describe('Push Notification Integration Tests', () => {
         mockAgentExecutor,
         new DefaultExecutionEventBusManager(),
         pushNotificationStore,
-        customPushNotificationSender
+        customPushNotificationSender,
+        undefined,
+        { allowLoopback: true }
       );
 
       const pushConfig: PushNotificationConfig = {
@@ -596,6 +603,7 @@ describe('Push Notification Integration Tests', () => {
         pushNotificationStore,
         {
           tokenHeaderName: 'X-Custom-Token',
+          urlValidationOptions: { allowLoopback: true },
         }
       );
       const customSenderSpy = vi.spyOn(customPushNotificationSender, 'send');
@@ -606,7 +614,9 @@ describe('Push Notification Integration Tests', () => {
         mockAgentExecutor,
         new DefaultExecutionEventBusManager(),
         pushNotificationStore,
-        customPushNotificationSender
+        customPushNotificationSender,
+        undefined,
+        { allowLoopback: true }
       );
 
       const pushConfig1: PushNotificationConfig = {

--- a/test/server/url_validator.spec.ts
+++ b/test/server/url_validator.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  validateWebhookUrl,
+  UrlValidationError,
+} from '../../src/server/push_notification/url_validator.js';
+
+describe('validateWebhookUrl (SSRF Protection per A2A Spec §13.2)', () => {
+  it('should allow valid public HTTP/HTTPS URLs', () => {
+    expect(() => validateWebhookUrl('https://example.com/webhook')).not.toThrow();
+    expect(() => validateWebhookUrl('http://api.external.org/v1/notify')).not.toThrow();
+    expect(() => validateWebhookUrl('https://8.8.8.8/webhook')).not.toThrow();
+  });
+
+  it('should reject invalid URL strings', () => {
+    expect(() => validateWebhookUrl('not-a-url')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('')).toThrow(UrlValidationError);
+  });
+
+  it('should reject non-HTTP/HTTPS schemes', () => {
+    expect(() => validateWebhookUrl('file:///etc/passwd')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('ftp://example.com/file')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('gopher://127.0.0.1:70')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('javascript:alert(1)')).toThrow(UrlValidationError);
+  });
+
+  it('should reject loopback/localhost addresses by default', () => {
+    expect(() => validateWebhookUrl('http://localhost:8080/webhook')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('http://sub.localhost/path')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('http://127.0.0.1:9999/keys')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('http://127.0.0.2/test')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('http://[::1]/test')).toThrow(UrlValidationError);
+  });
+
+  it('should reject link-local addresses by default', () => {
+    expect(() => validateWebhookUrl('http://169.254.169.254/latest/meta-data/')).toThrow(
+      UrlValidationError
+    );
+    expect(() => validateWebhookUrl('http://169.254.1.1/admin')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('http://[fe80::1]/admin')).toThrow(UrlValidationError);
+  });
+
+  it('should reject private RFC-1918 IPv4 ranges by default', () => {
+    // 10.0.0.0/8
+    expect(() => validateWebhookUrl('http://10.0.0.1/admin')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('http://10.255.255.254/secret')).toThrow(UrlValidationError);
+
+    // 172.16.0.0/12
+    expect(() => validateWebhookUrl('http://172.16.0.1/internal')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('http://172.31.255.255/internal')).toThrow(UrlValidationError);
+
+    // 192.168.0.0/16
+    expect(() => validateWebhookUrl('http://192.168.1.1/router')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('http://192.168.0.100/api')).toThrow(UrlValidationError);
+  });
+
+  it('should reject IPv6 unique local addresses (ULA) by default', () => {
+    expect(() => validateWebhookUrl('http://[fc00::1]/api')).toThrow(UrlValidationError);
+    expect(() => validateWebhookUrl('http://[fd00::1]/api')).toThrow(UrlValidationError);
+  });
+
+  it('should allow loopback when allowLoopback option is true', () => {
+    expect(() =>
+      validateWebhookUrl('http://127.0.0.1:8080/webhook', { allowLoopback: true })
+    ).not.toThrow();
+    expect(() =>
+      validateWebhookUrl('http://localhost:3000/notify', { allowLoopback: true })
+    ).not.toThrow();
+  });
+
+  it('should allow private networks when allowPrivateNetworks option is true', () => {
+    expect(() =>
+      validateWebhookUrl('http://10.0.0.1/notify', { allowPrivateNetworks: true })
+    ).not.toThrow();
+    expect(() =>
+      validateWebhookUrl('http://192.168.1.1/notify', { allowPrivateNetworks: true })
+    ).not.toThrow();
+  });
+
+  it('should respect allowedHosts allowlist', () => {
+    expect(() =>
+      validateWebhookUrl('http://127.0.0.1:8080/webhook', {
+        allowedHosts: ['127.0.0.1'],
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      validateWebhookUrl('http://internal.company.com/webhook', {
+        allowedHosts: [/^internal\./],
+      })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
# Description

This PR fixes issue #584 by adding URL validation for push notification webhooks as required by A2A Protocol Specification §13.2 to prevent Server-Side Request Forgery (SSRF) attacks.

### Changes Included:
- **URL Validation**: Added `validateWebhookUrl` to check webhook URLs upon receipt and before sending notifications.
- **SSRF Protection**: Rejects loopback (`127.0.0.1`, `localhost`), cloud metadata (`169.254.169.254`), private IP ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), and non-HTTP(S) schemes.
- **Redirect Protection**: Configured `redirect: 'error'` on fetch calls to prevent HTTP redirect bypasses.
- **Configurable Options**: Added optional settings (`allowLoopback`, `allowedHosts`) for internal testing and local setups.
- **Tests**: Added unit tests in `url_validator.spec.ts`. All 420 tests pass cleanly.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-js/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass
- [ ] Appropriate docs were updated (if necessary)

Fixes #584 
