### PR TITLE
chore: prepare for 1.0.0 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ over the protocol) and A2A **clients** (applications discovering and driving
 those agents) — one package, three wire transports (JSON-RPC,
 HTTP+JSON/REST, gRPC), and an opt-in compatibility layer for v0.3 peers.
 
-- 🚀 **v1.0 beta release** tracking [A2A Protocol Specification v1.0](https://a2a-protocol.org/v1.0.0/specification/).
+- 🚀 **v1.0 stable release** implementing [A2A Protocol Specification v1.0](https://a2a-protocol.org/v1.0.0/specification/).
 - 🔌 **Three transports** — JSON-RPC, HTTP+JSON/REST, and gRPC (Node-only),
   all backed by a single `DefaultRequestHandler`.
 - 🔄 **v0.3 backward compatibility** as an opt-in layer so v1.0 deployments
@@ -28,10 +28,10 @@ HTTP+JSON/REST, gRPC), and an opt-in compatibility layer for v0.3 peers.
 
 ## Installation
 
-You can install the A2A SDK using `npm`. The v1.0 beta release is now available:
+You can install the A2A SDK using `npm`:
 
 ```bash
-npm install @a2a-js/sdk@next
+npm install @a2a-js/sdk
 ```
 
 ### For Server Usage

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -14,7 +14,7 @@ model changes (renamed fields, restructured types, new operations), see:
 - Install the v1.0 SDK:
 
   ```bash
-  npm install @a2a-js/sdk@next
+  npm install @a2a-js/sdk
   ```
 
 > Migrating all v0.3 clients to v1.0 during upgrade is not required: the v1.0 SDK

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,6 @@
 {
   "release-type": "node",
   "include-component-in-tag": false,
-  "prerelease": true,
-  "prerelease-type": "beta",
-  "versioning": "prerelease",
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
Exit the beta prerelease and instruct release-please to use 1.0.0 as the next release version.

Release-As: 1.0.0