### PR TITLE
ci: point next dist-tag at stable releases too

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,16 +17,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
       - run: npm ci
       - run: npm run build
-      
+
       # Now configure with the publish service for install.
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: 'https://wombat-dressing-room.appspot.com/'
 
       - name: Publish to NPM
@@ -36,5 +36,13 @@ jobs:
           else
             npm publish --provenance --access public
           fi
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - name: Point `next` tag at the stable release too
+        if: ${{ github.event.release.prerelease == false }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          npm dist-tag add "@a2a-js/sdk@${VERSION}" next
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -35,14 +35,8 @@ jobs:
             npm publish --provenance --access public --tag next
           else
             npm publish --provenance --access public
+            VERSION=$(node -p "require('./package.json').version")
+            npm dist-tag add "@a2a-js/sdk@${VERSION}" next
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-
-      - name: Point `next` tag at the stable release too
-        if: ${{ github.event.release.prerelease == false }}
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          npm dist-tag add "@a2a-js/sdk@${VERSION}" next
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
# Description

New pointing logic:
```
If stable release:
    release under latest and next tag
else:
    release under next tag
```

Also bumps node version to `20` in the workflow
