### PR TITLE
fix(compat/v0_3/translate): add null and undefined checks to array and string fields

### DIFF
--- a/src/compat/v0_3/translate/_validate.ts
+++ b/src/compat/v0_3/translate/_validate.ts
@@ -1,0 +1,15 @@
+import { A2AError } from '../server/error.js';
+
+export function requireArray<T>(value: T[] | undefined | null, path: string): T[] {
+  if (!Array.isArray(value)) {
+    throw A2AError.invalidParams(`${path} is required and must be an array`);
+  }
+  return value;
+}
+
+export function requireObject<T>(value: T | undefined | null, path: string): T {
+  if (value == null || typeof value !== 'object') {
+    throw A2AError.invalidParams(`${path} is required`);
+  }
+  return value;
+}

--- a/src/compat/v0_3/translate/agent_card.ts
+++ b/src/compat/v0_3/translate/agent_card.ts
@@ -101,7 +101,7 @@ export function toCompatAgentCapabilities(core: V1AgentCapabilities): legacy.Age
   const result: legacy.AgentCapabilities1 = {};
   if (core.streaming !== undefined) result.streaming = core.streaming;
   if (core.pushNotifications !== undefined) result.pushNotifications = core.pushNotifications;
-  if (core.extensions.length > 0) {
+  if (core.extensions && core.extensions.length > 0) {
     result.extensions = core.extensions.map(toCompatAgentExtension);
   }
   return result;
@@ -112,7 +112,7 @@ export function toCoreAgentSkill(compat: legacy.AgentSkill): V1AgentSkill {
     id: compat.id,
     name: compat.name,
     description: compat.description,
-    tags: [...compat.tags],
+    tags: compat.tags ? [...compat.tags] : [],
     examples: compat.examples ? [...compat.examples] : [],
     inputModes: compat.inputModes ? [...compat.inputModes] : [],
     outputModes: compat.outputModes ? [...compat.outputModes] : [],
@@ -125,12 +125,12 @@ export function toCompatAgentSkill(core: V1AgentSkill): legacy.AgentSkill {
     id: core.id,
     name: core.name,
     description: core.description,
-    tags: [...core.tags],
+    tags: core.tags ? [...core.tags] : [],
   };
-  if (core.examples.length > 0) result.examples = [...core.examples];
-  if (core.inputModes.length > 0) result.inputModes = [...core.inputModes];
-  if (core.outputModes.length > 0) result.outputModes = [...core.outputModes];
-  if (core.securityRequirements.length > 0) {
+  if (core.examples && core.examples.length > 0) result.examples = [...core.examples];
+  if (core.inputModes && core.inputModes.length > 0) result.inputModes = [...core.inputModes];
+  if (core.outputModes && core.outputModes.length > 0) result.outputModes = [...core.outputModes];
+  if (core.securityRequirements && core.securityRequirements.length > 0) {
     result.security = core.securityRequirements.map(toCompatSecurityRequirement);
   }
   return result;
@@ -170,7 +170,7 @@ export function toCoreAgentCard(compat: legacy.AgentCard): V1AgentCard {
   const additional = compat.additionalInterfaces?.map(toCoreAgentInterface) ?? [];
   const supportedInterfaces = [primary, ...additional];
 
-  const capabilities = toCoreAgentCapabilities(compat.capabilities);
+  const capabilities = toCoreAgentCapabilities(compat.capabilities ?? {});
   if (compat.supportsAuthenticatedExtendedCard !== undefined) {
     capabilities.extendedAgentCard = compat.supportsAuthenticatedExtendedCard;
   }
@@ -191,9 +191,9 @@ export function toCoreAgentCard(compat: legacy.AgentCard): V1AgentCard {
         )
       : {},
     securityRequirements: compat.security ? compat.security.map(toCoreSecurityRequirement) : [],
-    defaultInputModes: [...compat.defaultInputModes],
-    defaultOutputModes: [...compat.defaultOutputModes],
-    skills: compat.skills.map(toCoreAgentSkill),
+    defaultInputModes: compat.defaultInputModes ? [...compat.defaultInputModes] : [],
+    defaultOutputModes: compat.defaultOutputModes ? [...compat.defaultOutputModes] : [],
+    skills: compat.skills ? compat.skills.map(toCoreAgentSkill) : [],
     signatures: compat.signatures ? compat.signatures.map(toCoreAgentCardSignature) : [],
   };
 
@@ -256,7 +256,7 @@ export function toCompatAgentCard(
       : undefined;
 
   const securitySchemes =
-    Object.keys(core.securitySchemes).length > 0
+    core.securitySchemes && Object.keys(core.securitySchemes).length > 0
       ? Object.fromEntries(
           Object.entries(core.securitySchemes).map(([key, scheme]) => [
             key,
@@ -275,9 +275,9 @@ export function toCompatAgentCard(
     preferredTransport: primary.protocolBinding,
     protocolVersion: emittedProtocolVersion,
     capabilities,
-    defaultInputModes: [...core.defaultInputModes],
-    defaultOutputModes: [...core.defaultOutputModes],
-    skills: core.skills.map(toCompatAgentSkill),
+    defaultInputModes: core.defaultInputModes ? [...core.defaultInputModes] : [],
+    defaultOutputModes: core.defaultOutputModes ? [...core.defaultOutputModes] : [],
+    skills: (core.skills ?? []).map(toCompatAgentSkill),
   };
 
   if (additionalInterfaces.length > 0) {
@@ -292,10 +292,10 @@ export function toCompatAgentCard(
     result.supportsAuthenticatedExtendedCard = supportsExtendedCard;
   }
   if (securitySchemes !== undefined) result.securitySchemes = securitySchemes;
-  if (core.securityRequirements.length > 0) {
+  if (core.securityRequirements && core.securityRequirements.length > 0) {
     result.security = core.securityRequirements.map(toCompatSecurityRequirement);
   }
-  if (core.signatures.length > 0) {
+  if (core.signatures && core.signatures.length > 0) {
     result.signatures = core.signatures.map(toCompatAgentCardSignature);
   }
 

--- a/src/compat/v0_3/translate/agent_card.ts
+++ b/src/compat/v0_3/translate/agent_card.ts
@@ -31,6 +31,7 @@ import type {
 } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
 import { deepCloneMetadata } from './_clone.js';
+import { requireArray, requireObject } from './_validate.js';
 
 // Default when the v0.3 card omits `preferredTransport`.
 const DEFAULT_PREFERRED_TRANSPORT = 'JSONRPC';
@@ -112,7 +113,7 @@ export function toCoreAgentSkill(compat: legacy.AgentSkill): V1AgentSkill {
     id: compat.id,
     name: compat.name,
     description: compat.description,
-    tags: compat.tags ? [...compat.tags] : [],
+    tags: [...requireArray(compat.tags, 'skill.tags')],
     examples: compat.examples ? [...compat.examples] : [],
     inputModes: compat.inputModes ? [...compat.inputModes] : [],
     outputModes: compat.outputModes ? [...compat.outputModes] : [],
@@ -125,7 +126,7 @@ export function toCompatAgentSkill(core: V1AgentSkill): legacy.AgentSkill {
     id: core.id,
     name: core.name,
     description: core.description,
-    tags: core.tags ? [...core.tags] : [],
+    tags: [...requireArray(core.tags, 'skill.tags')],
   };
   if (core.examples && core.examples.length > 0) result.examples = [...core.examples];
   if (core.inputModes && core.inputModes.length > 0) result.inputModes = [...core.inputModes];
@@ -170,7 +171,9 @@ export function toCoreAgentCard(compat: legacy.AgentCard): V1AgentCard {
   const additional = compat.additionalInterfaces?.map(toCoreAgentInterface) ?? [];
   const supportedInterfaces = [primary, ...additional];
 
-  const capabilities = toCoreAgentCapabilities(compat.capabilities ?? {});
+  const capabilities = toCoreAgentCapabilities(
+    requireObject(compat.capabilities, 'agentCard.capabilities')
+  );
   if (compat.supportsAuthenticatedExtendedCard !== undefined) {
     capabilities.extendedAgentCard = compat.supportsAuthenticatedExtendedCard;
   }
@@ -191,9 +194,11 @@ export function toCoreAgentCard(compat: legacy.AgentCard): V1AgentCard {
         )
       : {},
     securityRequirements: compat.security ? compat.security.map(toCoreSecurityRequirement) : [],
-    defaultInputModes: compat.defaultInputModes ? [...compat.defaultInputModes] : [],
-    defaultOutputModes: compat.defaultOutputModes ? [...compat.defaultOutputModes] : [],
-    skills: compat.skills ? compat.skills.map(toCoreAgentSkill) : [],
+    defaultInputModes: [...requireArray(compat.defaultInputModes, 'agentCard.defaultInputModes')],
+    defaultOutputModes: [
+      ...requireArray(compat.defaultOutputModes, 'agentCard.defaultOutputModes'),
+    ],
+    skills: requireArray(compat.skills, 'agentCard.skills').map(toCoreAgentSkill),
     signatures: compat.signatures ? compat.signatures.map(toCoreAgentCardSignature) : [],
   };
 
@@ -275,9 +280,9 @@ export function toCompatAgentCard(
     preferredTransport: primary.protocolBinding,
     protocolVersion: emittedProtocolVersion,
     capabilities,
-    defaultInputModes: core.defaultInputModes ? [...core.defaultInputModes] : [],
-    defaultOutputModes: core.defaultOutputModes ? [...core.defaultOutputModes] : [],
-    skills: (core.skills ?? []).map(toCompatAgentSkill),
+    defaultInputModes: [...requireArray(core.defaultInputModes, 'agentCard.defaultInputModes')],
+    defaultOutputModes: [...requireArray(core.defaultOutputModes, 'agentCard.defaultOutputModes')],
+    skills: requireArray(core.skills, 'agentCard.skills').map(toCompatAgentSkill),
   };
 
   if (additionalInterfaces.length > 0) {

--- a/src/compat/v0_3/translate/artifacts.ts
+++ b/src/compat/v0_3/translate/artifacts.ts
@@ -6,6 +6,7 @@ import { toCompatPart, toCorePart } from './parts.js';
 import type { Artifact as V1Artifact } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
 import { deepCloneMetadata } from './_clone.js';
+import { requireArray } from './_validate.js';
 
 function nonEmptyString(value: string | undefined | null): string | undefined {
   return value == null || value === '' ? undefined : value;
@@ -20,7 +21,7 @@ export function toCoreArtifact(compatArtifact: legacy.Artifact): V1Artifact {
     artifactId: compatArtifact.artifactId,
     name: compatArtifact.name ?? '',
     description: compatArtifact.description ?? '',
-    parts: compatArtifact.parts ? compatArtifact.parts.map(toCorePart) : [],
+    parts: requireArray(compatArtifact.parts, 'artifact.parts').map(toCorePart),
     metadata: deepCloneMetadata(compatArtifact.metadata),
     extensions: compatArtifact.extensions ? [...compatArtifact.extensions] : [],
   };
@@ -29,7 +30,7 @@ export function toCoreArtifact(compatArtifact: legacy.Artifact): V1Artifact {
 export function toCompatArtifact(coreArtifact: V1Artifact): legacy.Artifact {
   const result: legacy.Artifact = {
     artifactId: coreArtifact.artifactId,
-    parts: (coreArtifact.parts ?? []).map(toCompatPart),
+    parts: requireArray(coreArtifact.parts, 'artifact.parts').map(toCompatPart),
   };
 
   const name = nonEmptyString(coreArtifact.name);

--- a/src/compat/v0_3/translate/artifacts.ts
+++ b/src/compat/v0_3/translate/artifacts.ts
@@ -7,12 +7,12 @@ import type { Artifact as V1Artifact } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
 import { deepCloneMetadata } from './_clone.js';
 
-function nonEmptyString(value: string): string | undefined {
-  return value === '' ? undefined : value;
+function nonEmptyString(value: string | undefined | null): string | undefined {
+  return value == null || value === '' ? undefined : value;
 }
 
-function nonEmptyArray<T>(value: T[]): T[] | undefined {
-  return value.length === 0 ? undefined : [...value];
+function nonEmptyArray<T>(value: T[] | undefined | null): T[] | undefined {
+  return value == null || value.length === 0 ? undefined : [...value];
 }
 
 export function toCoreArtifact(compatArtifact: legacy.Artifact): V1Artifact {
@@ -20,7 +20,7 @@ export function toCoreArtifact(compatArtifact: legacy.Artifact): V1Artifact {
     artifactId: compatArtifact.artifactId,
     name: compatArtifact.name ?? '',
     description: compatArtifact.description ?? '',
-    parts: compatArtifact.parts.map(toCorePart),
+    parts: compatArtifact.parts ? compatArtifact.parts.map(toCorePart) : [],
     metadata: deepCloneMetadata(compatArtifact.metadata),
     extensions: compatArtifact.extensions ? [...compatArtifact.extensions] : [],
   };
@@ -29,7 +29,7 @@ export function toCoreArtifact(compatArtifact: legacy.Artifact): V1Artifact {
 export function toCompatArtifact(coreArtifact: V1Artifact): legacy.Artifact {
   const result: legacy.Artifact = {
     artifactId: coreArtifact.artifactId,
-    parts: coreArtifact.parts.map(toCompatPart),
+    parts: (coreArtifact.parts ?? []).map(toCompatPart),
   };
 
   const name = nonEmptyString(coreArtifact.name);

--- a/src/compat/v0_3/translate/messages.ts
+++ b/src/compat/v0_3/translate/messages.ts
@@ -9,6 +9,7 @@ import { A2AError } from '../server/error.js';
 import type { Message as V1Message } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
 import { deepCloneMetadata } from './_clone.js';
+import { requireArray } from './_validate.js';
 
 function nonEmptyString(value: string | undefined | null): string | undefined {
   return value == null || value === '' ? undefined : value;
@@ -48,7 +49,7 @@ export function toCompatMessage(coreMsg: V1Message): legacy.Message {
     kind: 'message',
     messageId: coreMsg.messageId,
     role: toCompatRole(coreMsg.role),
-    parts: (coreMsg.parts ?? []).map(toCompatPart),
+    parts: requireArray(coreMsg.parts, 'message.parts').map(toCompatPart),
   };
 
   const contextId = nonEmptyString(coreMsg.contextId);

--- a/src/compat/v0_3/translate/messages.ts
+++ b/src/compat/v0_3/translate/messages.ts
@@ -10,12 +10,12 @@ import type { Message as V1Message } from '../../../types/pb/a2a.js';
 import type * as legacy from '../types/types.js';
 import { deepCloneMetadata } from './_clone.js';
 
-function nonEmptyString(value: string): string | undefined {
-  return value === '' ? undefined : value;
+function nonEmptyString(value: string | undefined | null): string | undefined {
+  return value == null || value === '' ? undefined : value;
 }
 
-function nonEmptyArray<T>(value: T[]): T[] | undefined {
-  return value.length === 0 ? undefined : [...value];
+function nonEmptyArray<T>(value: T[] | undefined | null): T[] | undefined {
+  return value == null || value.length === 0 ? undefined : [...value];
 }
 
 export function toCoreMessage(compatMsg: legacy.Message): V1Message {
@@ -48,7 +48,7 @@ export function toCompatMessage(coreMsg: V1Message): legacy.Message {
     kind: 'message',
     messageId: coreMsg.messageId,
     role: toCompatRole(coreMsg.role),
-    parts: coreMsg.parts.map(toCompatPart),
+    parts: (coreMsg.parts ?? []).map(toCompatPart),
   };
 
   const contextId = nonEmptyString(coreMsg.contextId);

--- a/src/compat/v0_3/translate/requests.ts
+++ b/src/compat/v0_3/translate/requests.ts
@@ -65,7 +65,7 @@ export function toCompatSendMessageConfiguration(
   // absent/empty on the wire, so a round-trip from an explicit `[]`
   // stays stable; the only effect is callers who originally omitted it
   // see `[]` on the return path.
-  result.acceptedOutputModes = [...core.acceptedOutputModes];
+  result.acceptedOutputModes = core.acceptedOutputModes ? [...core.acceptedOutputModes] : [];
   if (core.historyLength !== undefined) result.historyLength = core.historyLength;
   if (core.taskPushNotificationConfig) {
     result.pushNotificationConfig = toCompatPushNotificationConfig(core.taskPushNotificationConfig);

--- a/src/compat/v0_3/translate/tasks.ts
+++ b/src/compat/v0_3/translate/tasks.ts
@@ -61,10 +61,10 @@ export function toCompatTask(coreTask: V1Task): legacy.Task {
     status: coreTask.status ? toCompatTaskStatus(coreTask.status) : { state: 'unknown' },
   };
 
-  if (coreTask.history.length > 0) {
+  if (coreTask.history && coreTask.history.length > 0) {
     result.history = coreTask.history.map(toCompatMessage);
   }
-  if (coreTask.artifacts.length > 0) {
+  if (coreTask.artifacts && coreTask.artifacts.length > 0) {
     result.artifacts = coreTask.artifacts.map(toCompatArtifact);
   }
   const metadata = deepCloneMetadata(coreTask.metadata);

--- a/test/compat/v0_3/translate/_validate.spec.ts
+++ b/test/compat/v0_3/translate/_validate.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { requireArray, requireObject } from '../../../../src/compat/v0_3/translate/_validate.js';
+import { A2AError } from '../../../../src/compat/v0_3/server/error.js';
+import { JSON_RPC_ERROR_CODE } from '../../../../src/errors/json_rpc.js';
+
+describe('_validate', () => {
+  describe('requireArray', () => {
+    it('returns the value when it is an array', () => {
+      const arr = [1, 2, 3];
+      expect(requireArray(arr, 'foo')).toBe(arr);
+    });
+
+    it('accepts an empty array', () => {
+      const arr: number[] = [];
+      expect(requireArray(arr, 'foo')).toBe(arr);
+    });
+
+    it.each([undefined, null, 'string', 42, {}, true])(
+      'throws A2AError.invalidParams for non-array input (%p)',
+      (value) => {
+        expect(() => requireArray(value as unknown as unknown[], 'foo.bar')).toThrowError(A2AError);
+        expect(() => requireArray(value as unknown as unknown[], 'foo.bar')).toThrow(
+          /foo\.bar is required and must be an array/
+        );
+      }
+    );
+
+    it('carries the JSON-RPC invalid-params code', () => {
+      try {
+        requireArray(undefined, 'x');
+        expect.fail('requireArray should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(A2AError);
+        expect(JSON_RPC_ERROR_CODE[(err as Error).name]).toBe(-32602);
+      }
+    });
+  });
+
+  describe('requireObject', () => {
+    it('returns the value when it is a plain object', () => {
+      const obj = { a: 1 };
+      expect(requireObject(obj, 'foo')).toBe(obj);
+    });
+
+    it.each([undefined, null])('throws for %p', (value) => {
+      expect(() => requireObject(value, 'foo.bar')).toThrowError(A2AError);
+      expect(() => requireObject(value, 'foo.bar')).toThrow(/foo\.bar is required/);
+    });
+
+    it('throws for a non-object primitive', () => {
+      expect(() => requireObject('str' as unknown as object, 'foo')).toThrowError(A2AError);
+    });
+
+    it('carries the JSON-RPC invalid-params code', () => {
+      try {
+        requireObject(undefined, 'x');
+        expect.fail('requireObject should have thrown');
+      } catch (err) {
+        expect(err).toBeInstanceOf(A2AError);
+        expect(JSON_RPC_ERROR_CODE[(err as Error).name]).toBe(-32602);
+      }
+    });
+  });
+});

--- a/test/compat/v0_3/translate/agent_card.spec.ts
+++ b/test/compat/v0_3/translate/agent_card.spec.ts
@@ -20,6 +20,7 @@ import { VersionNotSupportedError } from '../../../../src/errors/index.js';
 import type {
   AgentCard as V1AgentCard,
   AgentInterface as V1AgentInterface,
+  AgentSkill as V1AgentSkill,
 } from '../../../../src/types/pb/a2a.js';
 import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
 
@@ -473,7 +474,7 @@ describe('agent_card', () => {
       });
     });
 
-    describe('robust to missing v1.0 array/object fields', () => {
+    describe('robust to missing v0.3-optional fields on incoming core object', () => {
       function partialV1Card(overrides: Partial<V1AgentCard> = {}): V1AgentCard {
         return {
           name: 'Agent',
@@ -496,21 +497,18 @@ describe('agent_card', () => {
           },
           securitySchemes: undefined as unknown as V1AgentCard['securitySchemes'],
           securityRequirements: undefined as unknown as V1AgentCard['securityRequirements'],
-          defaultInputModes: undefined as unknown as V1AgentCard['defaultInputModes'],
-          defaultOutputModes: undefined as unknown as V1AgentCard['defaultOutputModes'],
-          skills: undefined as unknown as V1AgentCard['skills'],
+          defaultInputModes: [],
+          defaultOutputModes: [],
+          skills: [],
           signatures: undefined as unknown as V1AgentCard['signatures'],
           ...overrides,
         };
       }
 
-      it('does not crash when every declared-required array/object field is missing at once', () => {
+      it('does not crash when every optional field is missing at once', () => {
         expect(() => toCompatAgentCard(partialV1Card())).not.toThrow();
         const compat = toCompatAgentCard(partialV1Card());
         expect(compat.url).toBe('https://api.example/legacy');
-        expect(compat.defaultInputModes).toEqual([]);
-        expect(compat.defaultOutputModes).toEqual([]);
-        expect(compat.skills).toEqual([]);
         expect(compat.securitySchemes).toBeUndefined();
         expect(compat.security).toBeUndefined();
         expect(compat.signatures).toBeUndefined();
@@ -528,18 +526,18 @@ describe('agent_card', () => {
         expect(compat.extensions).toBeUndefined();
       });
 
-      it('toCompatAgentSkill does not crash when tags is missing', () => {
+      it('toCompatAgentSkill does not crash when all optional arrays are missing', () => {
         const compat = toCompatAgentSkill({
           id: 's1',
           name: 'Skill',
           description: 'desc',
-          tags: undefined as unknown as string[],
+          tags: ['t'],
           examples: undefined as unknown as string[],
           inputModes: undefined as unknown as string[],
           outputModes: undefined as unknown as string[],
           securityRequirements: undefined as unknown as never[],
         });
-        expect(compat.tags).toEqual([]);
+        expect(compat.tags).toEqual(['t']);
         expect(compat.examples).toBeUndefined();
         expect(compat.inputModes).toBeUndefined();
         expect(compat.outputModes).toBeUndefined();
@@ -547,55 +545,102 @@ describe('agent_card', () => {
       });
     });
 
-    describe('toCoreAgentCard robust to missing v0.3 array/object fields', () => {
-      function partialCompatCard(overrides: Partial<legacy.AgentCard> = {}): legacy.AgentCard {
-        return {
+    describe('reports informative errors for missing required fields', () => {
+      it.each([['skill.tags', { id: 's1', name: 'Skill', description: 'desc' }]] as const)(
+        'toCoreAgentSkill throws when %s is missing',
+        (path, skill) => {
+          expect(() => toCoreAgentSkill(skill as unknown as legacy.AgentSkill)).toThrow(
+            new RegExp(`${path.replace('.', '\\.')} is required`)
+          );
+        }
+      );
+
+      it('toCompatAgentSkill throws when tags is missing', () => {
+        const core = {
+          id: 's1',
+          name: 'Skill',
+          description: 'desc',
+          examples: [],
+          inputModes: [],
+          outputModes: [],
+          securityRequirements: [],
+        } as unknown as V1AgentSkill;
+        expect(() => toCompatAgentSkill(core)).toThrow(/skill\.tags is required/);
+      });
+
+      it('toCoreAgentCard throws when capabilities is missing', () => {
+        const compat = {
           name: 'Agent',
           description: 'desc',
           version: '1.2.3',
           url: 'https://api.example/a2a',
           preferredTransport: 'JSONRPC',
           protocolVersion: '0.3',
-          capabilities: undefined as unknown as legacy.AgentCapabilities1,
-          defaultInputModes: undefined as unknown as string[],
-          defaultOutputModes: undefined as unknown as string[],
-          skills: undefined as unknown as legacy.AgentSkill[],
-          ...overrides,
-        };
-      }
-
-      it('does not crash when capabilities is missing', () => {
-        expect(() =>
-          toCoreAgentCard(
-            partialCompatCard({
-              defaultInputModes: [],
-              defaultOutputModes: [],
-              skills: [],
-            })
-          )
-        ).not.toThrow();
+          defaultInputModes: [],
+          defaultOutputModes: [],
+          skills: [],
+        } as unknown as legacy.AgentCard;
+        expect(() => toCoreAgentCard(compat)).toThrow(/agentCard\.capabilities is required/);
       });
 
-      it('does not crash when defaultInputModes / defaultOutputModes / skills are missing', () => {
-        expect(() => toCoreAgentCard(partialCompatCard({ capabilities: {} }))).not.toThrow();
-        const core = toCoreAgentCard(partialCompatCard({ capabilities: {} }));
-        expect(core.defaultInputModes).toEqual([]);
-        expect(core.defaultOutputModes).toEqual([]);
-        expect(core.skills).toEqual([]);
-      });
-
-      it('does not crash when every declared-required field is missing at once', () => {
-        expect(() => toCoreAgentCard(partialCompatCard())).not.toThrow();
-      });
-
-      it('toCoreAgentSkill does not crash when tags is missing', () => {
-        const skill = {
-          id: 's1',
-          name: 'Skill',
+      it.each([
+        ['agentCard.defaultInputModes', 'defaultInputModes'],
+        ['agentCard.defaultOutputModes', 'defaultOutputModes'],
+        ['agentCard.skills', 'skills'],
+      ] as const)('toCoreAgentCard throws when %s is missing', (path, missingField) => {
+        const compat = {
+          name: 'Agent',
           description: 'desc',
-        } as unknown as legacy.AgentSkill;
-        expect(() => toCoreAgentSkill(skill)).not.toThrow();
-        expect(toCoreAgentSkill(skill).tags).toEqual([]);
+          version: '1.2.3',
+          url: 'https://api.example/a2a',
+          preferredTransport: 'JSONRPC',
+          protocolVersion: '0.3',
+          capabilities: {},
+          defaultInputModes: [],
+          defaultOutputModes: [],
+          skills: [],
+        } as unknown as Record<string, unknown>;
+        delete compat[missingField];
+        expect(() => toCoreAgentCard(compat as unknown as legacy.AgentCard)).toThrow(
+          new RegExp(`${path.replace('.', '\\.')} is required`)
+        );
+      });
+
+      it.each([
+        ['agentCard.defaultInputModes', 'defaultInputModes'],
+        ['agentCard.defaultOutputModes', 'defaultOutputModes'],
+        ['agentCard.skills', 'skills'],
+      ] as const)('toCompatAgentCard throws when %s is missing', (path, missingField) => {
+        const core = {
+          name: 'Agent',
+          description: 'desc',
+          version: '1.2.3',
+          supportedInterfaces: [
+            {
+              url: 'https://api.example/legacy',
+              protocolBinding: 'JSONRPC',
+              tenant: '',
+              protocolVersion: '0.3',
+            },
+          ],
+          provider: undefined,
+          capabilities: {
+            streaming: undefined,
+            pushNotifications: undefined,
+            extensions: [],
+            extendedAgentCard: undefined,
+          },
+          securitySchemes: {},
+          securityRequirements: [],
+          defaultInputModes: [],
+          defaultOutputModes: [],
+          skills: [],
+          signatures: [],
+        } as unknown as Record<string, unknown>;
+        delete core[missingField];
+        expect(() => toCompatAgentCard(core as unknown as V1AgentCard)).toThrow(
+          new RegExp(`${path.replace('.', '\\.')} is required`)
+        );
       });
     });
   });

--- a/test/compat/v0_3/translate/agent_card.spec.ts
+++ b/test/compat/v0_3/translate/agent_card.spec.ts
@@ -472,5 +472,131 @@ describe('agent_card', () => {
         expect(out).toEqual([]);
       });
     });
+
+    describe('robust to missing v1.0 array/object fields', () => {
+      function partialV1Card(overrides: Partial<V1AgentCard> = {}): V1AgentCard {
+        return {
+          name: 'Agent',
+          description: 'desc',
+          version: '1.2.3',
+          supportedInterfaces: [
+            {
+              url: 'https://api.example/legacy',
+              protocolBinding: 'JSONRPC',
+              tenant: '',
+              protocolVersion: '0.3',
+            },
+          ],
+          provider: undefined,
+          capabilities: {
+            streaming: undefined,
+            pushNotifications: undefined,
+            extensions: undefined as unknown as never[],
+            extendedAgentCard: undefined,
+          },
+          securitySchemes: undefined as unknown as V1AgentCard['securitySchemes'],
+          securityRequirements: undefined as unknown as V1AgentCard['securityRequirements'],
+          defaultInputModes: undefined as unknown as V1AgentCard['defaultInputModes'],
+          defaultOutputModes: undefined as unknown as V1AgentCard['defaultOutputModes'],
+          skills: undefined as unknown as V1AgentCard['skills'],
+          signatures: undefined as unknown as V1AgentCard['signatures'],
+          ...overrides,
+        };
+      }
+
+      it('does not crash when every declared-required array/object field is missing at once', () => {
+        expect(() => toCompatAgentCard(partialV1Card())).not.toThrow();
+        const compat = toCompatAgentCard(partialV1Card());
+        expect(compat.url).toBe('https://api.example/legacy');
+        expect(compat.defaultInputModes).toEqual([]);
+        expect(compat.defaultOutputModes).toEqual([]);
+        expect(compat.skills).toEqual([]);
+        expect(compat.securitySchemes).toBeUndefined();
+        expect(compat.security).toBeUndefined();
+        expect(compat.signatures).toBeUndefined();
+      });
+
+      it('toCompatAgentCapabilities does not crash when extensions is missing', () => {
+        const compat = toCompatAgentCapabilities({
+          streaming: true,
+          pushNotifications: false,
+          extensions: undefined as unknown as never[],
+          extendedAgentCard: undefined,
+        });
+        expect(compat.streaming).toBe(true);
+        expect(compat.pushNotifications).toBe(false);
+        expect(compat.extensions).toBeUndefined();
+      });
+
+      it('toCompatAgentSkill does not crash when tags is missing', () => {
+        const compat = toCompatAgentSkill({
+          id: 's1',
+          name: 'Skill',
+          description: 'desc',
+          tags: undefined as unknown as string[],
+          examples: undefined as unknown as string[],
+          inputModes: undefined as unknown as string[],
+          outputModes: undefined as unknown as string[],
+          securityRequirements: undefined as unknown as never[],
+        });
+        expect(compat.tags).toEqual([]);
+        expect(compat.examples).toBeUndefined();
+        expect(compat.inputModes).toBeUndefined();
+        expect(compat.outputModes).toBeUndefined();
+        expect(compat.security).toBeUndefined();
+      });
+    });
+
+    describe('toCoreAgentCard robust to missing v0.3 array/object fields', () => {
+      function partialCompatCard(overrides: Partial<legacy.AgentCard> = {}): legacy.AgentCard {
+        return {
+          name: 'Agent',
+          description: 'desc',
+          version: '1.2.3',
+          url: 'https://api.example/a2a',
+          preferredTransport: 'JSONRPC',
+          protocolVersion: '0.3',
+          capabilities: undefined as unknown as legacy.AgentCapabilities1,
+          defaultInputModes: undefined as unknown as string[],
+          defaultOutputModes: undefined as unknown as string[],
+          skills: undefined as unknown as legacy.AgentSkill[],
+          ...overrides,
+        };
+      }
+
+      it('does not crash when capabilities is missing', () => {
+        expect(() =>
+          toCoreAgentCard(
+            partialCompatCard({
+              defaultInputModes: [],
+              defaultOutputModes: [],
+              skills: [],
+            })
+          )
+        ).not.toThrow();
+      });
+
+      it('does not crash when defaultInputModes / defaultOutputModes / skills are missing', () => {
+        expect(() => toCoreAgentCard(partialCompatCard({ capabilities: {} }))).not.toThrow();
+        const core = toCoreAgentCard(partialCompatCard({ capabilities: {} }));
+        expect(core.defaultInputModes).toEqual([]);
+        expect(core.defaultOutputModes).toEqual([]);
+        expect(core.skills).toEqual([]);
+      });
+
+      it('does not crash when every declared-required field is missing at once', () => {
+        expect(() => toCoreAgentCard(partialCompatCard())).not.toThrow();
+      });
+
+      it('toCoreAgentSkill does not crash when tags is missing', () => {
+        const skill = {
+          id: 's1',
+          name: 'Skill',
+          description: 'desc',
+        } as unknown as legacy.AgentSkill;
+        expect(() => toCoreAgentSkill(skill)).not.toThrow();
+        expect(toCoreAgentSkill(skill).tags).toEqual([]);
+      });
+    });
   });
 });

--- a/test/compat/v0_3/translate/artifacts.spec.ts
+++ b/test/compat/v0_3/translate/artifacts.spec.ts
@@ -85,4 +85,37 @@ describe('artifacts', () => {
       expect(toCompatArtifact(toCoreArtifact(compat))).toEqual(compat);
     });
   });
+
+  describe('tolerates missing array fields', () => {
+    it('toCompatArtifact does not crash when extensions is missing', () => {
+      const core = {
+        artifactId: 'a1',
+        name: '',
+        description: '',
+        parts: [],
+        metadata: undefined,
+      } as unknown as V1Artifact;
+      expect(() => toCompatArtifact(core)).not.toThrow();
+      const compat = toCompatArtifact(core);
+      expect(compat.extensions).toBeUndefined();
+    });
+
+    it('toCompatArtifact does not crash when parts is missing', () => {
+      const core = {
+        artifactId: 'a1',
+        name: '',
+        description: '',
+        metadata: undefined,
+        extensions: [],
+      } as unknown as V1Artifact;
+      expect(() => toCompatArtifact(core)).not.toThrow();
+      expect(toCompatArtifact(core).parts).toEqual([]);
+    });
+
+    it('toCoreArtifact does not crash when parts is missing on a v0.3 artifact', () => {
+      const compat = { artifactId: 'a1' } as unknown as legacy.Artifact;
+      expect(() => toCoreArtifact(compat)).not.toThrow();
+      expect(toCoreArtifact(compat).parts).toEqual([]);
+    });
+  });
 });

--- a/test/compat/v0_3/translate/artifacts.spec.ts
+++ b/test/compat/v0_3/translate/artifacts.spec.ts
@@ -3,6 +3,7 @@ import {
   toCompatArtifact,
   toCoreArtifact,
 } from '../../../../src/compat/v0_3/translate/artifacts.js';
+import { A2AError } from '../../../../src/compat/v0_3/server/error.js';
 import type { Artifact as V1Artifact } from '../../../../src/types/pb/a2a.js';
 import type * as legacy from '../../../../src/compat/v0_3/types/types.js';
 
@@ -86,7 +87,7 @@ describe('artifacts', () => {
     });
   });
 
-  describe('tolerates missing array fields', () => {
+  describe('tolerates missing v0.3-optional fields', () => {
     it('toCompatArtifact does not crash when extensions is missing', () => {
       const core = {
         artifactId: 'a1',
@@ -96,26 +97,21 @@ describe('artifacts', () => {
         metadata: undefined,
       } as unknown as V1Artifact;
       expect(() => toCompatArtifact(core)).not.toThrow();
-      const compat = toCompatArtifact(core);
-      expect(compat.extensions).toBeUndefined();
+      expect(toCompatArtifact(core).extensions).toBeUndefined();
+    });
+  });
+
+  describe('reports informative errors for missing required fields', () => {
+    it('toCompatArtifact throws A2AError.invalidParams when parts is missing', () => {
+      const core = { artifactId: 'a1' } as unknown as V1Artifact;
+      expect(() => toCompatArtifact(core)).toThrowError(A2AError);
+      expect(() => toCompatArtifact(core)).toThrow(/artifact\.parts is required/);
     });
 
-    it('toCompatArtifact does not crash when parts is missing', () => {
-      const core = {
-        artifactId: 'a1',
-        name: '',
-        description: '',
-        metadata: undefined,
-        extensions: [],
-      } as unknown as V1Artifact;
-      expect(() => toCompatArtifact(core)).not.toThrow();
-      expect(toCompatArtifact(core).parts).toEqual([]);
-    });
-
-    it('toCoreArtifact does not crash when parts is missing on a v0.3 artifact', () => {
+    it('toCoreArtifact throws A2AError.invalidParams when parts is missing', () => {
       const compat = { artifactId: 'a1' } as unknown as legacy.Artifact;
-      expect(() => toCoreArtifact(compat)).not.toThrow();
-      expect(toCoreArtifact(compat).parts).toEqual([]);
+      expect(() => toCoreArtifact(compat)).toThrowError(A2AError);
+      expect(() => toCoreArtifact(compat)).toThrow(/artifact\.parts is required/);
     });
   });
 });

--- a/test/compat/v0_3/translate/messages.spec.ts
+++ b/test/compat/v0_3/translate/messages.spec.ts
@@ -221,14 +221,14 @@ describe('messages', () => {
     });
   });
 
-  describe('tolerates missing v1.0 array fields', () => {
+  describe('tolerates missing v0.3-optional fields', () => {
     function makePartialCore(overrides: Partial<V1Message> = {}): V1Message {
       return {
         messageId: 'msg-1',
         contextId: '',
         taskId: '',
         role: Role.ROLE_USER,
-        parts: undefined as unknown as V1Message['parts'],
+        parts: [],
         metadata: undefined,
         extensions: undefined as unknown as V1Message['extensions'],
         referenceTaskIds: undefined as unknown as V1Message['referenceTaskIds'],
@@ -237,36 +237,18 @@ describe('messages', () => {
     }
 
     it('does not crash when referenceTaskIds is missing', () => {
-      const core = makePartialCore({
-        parts: [{ content: { $case: 'text', value: 'hi' } } as V1Message['parts'][number]],
-        extensions: [],
-      });
+      const core = makePartialCore({ extensions: [] });
       expect(() => toCompatMessage(core)).not.toThrow();
-      const compat = toCompatMessage(core);
-      expect(compat.referenceTaskIds).toBeUndefined();
+      expect(toCompatMessage(core).referenceTaskIds).toBeUndefined();
     });
 
     it('does not crash when extensions is missing', () => {
-      const core = makePartialCore({
-        parts: [],
-        referenceTaskIds: [],
-      });
+      const core = makePartialCore({ referenceTaskIds: [] });
       expect(() => toCompatMessage(core)).not.toThrow();
-      const compat = toCompatMessage(core);
-      expect(compat.extensions).toBeUndefined();
+      expect(toCompatMessage(core).extensions).toBeUndefined();
     });
 
-    it('does not crash when parts is missing', () => {
-      const core = makePartialCore({
-        extensions: [],
-        referenceTaskIds: [],
-      });
-      expect(() => toCompatMessage(core)).not.toThrow();
-      const compat = toCompatMessage(core);
-      expect(compat.parts).toEqual([]);
-    });
-
-    it('does not crash when every optional-in-practice field is missing at once', () => {
+    it('does not crash when both optional array fields are missing at once', () => {
       const core = makePartialCore();
       expect(() => toCompatMessage(core)).not.toThrow();
       expect(toCompatMessage(core)).toEqual({
@@ -277,17 +259,32 @@ describe('messages', () => {
       });
     });
 
-    it('tolerates null just like undefined', () => {
+    it('tolerates null just like undefined for optional fields', () => {
       const core = makePartialCore({
-        parts: null as unknown as V1Message['parts'],
         extensions: null as unknown as V1Message['extensions'],
         referenceTaskIds: null as unknown as V1Message['referenceTaskIds'],
       });
       expect(() => toCompatMessage(core)).not.toThrow();
       const compat = toCompatMessage(core);
-      expect(compat.parts).toEqual([]);
       expect(compat.extensions).toBeUndefined();
       expect(compat.referenceTaskIds).toBeUndefined();
+    });
+  });
+
+  describe('reports informative errors for missing required fields', () => {
+    it('toCompatMessage throws A2AError.invalidParams when parts is missing', () => {
+      const core = {
+        messageId: 'msg-1',
+        contextId: '',
+        taskId: '',
+        role: Role.ROLE_USER,
+        parts: undefined,
+        metadata: undefined,
+        extensions: [],
+        referenceTaskIds: [],
+      } as unknown as V1Message;
+      expect(() => toCompatMessage(core)).toThrowError(A2AError);
+      expect(() => toCompatMessage(core)).toThrow(/message\.parts is required/);
     });
   });
 });

--- a/test/compat/v0_3/translate/messages.spec.ts
+++ b/test/compat/v0_3/translate/messages.spec.ts
@@ -220,4 +220,74 @@ describe('messages', () => {
       expect(nested.tags).toEqual(['a', 'b']);
     });
   });
+
+  describe('tolerates missing v1.0 array fields', () => {
+    function makePartialCore(overrides: Partial<V1Message> = {}): V1Message {
+      return {
+        messageId: 'msg-1',
+        contextId: '',
+        taskId: '',
+        role: Role.ROLE_USER,
+        parts: undefined as unknown as V1Message['parts'],
+        metadata: undefined,
+        extensions: undefined as unknown as V1Message['extensions'],
+        referenceTaskIds: undefined as unknown as V1Message['referenceTaskIds'],
+        ...overrides,
+      };
+    }
+
+    it('does not crash when referenceTaskIds is missing', () => {
+      const core = makePartialCore({
+        parts: [{ content: { $case: 'text', value: 'hi' } } as V1Message['parts'][number]],
+        extensions: [],
+      });
+      expect(() => toCompatMessage(core)).not.toThrow();
+      const compat = toCompatMessage(core);
+      expect(compat.referenceTaskIds).toBeUndefined();
+    });
+
+    it('does not crash when extensions is missing', () => {
+      const core = makePartialCore({
+        parts: [],
+        referenceTaskIds: [],
+      });
+      expect(() => toCompatMessage(core)).not.toThrow();
+      const compat = toCompatMessage(core);
+      expect(compat.extensions).toBeUndefined();
+    });
+
+    it('does not crash when parts is missing', () => {
+      const core = makePartialCore({
+        extensions: [],
+        referenceTaskIds: [],
+      });
+      expect(() => toCompatMessage(core)).not.toThrow();
+      const compat = toCompatMessage(core);
+      expect(compat.parts).toEqual([]);
+    });
+
+    it('does not crash when every optional-in-practice field is missing at once', () => {
+      const core = makePartialCore();
+      expect(() => toCompatMessage(core)).not.toThrow();
+      expect(toCompatMessage(core)).toEqual({
+        kind: 'message',
+        messageId: 'msg-1',
+        role: 'user',
+        parts: [],
+      });
+    });
+
+    it('tolerates null just like undefined', () => {
+      const core = makePartialCore({
+        parts: null as unknown as V1Message['parts'],
+        extensions: null as unknown as V1Message['extensions'],
+        referenceTaskIds: null as unknown as V1Message['referenceTaskIds'],
+      });
+      expect(() => toCompatMessage(core)).not.toThrow();
+      const compat = toCompatMessage(core);
+      expect(compat.parts).toEqual([]);
+      expect(compat.extensions).toBeUndefined();
+      expect(compat.referenceTaskIds).toBeUndefined();
+    });
+  });
 });

--- a/test/compat/v0_3/translate/requests.spec.ts
+++ b/test/compat/v0_3/translate/requests.spec.ts
@@ -189,7 +189,7 @@ describe('requests', () => {
       ).toThrow(A2AError);
     });
 
-    it('does not crash when the v1 message omits referenceTaskIds/extensions/parts', () => {
+    it('does not crash when the v1 message omits referenceTaskIds and extensions', () => {
       const core = {
         tenant: '',
         message: {
@@ -197,6 +197,7 @@ describe('requests', () => {
           contextId: '',
           taskId: '',
           role: Role.ROLE_USER,
+          parts: [],
         } as unknown as V1SendMessageRequest['message'],
         configuration: undefined,
         metadata: undefined,

--- a/test/compat/v0_3/translate/requests.spec.ts
+++ b/test/compat/v0_3/translate/requests.spec.ts
@@ -93,6 +93,17 @@ describe('requests', () => {
       const back = toCompatSendMessageConfiguration(toCoreSendMessageConfiguration(compat));
       expect(back.acceptedOutputModes).toEqual([]);
     });
+
+    it('does not crash when acceptedOutputModes is missing on the core side', () => {
+      const compat = toCompatSendMessageConfiguration({
+        acceptedOutputModes: undefined as unknown as string[],
+        taskPushNotificationConfig: undefined,
+        historyLength: undefined,
+        returnImmediately: false,
+      });
+      expect(compat.acceptedOutputModes).toEqual([]);
+      expect(compat.blocking).toBe(true);
+    });
   });
 
   describe('SendMessageRequest', () => {
@@ -176,6 +187,32 @@ describe('requests', () => {
           'r1'
         )
       ).toThrow(A2AError);
+    });
+
+    it('does not crash when the v1 message omits referenceTaskIds/extensions/parts', () => {
+      const core = {
+        tenant: '',
+        message: {
+          messageId: 'msg-1',
+          contextId: '',
+          taskId: '',
+          role: Role.ROLE_USER,
+        } as unknown as V1SendMessageRequest['message'],
+        configuration: undefined,
+        metadata: undefined,
+      } as V1SendMessageRequest;
+
+      expect(() => toCompatSendMessageRequest(core, 'req-1')).not.toThrow();
+      expect(() => toCompatSendStreamingMessageRequest(core, 'req-1')).not.toThrow();
+
+      const compat = toCompatSendStreamingMessageRequest(core, 'req-1');
+      expect(compat.method).toBe('message/stream');
+      expect(compat.params.message).toEqual({
+        kind: 'message',
+        messageId: 'msg-1',
+        role: 'user',
+        parts: [],
+      });
     });
   });
 

--- a/test/compat/v0_3/translate/tasks.spec.ts
+++ b/test/compat/v0_3/translate/tasks.spec.ts
@@ -248,4 +248,38 @@ describe('tasks', () => {
       expect(toCompatTask(toCoreTask(compat))).toEqual(compat);
     });
   });
+
+  describe('toCompatTask tolerates missing v1.0 array fields', () => {
+    function makePartialCore(overrides: Partial<V1Task> = {}): V1Task {
+      return {
+        id: 't1',
+        contextId: 'ctx',
+        status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: '' },
+        history: undefined as unknown as V1Task['history'],
+        artifacts: undefined as unknown as V1Task['artifacts'],
+        metadata: undefined,
+        ...overrides,
+      };
+    }
+
+    it('does not crash when history is missing', () => {
+      const core = makePartialCore({ artifacts: [] });
+      expect(() => toCompatTask(core)).not.toThrow();
+      expect(toCompatTask(core).history).toBeUndefined();
+    });
+
+    it('does not crash when artifacts is missing', () => {
+      const core = makePartialCore({ history: [] });
+      expect(() => toCompatTask(core)).not.toThrow();
+      expect(toCompatTask(core).artifacts).toBeUndefined();
+    });
+
+    it('does not crash when both are missing', () => {
+      const core = makePartialCore();
+      expect(() => toCompatTask(core)).not.toThrow();
+      const compat = toCompatTask(core);
+      expect(compat.history).toBeUndefined();
+      expect(compat.artifacts).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
# Description

The v0.3 compat translators dereferenced V1/legacy array/object fields without any guard, so a partial object crashed with TypeError: Cannot read properties of undefined (reading 'length') inside nonEmptyArray.

Two-part fix:
1. Optional v0.3 fields (referenceTaskIds, extensions, history, artifacts, signatures, securitySchemes, securityRequirements, examples/inputModes/outputModes, acceptedOutputModes) — silently coerced to []/undefined when missing. nonEmptyArray/nonEmptyString helpers now accept T[] | undefined | null / string | undefined | null.
2. Required v0.3 fields (parts, tags, capabilities, defaultInputModes, defaultOutputModes, skills) — new requireArray / requireObject helpers in _validate.ts throw A2AError.invalidParams with the field path (e.g. message.parts is required and must be an array) instead of a native TypeError. Existing strict validation in toCoreMessage preserved.

Fixes #616 🦕
