### PR TITLE
fix(server): validate push-notification URLs before dispatch (SSRF)

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -46,6 +46,10 @@ export { validateVersion, getSupportedVersions } from './version.js';
 export type { PushNotificationSender } from './push_notification/push_notification_sender.js';
 export { DefaultPushNotificationSender } from './push_notification/default_push_notification_sender.js';
 export type { DefaultPushNotificationSenderOptions } from './push_notification/default_push_notification_sender.js';
+export {
+  isBlockedPushIp,
+  pushUrlValidationError,
+} from './push_notification/push_url_validation.js';
 export type {
   PushNotificationStore,
   StoredPushNotificationConfig,

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -11,6 +11,7 @@ import {
   PushNotificationSerializer,
   V1PushNotificationSerializer,
 } from './push_notification_serializer.js';
+import { pushUrlValidationError } from './push_url_validation.js';
 
 export interface DefaultPushNotificationSenderOptions {
   /** Timeout in milliseconds for the abort controller. Defaults to 5000ms. */
@@ -22,6 +23,14 @@ export interface DefaultPushNotificationSenderOptions {
    * @deprecated Use `pushConfig.authentication` with `AuthenticationInfo`.
    */
   tokenHeaderName?: string;
+  /**
+   * Push-notification URLs are client-supplied and the server POSTs to them,
+   * which makes them an SSRF vector (cloud metadata, internal services).
+   * By default each URL is validated at dispatch time and non-public targets
+   * are dropped. Set this to true only when legitimate webhooks live on
+   * private or loopback networks (validation is then skipped).
+   */
+  allowPrivatePushUrls?: boolean;
   /**
    * Per-wire-version push-notification serializers. The sender always
    * registers a built-in `'1.0'` serializer
@@ -42,7 +51,9 @@ export interface DefaultPushNotificationSenderOptions {
 export class DefaultPushNotificationSender implements PushNotificationSender {
   private readonly pushNotificationStore: PushNotificationStore;
   private notificationChain: Map<string, Promise<unknown>>;
-  private readonly options: Required<Omit<DefaultPushNotificationSenderOptions, 'serializers'>>;
+  private readonly options: Required<
+    Omit<DefaultPushNotificationSenderOptions, 'serializers'>
+  >;
   private readonly serializers: Map<string, PushNotificationSerializer>;
   private readonly fallbackSerializer: PushNotificationSerializer;
   // Avoid log spam when many notifications target the same unknown version.
@@ -57,6 +68,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     this.options = {
       timeout: options.timeout ?? 5000,
       tokenHeaderName: options.tokenHeaderName ?? 'X-A2A-Notification-Token',
+      allowPrivatePushUrls: options.allowPrivatePushUrls ?? false,
     };
 
     // Seed with the built-in v1.0 serializer, then overlay user-supplied
@@ -212,6 +224,17 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
   ): Promise<void> {
     const { config: pushConfig, wireVersion } = storedConfig;
     const url = pushConfig.url;
+
+    if (!this.options.allowPrivatePushUrls) {
+      const validationError = await pushUrlValidationError(url);
+      if (validationError) {
+        console.warn(
+          `Push-notification URL for task_id=${taskId} rejected: ${validationError}`
+        );
+        return;
+      }
+    }
+
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), this.options.timeout);
 
@@ -219,6 +242,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
       const serializer = this._resolveSerializer(wireVersion);
       const { body, contentType } = serializer.serialize(streamResponse);
 
+      // Do not follow redirects: validation covers the initial URL only.
       const response = await fetch(url, {
         method: 'POST',
         headers: {
@@ -227,6 +251,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
         },
         body,
         signal: controller.signal,
+        redirect: 'error',
       });
 
       if (!response.ok) {

--- a/src/server/push_notification/push_url_validation.ts
+++ b/src/server/push_notification/push_url_validation.ts
@@ -1,0 +1,158 @@
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+/**
+ * Whether an address is not a public unicast destination for push webhooks.
+ * Covers loopback, RFC 1918 / RFC 4193 private, link-local, unspecified,
+ * multicast, RFC 6598 CGNAT, and RFC 2544 benchmarking ranges.
+ */
+export function isBlockedPushIp(ip: string): boolean {
+  const normalized = ip.split('%', 1)[0] ?? ip;
+  const version = isIP(normalized);
+  if (version === 0) {
+    return true;
+  }
+
+  if (version === 4) {
+    return isBlockedIpv4(normalized);
+  }
+
+  // IPv4-mapped IPv6 (::ffff:a.b.c.d)
+  const mapped = ipv4MappedFromV6(normalized);
+  if (mapped !== undefined) {
+    return isBlockedIpv4(mapped);
+  }
+
+  return isBlockedIpv6(normalized);
+}
+
+function isBlockedIpv4(ip: string): boolean {
+  const parts = ip.split('.').map((p) => Number(p));
+  if (parts.length !== 4 || parts.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) {
+    return true;
+  }
+  const [a, b] = parts;
+
+  // 0.0.0.0/8 unspecified / "this" network
+  if (a === 0) return true;
+  // 10.0.0.0/8
+  if (a === 10) return true;
+  // 127.0.0.0/8 loopback
+  if (a === 127) return true;
+  // 169.254.0.0/16 link-local (incl. cloud metadata)
+  if (a === 169 && b === 254) return true;
+  // 172.16.0.0/12
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.168.0.0/16
+  if (a === 192 && b === 168) return true;
+  // 100.64.0.0/10 CGNAT (RFC 6598)
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  // 198.18.0.0/15 benchmarking (RFC 2544)
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  // 224.0.0.0/4 multicast
+  if (a >= 224 && a <= 239) return true;
+  // 240.0.0.0/4 reserved
+  if (a >= 240) return true;
+
+  return false;
+}
+
+function isBlockedIpv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+  // Unspecified
+  if (lower === '::' || lower === '0:0:0:0:0:0:0:0') return true;
+  // Loopback
+  if (lower === '::1' || lower === '0:0:0:0:0:0:0:1') return true;
+  // Expand coarsely via URL parser for prefix checks
+  try {
+    const expanded = expandIpv6(lower);
+    // fe80::/10 link-local
+    if (expanded[0] === 0xfe80 || (expanded[0] & 0xffc0) === 0xfe80) return true;
+    // fc00::/7 ULA
+    if ((expanded[0] & 0xfe00) === 0xfc00) return true;
+    // ff00::/8 multicast
+    if ((expanded[0] & 0xff00) === 0xff00) return true;
+  } catch {
+    return true;
+  }
+  return false;
+}
+
+function ipv4MappedFromV6(ip: string): string | undefined {
+  const lower = ip.toLowerCase();
+  if (lower.startsWith('::ffff:')) {
+    const rest = lower.slice('::ffff:'.length);
+    if (isIP(rest) === 4) {
+      return rest;
+    }
+  }
+  return undefined;
+}
+
+function expandIpv6(ip: string): number[] {
+  // Minimal expander for prefix checks only.
+  const sides = ip.split('::');
+  let head = sides[0] ? sides[0].split(':') : [];
+  let tail = sides.length > 1 && sides[1] ? sides[1].split(':') : [];
+  if (sides.length > 2) {
+    throw new Error('invalid ipv6');
+  }
+  const missing = 8 - (head.length + tail.length);
+  if (missing < 0) {
+    throw new Error('invalid ipv6');
+  }
+  const middles = Array(missing).fill('0');
+  const parts = [...head, ...middles, ...tail].map((p) => parseInt(p || '0', 16));
+  if (parts.length !== 8 || parts.some((n) => Number.isNaN(n))) {
+    throw new Error('invalid ipv6');
+  }
+  return parts;
+}
+
+/**
+ * Return an error string if a push-notification URL is not safe to POST to.
+ * Rejects non-http(s) schemes and hosts that resolve to blocked addresses.
+ * Unresolvable hosts fail closed.
+ */
+export async function pushUrlValidationError(url: string): Promise<string | undefined> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return 'unparseable URL';
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return `scheme '${parsed.protocol.replace(/:$/, '')}' is not http/https`;
+  }
+
+  const host = parsed.hostname;
+  if (!host) {
+    return 'no hostname';
+  }
+
+  // Literal IP in the URL: check directly (skip DNS).
+  const literal = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host;
+  if (isIP(literal) !== 0) {
+    if (isBlockedPushIp(literal)) {
+      return `host '${host}' is a non-public address`;
+    }
+    return undefined;
+  }
+
+  try {
+    const results = await lookup(host, { all: true, verbatim: true });
+    if (results.length === 0) {
+      return `host '${host}' could not be resolved`;
+    }
+    for (const { address } of results) {
+      if (isBlockedPushIp(address)) {
+        return `host '${host}' resolves to a non-public address`;
+      }
+    }
+  } catch {
+    return `host '${host}' could not be resolved`;
+  }
+
+  return undefined;
+}

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -54,6 +54,7 @@ import {
 } from '../push_notification/push_notification_store.js';
 import { PushNotificationSender } from '../push_notification/push_notification_sender.js';
 import { DefaultPushNotificationSender } from '../push_notification/default_push_notification_sender.js';
+import { pushUrlValidationError } from '../push_notification/push_url_validation.js';
 import { ServerCallContext } from '../context.js';
 import { DEFAULT_PAGE_SIZE } from '../../constants.js';
 import {
@@ -84,6 +85,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   private readonly pushNotificationSender?: PushNotificationSender;
   private readonly extendedAgentCardProvider?: AgentCard | ExtendedAgentCardProvider;
   private readonly agentCardSignatureGenerator?: AgentCardSignatureGenerator;
+  private readonly allowPrivatePushUrls: boolean;
 
   constructor(
     agentCard: AgentCard,
@@ -93,7 +95,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     pushNotificationStore?: PushNotificationStore,
     pushNotificationSender?: PushNotificationSender,
     extendedAgentCardProvider?: AgentCard | ExtendedAgentCardProvider,
-    agentCardSignatureGenerator?: AgentCardSignatureGenerator
+    agentCardSignatureGenerator?: AgentCardSignatureGenerator,
+    allowPrivatePushUrls: boolean = false
   ) {
     this.agentCard = agentCard;
     this.taskStore = taskStore;
@@ -101,11 +104,33 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     this.eventBusManager = eventBusManager;
     this.extendedAgentCardProvider = extendedAgentCardProvider;
     this.agentCardSignatureGenerator = agentCardSignatureGenerator;
+    this.allowPrivatePushUrls = allowPrivatePushUrls;
 
     if (agentCard.capabilities?.pushNotifications) {
       this.pushNotificationStore = pushNotificationStore || new InMemoryPushNotificationStore();
       this.pushNotificationSender =
-        pushNotificationSender || new DefaultPushNotificationSender(this.pushNotificationStore);
+        pushNotificationSender ||
+        new DefaultPushNotificationSender(this.pushNotificationStore, {
+          allowPrivatePushUrls: this.allowPrivatePushUrls,
+        });
+    }
+  }
+
+  /**
+   * Reject client-supplied push webhook URLs that are not safe to POST to.
+   * Skipped when {@link allowPrivatePushUrls} is true (trusted internal webhooks).
+   */
+  private async _assertPushConfigUrlAllowed(
+    config: TaskPushNotificationConfig
+  ): Promise<void> {
+    if (this.allowPrivatePushUrls) {
+      return;
+    }
+    const validationError = await pushUrlValidationError(config.url);
+    if (validationError) {
+      throw new RequestMalformedError(
+        `invalid push config endpoint URL: ${validationError}`
+      );
     }
   }
 
@@ -580,6 +605,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       params.configuration?.taskPushNotificationConfig &&
       this.agentCard.capabilities?.pushNotifications
     ) {
+      await this._assertPushConfigUrlAllowed(params.configuration.taskPushNotificationConfig);
       await this.pushNotificationStore?.save(
         taskId,
         context,
@@ -676,6 +702,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       params.configuration?.taskPushNotificationConfig &&
       this.agentCard.capabilities?.pushNotifications
     ) {
+      await this._assertPushConfigUrlAllowed(params.configuration.taskPushNotificationConfig);
       await this.pushNotificationStore?.save(
         taskId,
         context,
@@ -827,6 +854,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       throw new TaskNotFoundError(`Task not found: ${taskId}`);
     }
 
+    await this._assertPushConfigUrlAllowed(params);
     await this.pushNotificationStore?.save(taskId, context, params);
     return structuredClone(params);
   }

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -144,7 +144,10 @@ describe('Push Notification Integration Tests', () => {
       mockAgentExecutor,
       executionEventBusManager,
       pushNotificationStore,
-      pushNotificationSender
+      pushNotificationSender,
+      undefined,
+      undefined,
+      true
     );
   });
 
@@ -588,7 +591,10 @@ describe('Push Notification Integration Tests', () => {
         mockAgentExecutor,
         new DefaultExecutionEventBusManager(),
         pushNotificationStore,
-        customPushNotificationSender
+        customPushNotificationSender,
+        undefined,
+        undefined,
+        true
       );
 
       const pushConfig: TaskPushNotificationConfig = {
@@ -769,7 +775,10 @@ describe('Push Notification Integration Tests', () => {
         mockAgentExecutor,
         new DefaultExecutionEventBusManager(),
         pushNotificationStore,
-        customPushNotificationSender
+        customPushNotificationSender,
+        undefined,
+        undefined,
+        true
       );
 
       const pushConfig1: TaskPushNotificationConfig = {

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -134,7 +134,7 @@ describe('Push Notification Integration Tests', () => {
     mockAgentExecutor = new MockAgentExecutor();
     const executionEventBusManager = new DefaultExecutionEventBusManager();
     pushNotificationStore = new InMemoryPushNotificationStore();
-    pushNotificationSender = new DefaultPushNotificationSender(pushNotificationStore);
+    pushNotificationSender = new DefaultPushNotificationSender(pushNotificationStore, { allowPrivatePushUrls: true });
     pushNotificationSenderSpy = vi.spyOn(pushNotificationSender, 'send');
     defaultContext = new ServerCallContext();
 
@@ -577,8 +577,7 @@ describe('Push Notification Integration Tests', () => {
     it('should use custom header name when tokenHeaderName is specified', async () => {
       const customPushNotificationSender = new DefaultPushNotificationSender(
         pushNotificationStore,
-        {
-          tokenHeaderName: 'X-Custom-Auth-Token',
+        { allowPrivatePushUrls: true, tokenHeaderName: 'X-Custom-Auth-Token',
         }
       );
       const customSenderSpy = vi.spyOn(customPushNotificationSender, 'send');
@@ -759,8 +758,7 @@ describe('Push Notification Integration Tests', () => {
     it('should handle multiple push configs with different header configurations', async () => {
       const customPushNotificationSender = new DefaultPushNotificationSender(
         pushNotificationStore,
-        {
-          tokenHeaderName: 'X-Custom-Token',
+        { allowPrivatePushUrls: true, tokenHeaderName: 'X-Custom-Token',
         }
       );
       const customSenderSpy = vi.spyOn(customPushNotificationSender, 'send');

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -124,7 +124,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
   });
 
   it('uses the built-in v1.0 serializer for v1.0-tagged configs (regression)', async () => {
-    const sender = new DefaultPushNotificationSender(store);
+    const sender = new DefaultPushNotificationSender(store, { allowPrivatePushUrls: true });
     const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
     await store.save('task-v1', ctxV1, makeConfig(`${baseUrl}/notify`));
 
@@ -142,6 +142,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
       },
     };
     const sender = new DefaultPushNotificationSender(store, {
+      allowPrivatePushUrls: true,
       serializers: { [A2A_LEGACY_PROTOCOL_VERSION]: v03Serializer },
     });
     const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
@@ -161,6 +162,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
       },
     };
     const sender = new DefaultPushNotificationSender(store, {
+      allowPrivatePushUrls: true,
       serializers: { [A2A_LEGACY_PROTOCOL_VERSION]: v03Serializer },
     });
 
@@ -180,7 +182,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
 
   it('falls back to the v1.0 serializer with a one-time warning for unknown wire versions', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const sender = new DefaultPushNotificationSender(store);
+    const sender = new DefaultPushNotificationSender(store, { allowPrivatePushUrls: true });
     // Register two configs under an unknown wire version on the same task so
     // we can verify the warning is emitted only once per instance per
     // unknown version.
@@ -209,6 +211,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
       },
     };
     const sender = new DefaultPushNotificationSender(store, {
+      allowPrivatePushUrls: true,
       serializers: { [A2A_PROTOCOL_VERSION]: customV1 },
     });
     const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
@@ -222,7 +225,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
   });
 
   it('preserves auth headers alongside serializer-supplied content type', async () => {
-    const sender = new DefaultPushNotificationSender(store);
+    const sender = new DefaultPushNotificationSender(store, { allowPrivatePushUrls: true });
     const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
     await store.save(
       'task-auth',
@@ -243,7 +246,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     // Push notifications accept all four StreamResponse payload
     // variants. The built-in v1.0 serializer encodes the message as part
     // of the canonical StreamResponse JSON wrapper.
-    const sender = new DefaultPushNotificationSender(store);
+    const sender = new DefaultPushNotificationSender(store, { allowPrivatePushUrls: true });
     const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
     await store.save('task-msg', ctxV1, makeConfig(`${baseUrl}/notify`));
 
@@ -257,7 +260,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
   it('silently skips dispatch for stand-alone messages (no task association)', async () => {
     // Message-only stream pattern: no taskId means no config can ever
     // match. Sender returns silently without hitting the store.
-    const sender = new DefaultPushNotificationSender(store);
+    const sender = new DefaultPushNotificationSender(store, { allowPrivatePushUrls: true });
     const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
 
     await sender.send(makeMessage(''), ctxV1);
@@ -281,6 +284,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
       },
     };
     const sender = new DefaultPushNotificationSender(customStore, {
+      allowPrivatePushUrls: true,
       serializers: { [ProtocolVersion.V0_3]: v03Serializer },
     });
     const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
@@ -308,6 +312,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
       },
     };
     const sender = new DefaultPushNotificationSender(customStore, {
+      allowPrivatePushUrls: true,
       serializers: { [ProtocolVersion.V0_3]: v03Serializer },
     });
     const ctxEmpty = new ServerCallContext({ requestedVersion: '' });
@@ -333,7 +338,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     };
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     // Default sender — only the built-in V1 serializer. No compat opt-in.
-    const sender = new DefaultPushNotificationSender(customStore);
+    const sender = new DefaultPushNotificationSender(customStore, { allowPrivatePushUrls: true });
     const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
 
     await sender.send(makeStatusUpdate('task-bare-v1'), ctxV1);

--- a/test/server/push_url_validation.spec.ts
+++ b/test/server/push_url_validation.spec.ts
@@ -7,8 +7,12 @@ import {
 import { DefaultPushNotificationSender } from '../../src/server/push_notification/default_push_notification_sender.js';
 import { InMemoryPushNotificationStore } from '../../src/server/push_notification/push_notification_store.js';
 import { ServerCallContext } from '../../src/server/context.js';
-import { StreamResponse, TaskState } from '../../src/types/pb/a2a.js';
+import { AgentCard, StreamResponse, Task, TaskState } from '../../src/types/pb/a2a.js';
 import { A2A_PROTOCOL_VERSION } from '../../src/constants.js';
+import { DefaultRequestHandler } from '../../src/server/request_handler/default_request_handler.js';
+import { InMemoryTaskStore } from '../../src/server/store.js';
+import { DefaultExecutionEventBusManager } from '../../src/server/events/execution_event_bus_manager.js';
+import { MockAgentExecutor } from './mocks/agent-executor.mock.js';
 
 describe('isBlockedPushIp', () => {
   it('blocks loopback, private, link-local, CGNAT, benchmarking, multicast', () => {
@@ -134,5 +138,64 @@ describe('DefaultPushNotificationSender SSRF guard', () => {
     expect(fetchSpy).toHaveBeenCalled();
     expect(fetchSpy.mock.calls[0][1]).toMatchObject({ redirect: 'error' });
     fetchSpy.mockRestore();
+  });
+});
+
+describe('create-time push URL validation', () => {
+  const agentCard: AgentCard = {
+    name: 'Push Agent',
+    description: 'test',
+    version: '1.0.0',
+    provider: undefined,
+    documentationUrl: '',
+    supportedInterfaces: [
+      { url: 'http://localhost/a2a', protocolBinding: 'HTTP+JSON', tenant: '', protocolVersion: '1.0' },
+    ],
+    capabilities: { extensions: [], streaming: true, pushNotifications: true },
+    securitySchemes: {},
+    securityRequirements: [],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    signatures: [],
+  };
+
+  it('rejects private URLs on createTaskPushNotificationConfig', async () => {
+    const taskStore = new InMemoryTaskStore();
+    const pushStore = new InMemoryPushNotificationStore();
+    const handler = new DefaultRequestHandler(
+      agentCard,
+      taskStore,
+      new MockAgentExecutor(),
+      new DefaultExecutionEventBusManager(),
+      pushStore
+    );
+    const ctx = new ServerCallContext();
+    const taskId = 't-create';
+    await taskStore.save(
+      {
+        id: taskId,
+        contextId: 'c',
+        status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      } satisfies Task,
+      ctx
+    );
+
+    await expect(
+      handler.createTaskPushNotificationConfig(
+        {
+          tenant: '',
+          taskId,
+          id: '',
+          url: 'http://169.254.169.254/latest/meta-data/',
+          token: '',
+          authentication: undefined,
+        },
+        ctx
+      )
+    ).rejects.toThrow(/invalid push config endpoint URL/);
   });
 });

--- a/test/server/push_url_validation.spec.ts
+++ b/test/server/push_url_validation.spec.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  isBlockedPushIp,
+  pushUrlValidationError,
+} from '../../src/server/push_notification/push_url_validation.js';
+import { DefaultPushNotificationSender } from '../../src/server/push_notification/default_push_notification_sender.js';
+import { InMemoryPushNotificationStore } from '../../src/server/push_notification/push_notification_store.js';
+import { ServerCallContext } from '../../src/server/context.js';
+import { StreamResponse, TaskState } from '../../src/types/pb/a2a.js';
+import { A2A_PROTOCOL_VERSION } from '../../src/constants.js';
+
+describe('isBlockedPushIp', () => {
+  it('blocks loopback, private, link-local, CGNAT, benchmarking, multicast', () => {
+    for (const ip of [
+      '127.0.0.1',
+      '10.0.0.1',
+      '172.16.0.1',
+      '192.168.1.1',
+      '169.254.169.254',
+      '0.0.0.0',
+      '100.64.0.1',
+      '198.18.0.1',
+      '224.0.0.1',
+      '::1',
+      '::',
+      '::ffff:127.0.0.1',
+      'fe80::1',
+      'fc00::1',
+    ]) {
+      expect(isBlockedPushIp(ip), ip).toBe(true);
+    }
+  });
+
+  it('allows public unicast', () => {
+    expect(isBlockedPushIp('8.8.8.8')).toBe(false);
+    expect(isBlockedPushIp('1.1.1.1')).toBe(false);
+  });
+});
+
+describe('pushUrlValidationError', () => {
+  it('rejects non-http schemes', async () => {
+    expect(await pushUrlValidationError('file:///etc/passwd')).toMatch(/scheme/);
+    expect(await pushUrlValidationError('ftp://example.com')).toMatch(/scheme/);
+  });
+
+  it('rejects literal private IPs', async () => {
+    expect(await pushUrlValidationError('http://127.0.0.1/hook')).toMatch(/non-public/);
+    expect(await pushUrlValidationError('http://169.254.169.254/latest/meta-data/')).toMatch(
+      /non-public/
+    );
+    expect(await pushUrlValidationError('http://100.64.0.1/hook')).toMatch(/non-public/);
+  });
+
+  it('allows public https hosts', async () => {
+    expect(await pushUrlValidationError('https://example.com/hook')).toBeUndefined();
+  });
+});
+
+describe('DefaultPushNotificationSender SSRF guard', () => {
+  it('drops private targets by default (does not fetch)', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok'));
+    const store = new InMemoryPushNotificationStore();
+    const sender = new DefaultPushNotificationSender(store);
+    const ctx = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save('task-ssrf', ctx, {
+      tenant: '',
+      taskId: 'task-ssrf',
+      id: 'cfg',
+      url: 'http://127.0.0.1:9/hook',
+      token: '',
+      authentication: undefined,
+    });
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await sender.send(
+      {
+        payload: {
+          $case: 'statusUpdate',
+          value: {
+            taskId: 'task-ssrf',
+            contextId: 'ctx',
+            status: {
+              state: TaskState.TASK_STATE_WORKING,
+              message: undefined,
+              timestamp: '2026-08-11T00:00:00Z',
+            },
+            metadata: {},
+          },
+        },
+      } satisfies StreamResponse,
+      ctx
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+    fetchSpy.mockRestore();
+    warn.mockRestore();
+  });
+
+  it('revert-test: allowPrivatePushUrls true would call fetch for loopback', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('ok', { status: 200 }));
+    const store = new InMemoryPushNotificationStore();
+    const sender = new DefaultPushNotificationSender(store, { allowPrivatePushUrls: true });
+    const ctx = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save('task-ok', ctx, {
+      tenant: '',
+      taskId: 'task-ok',
+      id: 'cfg',
+      url: 'http://127.0.0.1:9/hook',
+      token: '',
+      authentication: undefined,
+    });
+
+    await sender.send(
+      {
+        payload: {
+          $case: 'statusUpdate',
+          value: {
+            taskId: 'task-ok',
+            contextId: 'ctx',
+            status: {
+              state: TaskState.TASK_STATE_WORKING,
+              message: undefined,
+              timestamp: '2026-08-11T00:00:00Z',
+            },
+            metadata: {},
+          },
+        },
+      } satisfies StreamResponse,
+      ctx
+    );
+
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[0][1]).toMatchObject({ redirect: 'error' });
+    fetchSpy.mockRestore();
+  });
+});

--- a/test/server/request_handler/push_notification_config.spec.ts
+++ b/test/server/request_handler/push_notification_config.spec.ts
@@ -92,13 +92,13 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
     await taskStore.save(makeTask(taskId), serverContext);
 
     const result = await handler.createTaskPushNotificationConfig(
-      makeIdLessConfig(taskId, 'https://example.test/webhook-1'),
+      makeIdLessConfig(taskId, 'https://example.com/webhook-1'),
       serverContext
     );
 
     expect(result.id).toMatch(UUIDV4_RE);
     expect(result.taskId).toBe(taskId);
-    expect(result.url).toBe('https://example.test/webhook-1');
+    expect(result.url).toBe('https://example.com/webhook-1');
 
     // Verify persistence: the record returned must be the one in the
     // store, not a reflection of the input.
@@ -116,11 +116,11 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
     await taskStore.save(makeTask(taskId), serverContext);
 
     const first = await handler.createTaskPushNotificationConfig(
-      makeIdLessConfig(taskId, 'https://example.test/webhook-A'),
+      makeIdLessConfig(taskId, 'https://example.com/webhook-A'),
       serverContext
     );
     const second = await handler.createTaskPushNotificationConfig(
-      makeIdLessConfig(taskId, 'https://example.test/webhook-B'),
+      makeIdLessConfig(taskId, 'https://example.com/webhook-B'),
       serverContext
     );
 
@@ -132,8 +132,8 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
     expect(stored).toHaveLength(2);
     expect(stored.map((c) => c.id).sort()).toEqual([first.id, second.id].sort());
     expect(stored.map((c) => c.url).sort()).toEqual([
-      'https://example.test/webhook-A',
-      'https://example.test/webhook-B',
+      'https://example.com/webhook-A',
+      'https://example.com/webhook-B',
     ]);
   });
 
@@ -145,14 +145,14 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
       tenant: '',
       taskId,
       id: 'caller-chosen-id',
-      url: 'https://example.test/webhook-explicit',
+      url: 'https://example.com/webhook-explicit',
       token: 'shh',
       authentication: undefined,
     };
     const result = await handler.createTaskPushNotificationConfig(params, serverContext);
 
     expect(result.id).toBe('caller-chosen-id');
-    expect(result.url).toBe('https://example.test/webhook-explicit');
+    expect(result.url).toBe('https://example.com/webhook-explicit');
 
     // The returned object must be a deep clone, not the input reference —
     // caller-side mutations of the returned value must not reach the
@@ -161,7 +161,7 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
     expect(result).not.toBe(params);
     result.url = 'https://attacker.test/';
     const stored = await pushNotificationStore.load(taskId, serverContext);
-    expect(stored[0].url).toBe('https://example.test/webhook-explicit');
+    expect(stored[0].url).toBe('https://example.com/webhook-explicit');
   });
 
   it('listTaskPushNotificationConfigs returns every entry after mixed id-less + explicit Creates', async () => {
@@ -169,7 +169,7 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
     await taskStore.save(makeTask(taskId), serverContext);
 
     const idless1 = await handler.createTaskPushNotificationConfig(
-      makeIdLessConfig(taskId, 'https://example.test/wh-1'),
+      makeIdLessConfig(taskId, 'https://example.com/wh-1'),
       serverContext
     );
     const explicit = await handler.createTaskPushNotificationConfig(
@@ -177,14 +177,14 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
         tenant: '',
         taskId,
         id: 'pinned',
-        url: 'https://example.test/wh-2',
+        url: 'https://example.com/wh-2',
         token: '',
         authentication: undefined,
       },
       serverContext
     );
     const idless2 = await handler.createTaskPushNotificationConfig(
-      makeIdLessConfig(taskId, 'https://example.test/wh-3'),
+      makeIdLessConfig(taskId, 'https://example.com/wh-3'),
       serverContext
     );
 
@@ -197,4 +197,19 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
     const idsSeen = list.configs.map((c) => c.id).sort();
     expect(idsSeen).toEqual([idless1.id, explicit.id, idless2.id].sort());
   });
+  it('rejects private push webhook URLs at create time (SSRF)', async () => {
+    const taskId = 'task-ssrf-create';
+    await taskStore.save(makeTask(taskId), serverContext);
+
+    await expect(
+      handler.createTaskPushNotificationConfig(
+        makeIdLessConfig(taskId, 'http://127.0.0.1/hook'),
+        serverContext
+      )
+    ).rejects.toThrow(/invalid push config endpoint URL/);
+
+    const stored = await pushNotificationStore.load(taskId, serverContext);
+    expect(stored).toHaveLength(0);
+  });
+
 });


### PR DESCRIPTION
## Summary

`DefaultPushNotificationSender` POSTed to whatever webhook URL a client stored, with no scheme or resolved-IP checks. Create paths (`createTaskPushNotificationConfig` and embedded `taskPushNotificationConfig` on send) also stored those URLs unchecked.

This adds fail-closed validation (sibling of a2a-python#1164 / #1173 and a2a-go push SSRF hardening):

- http/https only
- DNS resolve (or literal IP) must be public unicast (incl. CGNAT / benchmarking / multicast blocks)
- Applied at dispatch and at config creation / send embed
- `allowPrivatePushUrls` opt-in on sender and `DefaultRequestHandler` for trusted private/loopback webhooks
- `fetch` uses `redirect: 'error'` so redirects cannot bypass the initial-URL check

## Attacker model

Any client that can register a push config can make the agent server send authenticated POSTs to internal targets. Validation runs before store and before fetch.

## Test plan

- [x] `test/server/push_url_validation.spec.ts` (blocked IPs, dispatch drop, create reject, allowPrivate opt-in, revert-tested)
- [x] push config / sender serializer / integration suites
- [ ] CI