### PR TITLE
fix: Add serialization for listTasks input/output parameters.

### DIFF
--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -11,8 +11,10 @@ import {
   RestTransportHandler,
   HTTP_STATUS,
   mapErrorToStatus,
+  parseIncludeArtifacts,
   toHTTPError,
 } from '../transports/rest/rest_transport_handler.js';
+import { serializeListTasksResponse } from '../transports/list_tasks_serializer.js';
 import {
   ServerCallContext,
   ServerCallContextBuilder,
@@ -447,7 +449,12 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   registerRoute('get', '/tasks', async (req, res) => {
     const context = await buildContext(req);
     const result = await restTransportHandler.listTasks(req.query, context);
-    sendResponse<ListTasksResponse>(res, HTTP_STATUS.OK, context, result, ListTasksResponse);
+    const includeArtifacts = parseIncludeArtifacts(req.query.includeArtifacts);
+    sendResponse<ListTasksResponse>(res, HTTP_STATUS.OK, context, result, {
+      ...ListTasksResponse,
+      toJSON: (message: ListTasksResponse) =>
+        serializeListTasksResponse(message, { includeArtifacts }),
+    });
   });
 
   /**

--- a/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -12,10 +12,10 @@ import {
   DeleteTaskPushNotificationConfigRequest,
   ListTaskPushNotificationConfigsRequest,
   ListTasksRequest,
-  ListTasksResponse,
   ListTaskPushNotificationConfigsResponse,
   AgentCard,
 } from '../../../index.js';
+import { serializeListTasksResponse } from '../list_tasks_serializer.js';
 import {
   A2A_ERROR_CODE,
   type ErrorDetail,
@@ -152,14 +152,14 @@ export class JsonRpcTransportHandler {
               await this.requestHandler.getTask(GetTaskRequest.fromJSON(rpcRequest.params), context)
             );
             break;
-          case 'ListTasks':
-            result = ListTasksResponse.toJSON(
-              await this.requestHandler.listTasks(
-                ListTasksRequest.fromJSON(rpcRequest.params),
-                context
-              )
+          case 'ListTasks': {
+            const listTasksRequest = ListTasksRequest.fromJSON(rpcRequest.params);
+            result = serializeListTasksResponse(
+              await this.requestHandler.listTasks(listTasksRequest, context),
+              { includeArtifacts: listTasksRequest.includeArtifacts }
             );
             break;
+          }
           case 'CancelTask':
             result = Task.toJSON(
               await this.requestHandler.cancelTask(

--- a/src/server/transports/list_tasks_serializer.ts
+++ b/src/server/transports/list_tasks_serializer.ts
@@ -1,0 +1,58 @@
+/**
+ * Wire serialization for `ListTasks`, which needs field-presence rules that
+ * differ from the default ProtoJSON encoding used everywhere else.
+ */
+
+import { ListTasksResponse } from '../../types/pb/a2a.js';
+
+/** Options controlling {@link serializeListTasksResponse}. */
+export interface SerializeListTasksResponseOptions {
+  /**
+   * The `includeArtifacts` value from the originating `ListTasksRequest`.
+   */
+  includeArtifacts?: boolean;
+}
+
+/**
+ * Serializes a `ListTasksResponse` for the JSON-RPC and REST bindings.
+ */
+export function serializeListTasksResponse(
+  response: ListTasksResponse,
+  options?: SerializeListTasksResponseOptions
+): Record<string, unknown> {
+  const serialized = ListTasksResponse.toJSON(response) as Record<string, unknown>;
+  // Destructured so the four fields are re-inserted in proto field order
+  // instead of inheriting the position they happened to get from the encoder,
+  // which keeps the emitted key order stable across pages.
+  const { tasks, nextPageToken, pageSize, totalSize, ...rest } = serialized;
+  const serializedTasks = (tasks as unknown[]) ?? [];
+
+  return {
+    tasks: options?.includeArtifacts
+      ? serializedTasks.map(withMaterializedArtifacts)
+      : serializedTasks,
+    nextPageToken: nextPageToken ?? '',
+    pageSize: pageSize ?? 0,
+    totalSize: totalSize ?? 0,
+    ...rest,
+  };
+}
+
+/**
+ * Restores an `artifacts: []` that ProtoJSON elided.
+ *
+ * Only called when the request asked for artifacts, where §3.1.4 says the
+ * field "should be included with its actual content (which may be an empty
+ * array if the task has no artifacts)". When artifacts were not requested
+ * the field stays absent, as that same section requires.
+ */
+function withMaterializedArtifacts(task: unknown): unknown {
+  if (typeof task !== 'object' || task === null) {
+    return task;
+  }
+  const serializedTask = task as Record<string, unknown>;
+  if (serializedTask.artifacts !== undefined) {
+    return serializedTask;
+  }
+  return { ...serializedTask, artifacts: [] };
+}

--- a/src/server/transports/rest/rest_transport_handler.ts
+++ b/src/server/transports/rest/rest_transport_handler.ts
@@ -32,6 +32,10 @@ import {
 
 export { HTTP_STATUS, mapErrorToStatus, toHTTPError };
 
+export function parseIncludeArtifacts(value: unknown): boolean {
+  return value === 'true' || value === true;
+}
+
 /**
  * Handles the REST transport layer, routing requests to an
  * {@link A2ARequestHandler}. Performs type conversion, validation, and
@@ -115,8 +119,7 @@ export class RestTransportHandler {
       pageToken: (queryParams.pageToken as string) || '',
       historyLength: queryParams.historyLength ? Number(queryParams.historyLength) : undefined,
       statusTimestampAfter: (queryParams.statusTimestampAfter as string) || undefined,
-      includeArtifacts:
-        queryParams.includeArtifacts === 'true' || queryParams.includeArtifacts === true,
+      includeArtifacts: parseIncludeArtifacts(queryParams.includeArtifacts),
     };
 
     return this.requestHandler.listTasks(params, context);

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -475,6 +475,74 @@ describe('restHandler', () => {
         'Should default to TASK_STATE_UNSPECIFIED (0)'
       );
     });
+
+    describe('response field presence (§3.1.4)', () => {
+      it('should emit the required pagination fields for an empty page', async () => {
+        (mockRequestHandler.listTasks as Mock).mockResolvedValue({
+          tasks: [],
+          nextPageToken: '',
+          pageSize: 20,
+          totalSize: 0,
+        });
+
+        const response = await request(app)
+          .get('/tasks?pageSize=20')
+          .set('A2A-Version', '1.0')
+          .expect(200);
+
+        assert.deepEqual(response.body, {
+          tasks: [],
+          nextPageToken: '',
+          pageSize: 20,
+          totalSize: 0,
+        });
+      });
+
+      it('should omit artifacts entirely when includeArtifacts is false', async () => {
+        (mockRequestHandler.listTasks as Mock).mockResolvedValue({
+          tasks: [testTask],
+          nextPageToken: '',
+          pageSize: 20,
+          totalSize: 1,
+        });
+
+        const response = await request(app)
+          .get('/tasks?includeArtifacts=false')
+          .set('A2A-Version', '1.0')
+          .expect(200);
+
+        expect(response.body.tasks[0]).not.toHaveProperty('artifacts');
+      });
+
+      it('should omit artifacts when includeArtifacts is not supplied', async () => {
+        (mockRequestHandler.listTasks as Mock).mockResolvedValue({
+          tasks: [testTask],
+          nextPageToken: '',
+          pageSize: 20,
+          totalSize: 1,
+        });
+
+        const response = await request(app).get('/tasks').set('A2A-Version', '1.0').expect(200);
+
+        expect(response.body.tasks[0]).not.toHaveProperty('artifacts');
+      });
+
+      it('should emit an empty artifacts array when includeArtifacts is true', async () => {
+        (mockRequestHandler.listTasks as Mock).mockResolvedValue({
+          tasks: [testTask],
+          nextPageToken: '',
+          pageSize: 20,
+          totalSize: 1,
+        });
+
+        const response = await request(app)
+          .get('/tasks?includeArtifacts=true')
+          .set('A2A-Version', '1.0')
+          .expect(200);
+
+        assert.deepEqual(response.body.tasks[0].artifacts, []);
+      });
+    });
   });
 
   describe('/tasks/:taskId:subscribe', () => {

--- a/test/server/jsonrpc_transport_handler.spec.ts
+++ b/test/server/jsonrpc_transport_handler.spec.ts
@@ -221,6 +221,119 @@ describe('JsonRpcTransportHandler', () => {
     });
   });
 
+  describe('ListTasks serialization (§3.1.4)', () => {
+    const listTasks = async (params: Record<string, unknown>) => {
+      const response = (await transportHandler.handle(
+        { jsonrpc: '2.0', method: 'ListTasks', id: 1, params },
+        defaultContext
+      )) as { result: Record<string, unknown> };
+      return response.result;
+    };
+
+    const taskWithArtifacts = (artifacts: unknown[]): Record<string, unknown> => ({
+      id: 'task-1',
+      contextId: 'ctx-1',
+      status: { state: 'TASK_STATE_COMPLETED' },
+      artifacts,
+      history: [],
+      metadata: undefined,
+    });
+
+    it('emits the required pagination fields for an empty page', async () => {
+      // Default ProtoJSON elides all four at their default values, but
+      // §3.1.4 requires `nextPageToken` to always be present (empty string
+      // on the final page), and the reference SDKs emit the other three too.
+      (mockRequestHandler.listTasks as Mock).mockResolvedValue({
+        tasks: [],
+        nextPageToken: '',
+        pageSize: 20,
+        totalSize: 0,
+      });
+
+      expect(await listTasks({ pageSize: 20 })).toEqual({
+        tasks: [],
+        nextPageToken: '',
+        pageSize: 20,
+        totalSize: 0,
+      });
+    });
+
+    it('preserves populated pagination values', async () => {
+      (mockRequestHandler.listTasks as Mock).mockResolvedValue({
+        tasks: [taskWithArtifacts([])],
+        nextPageToken: 'cursor-2',
+        pageSize: 10,
+        totalSize: 5,
+      });
+
+      const result = await listTasks({ pageSize: 10 });
+
+      expect(result.nextPageToken).toBe('cursor-2');
+      expect(result.pageSize).toBe(10);
+      expect(result.totalSize).toBe(5);
+      expect(result.tasks).toHaveLength(1);
+    });
+
+    it('omits artifacts entirely when includeArtifacts is false', async () => {
+      // §3.1.4: the artifacts field MUST be omitted entirely, and "should not
+      // be present as an empty array or null value". Guards against the
+      // always-emit behaviour above ever being applied recursively.
+      (mockRequestHandler.listTasks as Mock).mockResolvedValue({
+        tasks: [taskWithArtifacts([])],
+        nextPageToken: '',
+        pageSize: 20,
+        totalSize: 1,
+      });
+
+      const result = await listTasks({ pageSize: 20, includeArtifacts: false });
+
+      expect((result.tasks as unknown[])[0]).not.toHaveProperty('artifacts');
+    });
+
+    it('omits artifacts when includeArtifacts is not supplied', async () => {
+      (mockRequestHandler.listTasks as Mock).mockResolvedValue({
+        tasks: [taskWithArtifacts([])],
+        nextPageToken: '',
+        pageSize: 20,
+        totalSize: 1,
+      });
+
+      const result = await listTasks({ pageSize: 20 });
+
+      expect((result.tasks as unknown[])[0]).not.toHaveProperty('artifacts');
+    });
+
+    it('emits an empty artifacts array when includeArtifacts is true', async () => {
+      // §3.1.4: when requested, artifacts "should be included with its actual
+      // content (which may be an empty array if the task has no artifacts)".
+      (mockRequestHandler.listTasks as Mock).mockResolvedValue({
+        tasks: [taskWithArtifacts([])],
+        nextPageToken: '',
+        pageSize: 20,
+        totalSize: 1,
+      });
+
+      const result = await listTasks({ pageSize: 20, includeArtifacts: true });
+
+      expect((result.tasks as unknown[])[0]).toHaveProperty('artifacts', []);
+    });
+
+    it('keeps populated artifacts when includeArtifacts is true', async () => {
+      (mockRequestHandler.listTasks as Mock).mockResolvedValue({
+        tasks: [taskWithArtifacts([{ artifactId: 'a-1', parts: [], name: 'report' }])],
+        nextPageToken: '',
+        pageSize: 20,
+        totalSize: 1,
+      });
+
+      const result = await listTasks({ pageSize: 20, includeArtifacts: true });
+
+      const artifacts = (result.tasks as Record<string, unknown>[])[0].artifacts as unknown[];
+      expect(artifacts).toHaveLength(1);
+      expect(artifacts[0]).toMatchObject({ artifactId: 'a-1' });
+    });
+  });
+
   describe('Error mapping', () => {
     it('should map RequestMalformedError to code and message', async () => {
       const mappedError = JsonRpcTransportHandler.mapToJSONRPCError(


### PR DESCRIPTION
# Description

ProtoJSON omits default values while such are a required output for the `listTasks` method. This is present for both REST and JSON_RCP transports.

This PR fixes that by adding a `list_tasks_serializer` that makes sure that all fields are outputted, even if their values are default ones.

Fixes #609  🦕
