### PR TITLE
fix: apply historyLength trimming on tasks/resubscribe snapshot

### DIFF
--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -388,7 +388,8 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
     const stream = await restTransportHandler.resubscribe(
       req.params.taskId,
       context,
-      (req.query.tenant as string) || ''
+      (req.query.tenant as string) || '',
+      req.query.historyLength
     );
     await sendStreamResponse(res, stream, context);
   };

--- a/src/server/request_handler/a2a_request_handler.ts
+++ b/src/server/request_handler/a2a_request_handler.ts
@@ -57,7 +57,7 @@ export interface A2ARequestHandler {
   ): Promise<void>;
 
   resubscribe(
-    params: SubscribeToTaskRequest,
+    params: SubscribeToTaskRequest & { historyLength?: number },
     context: ServerCallContext
   ): AsyncGenerator<StreamResponse, void, undefined>;
 

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -894,7 +894,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   }
 
   async *resubscribe(
-    params: SubscribeToTaskRequest,
+    params: SubscribeToTaskRequest & { historyLength?: number },
     context: ServerCallContext
   ): AsyncGenerator<StreamResponse, void, undefined> {
     if (!this.agentCard.capabilities?.streaming) {
@@ -902,6 +902,17 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     }
 
     const taskId = params.id;
+
+    // historyLength is not part of the canonical `SubscribeToTaskRequest`
+    // wire type, so validate it here (mirrors `parseHistoryLength` in the
+    // REST transport). NaN would otherwise bypass the `<= 0` check and
+    // `slice(-NaN)` → `slice(0)` would yield the full history.
+    if (params.historyLength !== undefined && !Number.isInteger(params.historyLength)) {
+      throw new RequestMalformedError('historyLength must be a valid non-negative integer');
+    }
+    if ((params.historyLength ?? 0) < 0) {
+      throw new RequestMalformedError('historyLength must be non-negative');
+    }
 
     // Attach to the event bus BEFORE loading the task from the store so
     // we don't miss events published between the load and subscription.
@@ -920,7 +931,10 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       }
 
       // The first event MUST be a Task representing the current state at
-      // the time of subscription.
+      // the time of subscription. Apply `historyLength` trimming just like
+      // `getTask`/`listTasks` so a resubscriber cannot bypass the
+      // client-imposed history limit.
+      this._applyHistoryLengthSemantics(task, params);
       yield { payload: { $case: 'task', value: task } };
 
       // No active event bus means no live executor to drain from — but

--- a/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -122,8 +122,7 @@ export class JsonRpcTransportHandler {
           // explicitly for the resubscribe snapshot trimming.
           const subscribeParams: SubscribeToTaskRequest & { historyLength?: number } =
             SubscribeToTaskRequest.fromJSON(params);
-          const rawHistoryLength = (params as Record<string, unknown> | undefined)
-            ?.historyLength;
+          const rawHistoryLength = (params as Record<string, unknown> | undefined)?.historyLength;
           if (rawHistoryLength !== undefined) {
             subscribeParams.historyLength = Number(rawHistoryLength);
           }

--- a/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -110,10 +110,25 @@ export class JsonRpcTransportHandler {
         if (!agentCard.capabilities?.streaming) {
           throw new UnsupportedOperationError(`Method ${method} requires streaming capability.`);
         }
-        const agentEventStream =
-          method === 'SendStreamingMessage'
-            ? this.requestHandler.sendMessageStream(SendMessageRequest.fromJSON(params), context)
-            : this.requestHandler.resubscribe(SubscribeToTaskRequest.fromJSON(params), context);
+        let agentEventStream: AsyncGenerator<StreamResponse, void, undefined>;
+        if (method === 'SendStreamingMessage') {
+          agentEventStream = this.requestHandler.sendMessageStream(
+            SendMessageRequest.fromJSON(params),
+            context
+          );
+        } else {
+          // `historyLength` is not part of the canonical
+          // `SubscribeToTaskRequest` wire type, so carry it through
+          // explicitly for the resubscribe snapshot trimming.
+          const subscribeParams: SubscribeToTaskRequest & { historyLength?: number } =
+            SubscribeToTaskRequest.fromJSON(params);
+          const rawHistoryLength = (params as Record<string, unknown> | undefined)
+            ?.historyLength;
+          if (rawHistoryLength !== undefined) {
+            subscribeParams.historyLength = Number(rawHistoryLength);
+          }
+          agentEventStream = this.requestHandler.resubscribe(subscribeParams, context);
+        }
 
         // Wrap the agent event stream into a JSON-RPC result stream.
         // Errors thrown by `agentEventStream` propagate out of the

--- a/src/server/transports/rest/rest_transport_handler.ts
+++ b/src/server/transports/rest/rest_transport_handler.ts
@@ -19,6 +19,7 @@ import {
   ListTasksResponse,
   TaskState,
   ListTaskPushNotificationConfigsResponse,
+  SubscribeToTaskRequest,
 } from '../../../index.js';
 import { taskStateFromJSON } from '../../../types/pb/a2a.js';
 import {
@@ -128,10 +129,18 @@ export class RestTransportHandler {
   async resubscribe(
     taskId: string,
     context: ServerCallContext,
-    tenant?: string
+    tenant?: string,
+    historyLength?: unknown
   ): Promise<AsyncGenerator<StreamResponse, void, undefined>> {
     await this.requireCapability('streaming');
-    return this.requestHandler.resubscribe({ id: taskId, tenant: tenant || '' }, context);
+    const params: SubscribeToTaskRequest & { historyLength?: number } = {
+      id: taskId,
+      tenant: tenant || '',
+    };
+    if (historyLength !== undefined) {
+      params.historyLength = this.parseHistoryLength(historyLength);
+    }
+    return this.requestHandler.resubscribe(params, context);
   }
 
   async createTaskPushNotificationConfig(

--- a/test/server/request_handler/resubscribe.spec.ts
+++ b/test/server/request_handler/resubscribe.spec.ts
@@ -177,7 +177,7 @@ describe('DefaultRequestHandler.resubscribe (§3.1.6)', () => {
     await expect(generator.next()).rejects.toThrow(UnsupportedOperationError);
   });
 
-  it('trims the snapshot history when historyLength is provided (BUG-13)', async () => {
+  it('trims the snapshot history when historyLength is provided', async () => {
     // Regression: resubscribe previously yielded the full task without
     // applying `_applyHistoryLengthSemantics`, letting a resubscriber
     // bypass the client-imposed history limit that getTask/listTasks
@@ -224,7 +224,7 @@ describe('DefaultRequestHandler.resubscribe (§3.1.6)', () => {
     expect(payload.value.history?.map((m) => m.messageId)).toEqual(['m2', 'm3']);
   });
 
-  it('omits history entirely when historyLength is 0 (BUG-13)', async () => {
+  it('omits history entirely when historyLength is 0', async () => {
     const taskId = 'task-trim-zero';
     const contextId = `ctx-${taskId}`;
     const persisted: Task = {
@@ -261,7 +261,7 @@ describe('DefaultRequestHandler.resubscribe (§3.1.6)', () => {
     expect(payload.value.history).toEqual([]);
   });
 
-  it('rejects non-integer historyLength with RequestMalformedError (BUG-13)', async () => {
+  it('rejects non-integer historyLength with RequestMalformedError', async () => {
     const taskId = 'task-trim-nan';
     await taskStore.save(makeTask(taskId), serverContext);
 
@@ -272,7 +272,7 @@ describe('DefaultRequestHandler.resubscribe (§3.1.6)', () => {
     await expect(generator.next()).rejects.toThrow(RequestMalformedError);
   });
 
-  it('rejects negative historyLength with RequestMalformedError (BUG-13)', async () => {
+  it('rejects negative historyLength with RequestMalformedError', async () => {
     const taskId = 'task-trim-negative';
     await taskStore.save(makeTask(taskId), serverContext);
 

--- a/test/server/request_handler/resubscribe.spec.ts
+++ b/test/server/request_handler/resubscribe.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../src/server/index.js';
 import {
   AgentCard,
+  Message,
   StreamResponse,
   Task,
   TaskState,
@@ -16,7 +17,7 @@ import {
 import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
 import { AgentEvent } from '../../../src/server/events/execution_event_bus.js';
 import { ServerCallContext } from '../../../src/server/context.js';
-import { TaskNotFoundError, UnsupportedOperationError } from '../../../src/errors/index.js';
+import { TaskNotFoundError, UnsupportedOperationError, RequestMalformedError } from '../../../src/errors/index.js';
 import { TERMINAL_STATE_LIST } from '../../../src/server/utils.js';
 import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
 
@@ -170,6 +171,112 @@ describe('DefaultRequestHandler.resubscribe (§3.1.6)', () => {
       serverContext
     );
     await expect(generator.next()).rejects.toThrow(UnsupportedOperationError);
+  });
+
+  it('trims the snapshot history when historyLength is provided (BUG-13)', async () => {
+    // Regression: resubscribe previously yielded the full task without
+    // applying `_applyHistoryLengthSemantics`, letting a resubscriber
+    // bypass the client-imposed history limit that getTask/listTasks
+    // enforce (CWE-200 information disclosure).
+    const taskId = 'task-trim';
+    const contextId = `ctx-${taskId}`;
+    const makeMsg = (messageId: string): Message => ({
+      messageId,
+      role: 1 as const,
+      parts: [
+        {
+          content: { $case: 'text' as const, value: messageId },
+          mediaType: 'text/plain',
+          filename: '',
+          metadata: {},
+        },
+      ],
+      contextId,
+      taskId,
+      extensions: [],
+      metadata: {},
+      referenceTaskIds: [],
+    });
+    const persisted: Task = {
+      id: taskId,
+      contextId,
+      status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
+      artifacts: [],
+      history: [makeMsg('m1'), makeMsg('m2'), makeMsg('m3')],
+      metadata: {},
+    };
+    await taskStore.save(persisted, serverContext);
+
+    const events: StreamResponse[] = [];
+    for await (const event of handler.resubscribe(
+      { id: taskId, tenant: '', historyLength: 2 },
+      serverContext
+    )) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(1);
+    const payload = events[0].payload as { $case: 'task'; value: Task };
+    expect(payload.value.history?.map((m) => m.messageId)).toEqual(['m2', 'm3']);
+  });
+
+  it('omits history entirely when historyLength is 0 (BUG-13)', async () => {
+    const taskId = 'task-trim-zero';
+    const contextId = `ctx-${taskId}`;
+    const persisted: Task = {
+      id: taskId,
+      contextId,
+      status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
+      artifacts: [],
+      history: [
+        {
+          messageId: 'm1',
+          role: 1 as const,
+          parts: [],
+          contextId,
+          taskId,
+          extensions: [],
+          metadata: {},
+          referenceTaskIds: [],
+        },
+      ],
+      metadata: {},
+    };
+    await taskStore.save(persisted, serverContext);
+
+    const events: StreamResponse[] = [];
+    for await (const event of handler.resubscribe(
+      { id: taskId, tenant: '', historyLength: 0 },
+      serverContext
+    )) {
+      events.push(event);
+    }
+
+    expect(events).toHaveLength(1);
+    const payload = events[0].payload as { $case: 'task'; value: Task };
+    expect(payload.value.history).toEqual([]);
+  });
+
+  it('rejects non-integer historyLength with RequestMalformedError (BUG-13)', async () => {
+    const taskId = 'task-trim-nan';
+    await taskStore.save(makeTask(taskId), serverContext);
+
+    const generator = handler.resubscribe(
+      { id: taskId, tenant: '', historyLength: NaN },
+      serverContext
+    );
+    await expect(generator.next()).rejects.toThrow(RequestMalformedError);
+  });
+
+  it('rejects negative historyLength with RequestMalformedError (BUG-13)', async () => {
+    const taskId = 'task-trim-negative';
+    await taskStore.save(makeTask(taskId), serverContext);
+
+    const generator = handler.resubscribe(
+      { id: taskId, tenant: '', historyLength: -1 },
+      serverContext
+    );
+    await expect(generator.next()).rejects.toThrow(RequestMalformedError);
   });
 
   it('yields the snapshot first and then forwards live bus events when a bus IS active', async () => {

--- a/test/server/request_handler/resubscribe.spec.ts
+++ b/test/server/request_handler/resubscribe.spec.ts
@@ -17,7 +17,11 @@ import {
 import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
 import { AgentEvent } from '../../../src/server/events/execution_event_bus.js';
 import { ServerCallContext } from '../../../src/server/context.js';
-import { TaskNotFoundError, UnsupportedOperationError, RequestMalformedError } from '../../../src/errors/index.js';
+import {
+  TaskNotFoundError,
+  UnsupportedOperationError,
+  RequestMalformedError,
+} from '../../../src/errors/index.js';
 import { TERMINAL_STATE_LIST } from '../../../src/server/utils.js';
 import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
 

--- a/test/server/rest_transport_handler.spec.ts
+++ b/test/server/rest_transport_handler.spec.ts
@@ -323,6 +323,26 @@ describe('RestTransportHandler', () => {
         mockContext
       );
     });
+
+    it('should pass a parsed historyLength through to the request handler (BUG-13)', async () => {
+      async function* mockStream() {
+        yield testTask;
+      }
+      (mockRequestHandler.resubscribe as Mock).mockResolvedValue(mockStream());
+
+      await transportHandler.resubscribe('task-1', mockContext, '', '10');
+
+      expect(mockRequestHandler.resubscribe as Mock).toHaveBeenCalledWith(
+        { id: 'task-1', tenant: '', historyLength: 10 },
+        mockContext
+      );
+    });
+
+    it('should throw InvalidParams if historyLength is invalid (BUG-13)', async () => {
+      await expect(
+        transportHandler.resubscribe('task-1', mockContext, '', 'invalid')
+      ).rejects.toThrow('historyLength must be a valid integer');
+    });
   });
 
   describe('Push Notification Config', () => {

--- a/test/server/rest_transport_handler.spec.ts
+++ b/test/server/rest_transport_handler.spec.ts
@@ -324,7 +324,7 @@ describe('RestTransportHandler', () => {
       );
     });
 
-    it('should pass a parsed historyLength through to the request handler (BUG-13)', async () => {
+    it('should pass a parsed historyLength through to the request handler', async () => {
       async function* mockStream() {
         yield testTask;
       }
@@ -338,7 +338,7 @@ describe('RestTransportHandler', () => {
       );
     });
 
-    it('should throw InvalidParams if historyLength is invalid (BUG-13)', async () => {
+    it('should throw InvalidParams if historyLength is invalid', async () => {
       await expect(
         transportHandler.resubscribe('task-1', mockContext, '', 'invalid')
       ).rejects.toThrow('historyLength must be a valid integer');


### PR DESCRIPTION
## What changed

### 1. Apply `historyLength` trimming on `tasks/resubscribe` snapshot

**Problem:** `resubscribe` yielded the full stored task without applying `_applyHistoryLengthSemantics`, unlike `getTask` and `listTasks`. A client that reconnects with `historyLength` expecting a trimmed snapshot receives the entire task history, defeating the `historyLength` information-disclosure protection (CWE-200). The canonical `SubscribeToTaskRequest` wire type has no `historyLength` field, and the `src/types/pb/a2a.ts` / `src/grpc/pb/a2a.ts` files are generated from the upstream A2A proto (via `buf generate`), so the field is carried at the handler/transport layer instead of editing the generated files.

**Fix (src/server/request_handler/default_request_handler.ts):**
- `resubscribe` now accepts `SubscribeToTaskRequest & { historyLength?: number }` and applies `_applyHistoryLengthSemantics` to the initial Task snapshot before yielding it.
- Validates `historyLength` (non-negative integer) and throws `RequestMalformedError` for `NaN`/negative values — a `NaN` would previously bypass the `<= 0` check and `slice(-NaN)` → `slice(0)` would return the full history.

**Fix (src/server/request_handler/a2a_request_handler.ts):**
- `A2ARequestHandler.resubscribe` signature widened to `SubscribeToTaskRequest & { historyLength?: number }` (optional field, backward-compatible for all existing call sites).

**Fix (src/server/transports/rest/rest_transport_handler.ts):**
- `resubscribe(taskId, context, tenant?, historyLength?)` parses the optional query value with the existing `parseHistoryLength` and forwards it to the handler.

**Fix (src/server/express/rest_handler.ts):**
- `GET/POST /tasks/:taskId:subscribe` passes `req.query.historyLength` through to the transport.

**Fix (src/server/transports/jsonrpc/jsonrpc_transport_handler.ts):**
- `SubscribeToTask` extracts `params.historyLength` from the raw JSON-RPC params (dropped by `SubscribeToTaskRequest.fromJSON`) and attaches it to the request passed to `resubscribe`.

**Note:** the gRPC transport cannot carry `historyLength` — the gRPC `SubscribeToTaskRequest` proto message has no `history_length` field (field 3 is unset in `src/grpc/pb/a2a.ts`), so the trimming is applied only for REST/JSON-RPC, matching the field's absence on the wire.

## Testing

- `npx vitest run test/server/request_handler/resubscribe.spec.ts test/server/rest_transport_handler.spec.ts test/server/jsonrpc_transport_handler.spec.ts` — all pass.
- New regression tests (6): snapshot trimming, `historyLength=0` omits history entirely, non-integer rejection, negative rejection (resubscribe.spec.ts); REST passthrough and REST validation of the parsed value (rest_transport_handler.spec.ts).
- `npx tsc --noEmit` passes.

Behavior change: `tasks/resubscribe` now honors an optional `historyLength` query param (REST) / `params.historyLength` (JSON-RPC); invalid values are rejected with `-32602`/400. When `historyLength` is absent, behavior is unchanged.
