### PR TITLE
test: add proto3 JSON conformance spec for the generated codecs

### DIFF
--- a/test/proto_json_conformance.spec.ts
+++ b/test/proto_json_conformance.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { Part, TaskStatus } from '../src/index.js';
+
+/**
+ * proto3 JSON conformance for the generated codecs.
+ *
+ * These same messages go over the wire to SDKs that generate from the same
+ * .proto with a different toolchain, so the JSON has to match. Cases were
+ * found by round-tripping a shared corpus through this SDK and a2a-python and
+ * diffing the output.
+ *
+ * `it.fails` marks a case that is known-broken today. When one gets fixed the
+ * marker starts failing, so the fix can't land without flipping it.
+ */
+
+describe('proto3 JSON conformance', () => {
+  describe('enums', () => {
+    // Baseline: both spellings of a known value work, so the harness itself is sound.
+    it('accepts a known value by name', () => {
+      const out = TaskStatus.toJSON(TaskStatus.fromJSON({ state: 'TASK_STATE_WORKING' })) as any;
+      expect(out.state).toBe('TASK_STATE_WORKING');
+    });
+
+    it('accepts a known value by number', () => {
+      const out = TaskStatus.toJSON(TaskStatus.fromJSON({ state: 2 })) as any;
+      expect(out.state).toBe('TASK_STATE_WORKING');
+    });
+
+    // TaskState currently stops at 8. When the spec adds 9, a 1.0 SDK sitting
+    // between two newer peers has to pass it through rather than eat it.
+    it.fails('keeps an unknown value as its number', () => {
+      const out = TaskStatus.toJSON(TaskStatus.fromJSON({ state: 99 })) as any;
+      expect(out.state).toBe(99);
+    });
+  });
+
+  describe('Timestamp', () => {
+    it('leaves an already-normalized timestamp alone', () => {
+      const out = TaskStatus.toJSON(
+        TaskStatus.fromJSON({ state: 'TASK_STATE_WORKING', timestamp: '2026-01-01T00:00:00Z' })
+      ) as any;
+      expect(out.timestamp).toBe('2026-01-01T00:00:00Z');
+    });
+
+    it.fails('rejects a value that is not a timestamp', () => {
+      expect(() =>
+        TaskStatus.fromJSON({ state: 'TASK_STATE_WORKING', timestamp: 'not-a-timestamp' })
+      ).toThrow();
+    });
+
+    // proto3 JSON output is always Z-normalized. a2a-python emits
+    // 2026-01-01T00:00:00Z for this input, so the two SDKs currently produce
+    // different bytes for the same instant.
+    it.fails('normalizes a non-UTC offset to Z', () => {
+      const out = TaskStatus.toJSON(
+        TaskStatus.fromJSON({ state: 'TASK_STATE_WORKING', timestamp: '2026-01-01T05:30:00+05:30' })
+      ) as any;
+      expect(out.timestamp).toBe('2026-01-01T00:00:00Z');
+    });
+  });
+
+  describe('Part.content oneof', () => {
+    it('round-trips a text part', () => {
+      const out = Part.toJSON(Part.fromJSON({ text: 'Café 日本語' })) as any;
+      expect(out.text).toBe('Café 日本語');
+    });
+
+    it('round-trips a bytes part', () => {
+      const out = Part.toJSON(
+        Part.fromJSON({ raw: '+/8=', mediaType: 'application/octet-stream' })
+      ) as any;
+      expect(out.raw).toBe('+/8=');
+    });
+
+    // Part.data is a google.protobuf.Value, and null is a Value. Dropping it
+    // turns a data part carrying null into a part with no content at all.
+    it.fails('keeps the data arm when the value is null', () => {
+      const out = Part.toJSON(Part.fromJSON({ data: null, mediaType: 'application/json' })) as any;
+      expect(out).toHaveProperty('data', null);
+    });
+
+    // More than one member of a oneof is malformed input. Right now whichever
+    // arm survives depends on the order of the generated fromJSON body.
+    it.fails('rejects more than one content arm', () => {
+      expect(() => Part.fromJSON({ text: 'hello', url: 'https://example.com/x' })).toThrow();
+    });
+  });
+});


### PR DESCRIPTION

# Description

## What

Adds `test/proto_json_conformance.spec.ts`, covering how the generated codecs handle
proto3 JSON. Ten cases: five that pass today and pin behaviour that's already correct,
and five marked `it.fails` for the divergences in #640, #641, #642 and #643.

No source changes. This documents current behaviour and gives the fixes a regression net
to land against.

## Why

These messages go over the wire to SDKs generated from the same `.proto` with a different
toolchain, so the JSON has to agree. I built a differential harness that round-trips a
shared corpus through this SDK and `a2a-python` and diffs the output, and it turned up
four disagreements:

- unknown enum values become `"UNRECOGNIZED"`, which `a2a-python` rejects
- `Timestamp` is an unvalidated string and is never normalized to UTC
- `Part.data` set to `null` drops the content oneof
- multiple content oneof arms are accepted instead of rejected

Each is filed separately with a full repro. This PR is just the tests.

## On `it.fails`

`it.fails` asserts that the body fails, so the suite is green today and goes red the
moment a bug is fixed. That's deliberate: the fix can't land without flipping the marker,
so none of these can be quietly resolved and forgotten. I checked the inversion is strict
with a control test whose body passes, and vitest reports it as a failure.

The five passing cases are there as controls. If a change breaks known-good behaviour like
bytes or non-ASCII round-tripping, those go red on their own.

## Where the fixes should go

All four live in `src/types/pb/a2a.ts`, which is generated and marked `DO NOT EDIT`, and I
couldn't find a regeneration path in the repo. Two of them, the enum sentinel and the
oneof leniency, are `ts-proto` behaviour rather than anything configurable, so I didn't
want to guess. Happy to send the fixes once you've said whether you'd prefer them patched
into the generated output, handled in a normalization layer at the transport boundary, or
raised upstream.

## Verification

```
npx vitest run                                        69 files, 1497 tests, all pass
npx vitest run test/proto_json_conformance.spec.ts    10 tests, all pass
npx tsc --noEmit -p tsconfig.test.json                clean
npx eslint test/proto_json_conformance.spec.ts        clean
```

Reproduced against `@a2a-js/sdk` 1.0.1 from npm as well as `main` at `1c6eb32`, so none of
this is a main-only artifact. Python side pinned at `a2a-python` `cff6727`.

Parts of this were put together with AI assistance. Every case was verified by hand
against both SDKs before filing.

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-js/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
- [x] Ensure the tests and linter pass
- [x] Appropriate docs were updated (if necessary)

Refs #640, #641, #642, #643
