### PR TITLE
ci(itk): install with npm ci so package-lock.json is honoured

### DIFF
--- a/.github/workflows/run-itk-nightly.yaml
+++ b/.github/workflows/run-itk-nightly.yaml
@@ -49,7 +49,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Node dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run Error Handling Tests
         run: bash itk/run_error_tests.sh

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -49,7 +49,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Node dependencies
-        run: npm install
+        run: npm ci
 
       - name: Run Error Handling Tests
         run: bash itk/run_error_tests.sh


### PR DESCRIPTION
# Description

The ITK agent builds from the root package.json, whose lock is already committed, but npm install can re-resolve and rewrite it. Switches both ITK workflows to npm ci.
