### PR TITLE
fix: Do not filter tasks in ListTasks if task state is unspecified

### DIFF
--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -1,4 +1,4 @@
-import { Task, ListTasksRequest, ListTasksResponse } from '../index.js';
+import { Task, ListTasksRequest, ListTasksResponse, TaskState } from '../index.js';
 import { ServerCallContext } from './context.js';
 import { DEFAULT_PAGE_SIZE } from '../constants.js';
 import { RequestMalformedError } from '../errors/index.js';
@@ -81,7 +81,7 @@ export class InMemoryTaskStore implements TaskStore {
       tasks = tasks.filter((task) => task.contextId === contextId);
     }
 
-    if (status !== undefined) {
+    if (status !== undefined && status !== TaskState.TASK_STATE_UNSPECIFIED) {
       tasks = tasks.filter((task) => task.status?.state === status);
     }
 

--- a/test/e2e.spec.ts
+++ b/test/e2e.spec.ts
@@ -10,7 +10,15 @@ import {
   RequestContext,
 } from '../src/server/index.js';
 import { AgentEvent } from '../src/server/events/execution_event_bus.js';
-import { AgentCard, Message, Role, Task, TaskState, StreamResponse } from '../src/index.js';
+import {
+  AgentCard,
+  ListTasksRequest,
+  Message,
+  Role,
+  Task,
+  TaskState,
+  StreamResponse,
+} from '../src/index.js';
 import {
   TaskNotFoundError,
   TaskNotCancelableError,
@@ -179,6 +187,69 @@ describe('Client E2E tests', () => {
             metadata: {},
           });
           expect(removeUndefinedFields(actual)).to.deep.equal(removeUndefinedFields(expected));
+        });
+      });
+
+      describe('listTasks', () => {
+        const storedTask: Task = {
+          id: 'list-1',
+          contextId: 'list-ctx',
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            timestamp: undefined,
+            message: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        };
+
+        const listParams: ListTasksRequest = {
+          tenant: '',
+          contextId: '',
+          status: TaskState.TASK_STATE_UNSPECIFIED,
+          pageSize: 10,
+          pageToken: '',
+          historyLength: undefined,
+          statusTimestampAfter: undefined,
+          includeArtifacts: false,
+        };
+
+        beforeEach(async () => {
+          agentExecutor.events = [AgentEvent.task(storedTask)];
+          const seedClient = await clientFactory.createFromAgentCard(agentCard);
+          await seedClient.sendMessage({
+            tenant: '',
+            message: createTestMessage('seed', 'seed'),
+            configuration: undefined,
+            metadata: {},
+          });
+        });
+
+        it('should list tasks when no status filter is supplied', async () => {
+          const client = await clientFactory.createFromAgentCard(agentCard);
+
+          const result = await client.listTasks(listParams);
+
+          expect(result.tasks).to.have.lengthOf(1);
+          expect(result.tasks[0].id).to.equal(storedTask.id);
+          expect(result.totalSize).to.equal(1);
+        });
+
+        it('should still honour an explicit status filter', async () => {
+          const client = await clientFactory.createFromAgentCard(agentCard);
+
+          const matching = await client.listTasks({
+            ...listParams,
+            status: TaskState.TASK_STATE_COMPLETED,
+          });
+          expect(matching.tasks).to.have.lengthOf(1);
+
+          const nonMatching = await client.listTasks({
+            ...listParams,
+            status: TaskState.TASK_STATE_WORKING,
+          });
+          expect(nonMatching.tasks).to.have.lengthOf(0);
         });
       });
 

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -2049,6 +2049,76 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     assert.equal(result.tasks[1].id, fakeTask1.id);
   });
 
+  describe('listTasks: status filter', () => {
+    const listedTask: Task = {
+      id: 'task-status-filter',
+      contextId: 'ctx-status-filter',
+      status: {
+        state: TaskState.TASK_STATE_COMPLETED,
+        message: undefined,
+        timestamp: new Date().toISOString(),
+      },
+      artifacts: [],
+      metadata: {},
+      history: [],
+    };
+
+    beforeEach(async () => {
+      await mockTaskStore.save(listedTask, serverCallContext);
+    });
+
+    it('returns every task when the wire request omits status', async () => {
+      const params = ListTasksRequest.fromJSON({ pageSize: 10 });
+      assert.equal(
+        params.status,
+        TaskState.TASK_STATE_UNSPECIFIED,
+        'an omitted status must deserialize to the zero value'
+      );
+
+      const result = await handler.listTasks(params, serverCallContext);
+
+      assert.lengthOf(result.tasks, 1, 'an unfiltered list must not filter anything out');
+      assert.equal(result.tasks[0].id, listedTask.id);
+      assert.equal(result.totalSize, 1);
+    });
+
+    it('returns every task when status is explicitly TASK_STATE_UNSPECIFIED', async () => {
+      const params = ListTasksRequest.fromJSON({ pageSize: 10 });
+      params.status = TaskState.TASK_STATE_UNSPECIFIED;
+
+      const result = await handler.listTasks(params, serverCallContext);
+
+      assert.lengthOf(result.tasks, 1);
+      assert.equal(result.totalSize, 1);
+    });
+
+    it('still filters when a real status is supplied', async () => {
+      const matching = await handler.listTasks(
+        ListTasksRequest.fromJSON({ pageSize: 10, status: 'TASK_STATE_COMPLETED' }),
+        serverCallContext
+      );
+      assert.lengthOf(matching.tasks, 1);
+      assert.equal(matching.totalSize, 1);
+
+      const nonMatching = await handler.listTasks(
+        ListTasksRequest.fromJSON({ pageSize: 10, status: 'TASK_STATE_WORKING' }),
+        serverCallContext
+      );
+      assert.lengthOf(nonMatching.tasks, 0);
+      assert.equal(nonMatching.totalSize, 0);
+    });
+
+    it('matches nothing for an unrecognized status rather than listing everything', async () => {
+      const params = ListTasksRequest.fromJSON({ pageSize: 10, status: 'NOT_A_REAL_STATE' });
+      assert.equal(params.status, TaskState.UNRECOGNIZED);
+
+      const result = await handler.listTasks(params, serverCallContext);
+
+      assert.lengthOf(result.tasks, 0);
+      assert.equal(result.totalSize, 0);
+    });
+  });
+
   it('listTasks: should throw RequestMalformedError if pageSize is < 1', async () => {
     const params: ListTasksRequest = {
       tenant: '',


### PR DESCRIPTION
# Description

An unfiltered ListTasks returned zero tasks on every binding.

`ListTasksRequest.status` is a non-optional proto enum, so a request that omits the filter deserializes to the zero value `TASK_STATE_UNSPECIFIED` rather than undefined. `InMemoryTaskStore.list` guarded on `status !== undefined`, so it treated "no filter" as "filter for `TASK_STATE_UNSPECIFIED`" and filtered every task out. `totalSize` is computed after filtering, so it reported 0 too.

This affected JSON-RPC, REST and gRPC alike, since the zero value is produced at the transport boundary. The SDK's own client could not list tasks against the SDK's own server: the client already omits the param when the status is `TASK_STATE_UNSPECIFIED`, and the server then re-materialised it as a filter.

Fixes #614 🦕
