### PR TITLE
fix(errors): global error branding via Symbol.hasInstance to fix instanceof checks across bundle entry points

### DIFF
--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -43,6 +43,19 @@ export interface A2AErrorOptions {
 }
 
 /**
+ * Realm-wide brand carried by every {@link A2AError}.
+ *
+ * The package ships one bundle per entry point and each bundle inlines
+ * its own copy of this module, so constructor identity is not shared:
+ * a plain `instanceof` fails for an error that crosses an entry
+ * boundary — e.g. a `TaskNotFoundError` from `@a2a-js/sdk/errors`
+ * reaching the adapter inside `@a2a-js/sdk/server/express`.
+ * `Symbol.for` resolves in the global registry, so every copy agrees
+ * on this key.
+ */
+const A2A_ERROR_BRAND: unique symbol = Symbol.for('@a2a-js/sdk.A2AError');
+
+/**
  * Base class for every SDK error and the concrete fallback used when
  * no semantic subclass matches (e.g. an unknown wire code). Carries
  * the spec-aligned `reason`, structured `metadata`, and a stable
@@ -58,6 +71,36 @@ export class A2AError extends Error {
   public readonly reason: string = 'INTERNAL_ERROR';
   /** Optional `google.rpc.ErrorInfo.metadata`. */
   public readonly metadata?: Record<string, string>;
+  /** @see {@link A2A_ERROR_BRAND} — defined on the prototype below. */
+  declare readonly [A2A_ERROR_BRAND]: true;
+
+  /**
+   * Makes `instanceof` immune to this module being duplicated across
+   * entry-point bundles: the brand stands in for constructor identity.
+   *
+   * Inherited by every subclass, so `err instanceof TaskNotFoundError`
+   * stays exact — subclasses are matched by name up the prototype
+   * chain, the same identity `error.name` and the registry tables below
+   * already key on. Their names come from the runtime strings in
+   * `specs`, so a bundler cannot rename them; the base class, whose
+   * name *is* a renameable binding, is answered by the brand alone.
+   */
+  static [Symbol.hasInstance](this: { name: string }, value: unknown): boolean {
+    if (typeof value !== 'object' || value === null || !(A2A_ERROR_BRAND in value)) return false;
+    // `Symbol.hasInstance` is looked up on the right-hand side, so `this`
+    // and this closure always come from the same copy of the module.
+    if ((this as unknown) === A2AError) return true;
+    for (
+      let proto: object | null = Object.getPrototypeOf(value);
+      proto !== null;
+      proto = Object.getPrototypeOf(proto)
+    ) {
+      if ((proto as { constructor?: { name?: string } }).constructor?.name === this.name) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   constructor(options?: A2AErrorOptions | string) {
     const opts = typeof options === 'string' ? { message: options } : options;
@@ -81,6 +124,9 @@ export class A2AError extends Error {
     };
   }
 }
+
+// Non-enumerable so the brand stays out of spreads and `console.log`.
+Object.defineProperty(A2AError.prototype, A2A_ERROR_BRAND, { value: true });
 
 /**
  * Registry row for one semantic error class. Only holds the fields

--- a/test/errors.spec.ts
+++ b/test/errors.spec.ts
@@ -545,3 +545,77 @@ describe('JSON-RPC roundtrip', () => {
     expect(isJsonRpcError(rebuilt)).toBe(true);
   });
 });
+
+describe('cross-entry error identity', () => {
+  // The published bundle inlines this module into every entry point
+  // (`@a2a-js/sdk/errors`, `@a2a-js/sdk/server/express`, …), so an error
+  // can be constructed by one copy and inspected by another.
+  // `vi.resetModules()` reproduces that split in-process. Regression test
+  // for issue, where the duplicate copy made the Express JSON-RPC adapter
+  // downgrade every semantic error to InternalError (-32603).
+  async function loadSecondCopy() {
+    vi.resetModules();
+    return import('../src/errors/index.js');
+  }
+
+  it('is actually testing two distinct copies', async () => {
+    const other = await loadSecondCopy();
+    expect(other.A2AError).not.toBe(A2AError);
+    expect(other.TaskNotFoundError).not.toBe(TaskNotFoundError);
+  });
+
+  it('matches instanceof across copies', async () => {
+    const other = await loadSecondCopy();
+    const err = new other.TaskNotFoundError();
+
+    expect(err).toBeInstanceOf(A2AError);
+    expect(err).toBeInstanceOf(TaskNotFoundError);
+    expect(err).toBeInstanceOf(Error);
+    // Transport subclasses resolve through the whole chain.
+    expect(new other.JsonRpcTaskNotFoundError()).toBeInstanceOf(TaskNotFoundError);
+  });
+
+  it('does not over-match', async () => {
+    const other = await loadSecondCopy();
+
+    expect(new other.TaskNotFoundError()).not.toBeInstanceOf(RequestMalformedError);
+    expect(new other.A2AError()).not.toBeInstanceOf(TaskNotFoundError);
+    expect(new Error('plain')).not.toBeInstanceOf(A2AError);
+    expect({}).not.toBeInstanceOf(A2AError);
+    expect(null).not.toBeInstanceOf(A2AError);
+    expect('boom').not.toBeInstanceOf(A2AError);
+  });
+
+  it('survives a bundler renaming one of the duplicated class bindings', async () => {
+    const other = await loadSecondCopy();
+    // A downstream bundler that pulls two entry points into one output
+    // renames the colliding binding — esbuild emits
+    // `var A2AError2 = class extends Error {}` — and an anonymous class
+    // expression takes its `.name` from that binding. Only the base
+    // class is exposed to this: the semantic subclasses are built from
+    // the runtime strings in `specs`, which no bundler rewrites.
+    Object.defineProperty(other.A2AError, 'name', { value: 'A2AError2' });
+    const err = new other.TaskNotFoundError();
+
+    expect(err).toBeInstanceOf(A2AError);
+    expect(err).toBeInstanceOf(TaskNotFoundError);
+    expect(err).not.toBeInstanceOf(RequestMalformedError);
+    expect(toJsonRpcError(err).code).toBe(A2A_ERROR_CODE.TASK_NOT_FOUND);
+    expect(restStatusFor(err)).toBe(HTTP_STATUS.NOT_FOUND);
+  });
+
+  it('serializes to the semantic wire code across copies', async () => {
+    const other = await loadSecondCopy();
+    const err = new other.TaskNotFoundError();
+
+    expect(toJsonRpcError(err).code).toBe(A2A_ERROR_CODE.TASK_NOT_FOUND);
+    expect(toJsonRpcError(new other.TaskNotCancelableError()).code).toBe(
+      A2A_ERROR_CODE.TASK_NOT_CANCELABLE
+    );
+    expect(restStatusFor(err)).toBe(HTTP_STATUS.NOT_FOUND);
+    expect(toRestErrorBody(err, restStatusFor(err)).error).toMatchObject({
+      status: 'NOT_FOUND',
+      details: [{ reason: 'TASK_NOT_FOUND' }],
+    });
+  });
+});


### PR DESCRIPTION
# Description

Protocol errors were downgraded to JSON-RPC `InternalError` (-32603), HTTP 500 and gRPC `UNKNOWN` whenever they crossed a package entry point.

`tsup` builds each subpath export as a separate bundle (`splitting: false`), so every entry inlines its own copy of `src/errors/base.ts` - 13 distinct `A2AError` constructors. The `instanceof A2AError` gate that all wire mapping goes through therefore failed for an error built by a different entry, e.g. a `TaskNotFoundError` from `@a2a-js/sdk/errors` reaching the adapter in `@a2a-js/sdk/server/express`. `A2AError` now carries a `Symbol.for()` brand and a `Symbol.hasInstance` that matches on it, so `instanceof` no longer depends on constructor identity. Subclasses inherit the check and stay exact — they are matched by class name up the prototype chain, the same identity `error.name` and the registry tables already key on. One change in `src/errors/base.ts` fixes all internal check sites plus user-land `instanceof TaskNotFoundError`; no call site changes.

Verified end to end on the built `dist`: JSON-RPC blocking/streaming, REST and gRPC all return the correct semantic code, in ESM and CJS. Also covers two cases the duplication caused beyond the report - a consumer bundling two entry points into one output (where the bundler renames the colliding class binding), and two SDK versions installed side by side.

Enabling `splitting: true` was evaluated as a root-cause fix and rejected: tsup's experimental CJS splitting rewrites the error class bodies into a sequence expression, which defeats JS named evaluation and silently sets `error.name` to `_class2` - turning *every* semantic error into -32603/500 for *every* CJS consumer. 

Fixes #608  🦕
