### PR TITLE
chore(cli): generalize auth support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ The `src/samples` directory contains practical examples. Each subdirectory has i
 *   **`authentication/`**: Bearer/JWT authentication with Passport, including a `UserBuilder` that propagates the authenticated user into the agent context.
 *   **`extensions/`**: Protocol extension implemented as an `AgentExecutor` decorator that stamps metadata onto outgoing events.
 *   **`client/interceptors/`**: Client `CallInterceptor`s for header injection and request timing, plus per-call `AbortSignal.timeout(...)`.
-*   **`cli.ts`**: Multi-transport interactive CLI client (JSON-RPC / REST / gRPC) with optional Google ADC authentication.
+*   **`cli.ts`**: Multi-transport interactive CLI client (JSON-RPC / REST / gRPC); `--auth` / `--svc-param` inject headers (gRPC metadata) into every request.
 
 ## Development Conventions
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Each sample directory has its own `README.md` with run instructions.
 | [`authentication`](src/samples/authentication/)                                 | Server-side Bearer/JWT authentication using Passport, including a `UserBuilder` that propagates the authenticated user into the agent context. |
 | [`extensions`](src/samples/extensions/)                                         | A2A protocol extension implemented as an `AgentExecutor` decorator that adds metadata to outgoing events.                                      |
 | [`client/interceptors`](src/samples/client/interceptors/)                       | Client `CallInterceptor`s for header injection and request timing, plus per-call `AbortSignal.timeout(...)`.                                   |
-| [`cli.ts`](src/samples/cli.ts)                                                  | Multi-transport interactive CLI client (JSON-RPC / REST / gRPC) with optional Google ADC authentication.                                       |
+| [`cli.ts`](src/samples/cli.ts)                                                  | Multi-transport interactive CLI client (JSON-RPC / REST / gRPC) with `--auth` / `--svc-param` header injection.                                |
 | [`agents/compat-v1-server`](src/samples/agents/compat-v1-server/)               | v1.0-native server with `legacyCompat: { enabled: true }` on every transport — JSON-RPC, REST, gRPC, agent card, and push notifications.       |
 | [`agents/compat-v1-client`](src/samples/agents/compat-v1-client/)               | v1.0-native client driving both the compat-aware server above and a hand-rolled mock v0.3 server in-process; pairs with `compat-v1-server`.    |
 
@@ -214,8 +214,8 @@ headers and retry on 401/403 responses.
 
 See the [`client/interceptors`](src/samples/client/interceptors/) sample for
 header injection + per-call `AbortSignal.timeout(...)`, and the
-[`cli.ts`](src/samples/cli.ts) sample for an `AuthenticationHandler` based on
-Google Application Default Credentials.
+[`cli.ts`](src/samples/cli.ts) sample for passing `--auth "Bearer $TOKEN"` as
+per-call `serviceParameters`.
 
 ### Authentication (server side)
 

--- a/src/samples/cli.ts
+++ b/src/samples/cli.ts
@@ -2,7 +2,7 @@
 
 import readline from 'node:readline';
 import crypto from 'node:crypto';
-import { GoogleAuth } from 'google-auth-library';
+import { parseArgs } from 'node:util';
 
 import {
   TaskStatusUpdateEvent,
@@ -17,13 +17,12 @@ import { TaskState, Role, taskStateToJSON, SendMessageRequest } from '../types/p
 import { AgentExecutionEvent, AgentEvent } from '../server/index.js';
 
 import {
-  AuthenticationHandler,
   ClientFactory,
   ClientFactoryOptions,
-  createAuthenticatingFetchWithRetry,
   DefaultAgentCardResolver,
   JsonRpcTransportFactory,
   RestTransportFactory,
+  ServiceParameters,
 } from '../client/index.js';
 import { GrpcTransportFactory } from '../client/transports/grpc/grpc_transport.js';
 
@@ -75,66 +74,96 @@ function agentCardFromTransport(url: string, transport?: string): AgentCard {
   };
 }
 
-// Application Default Credentials required for A2A agent running on Agent Engine.
-export class ADCHandler implements AuthenticationHandler {
-  private auth = new GoogleAuth({
-    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
-  });
+// --- CLI Arguments ---
+const USAGE = `A2A Terminal Client
 
-  async headers(): Promise<Record<string, string>> {
-    const client = await this.auth.getClient();
-    const token = await client.getAccessToken();
-    if (token?.token) {
-      return { Authorization: `Bearer ${token.token}` };
+Usage: a2a:cli [url] [flags]
+
+  --transport <name>   Force a transport: JSONRPC, HTTP+JSON, GRPC.
+                       Default: the first match between the agent card and this client.
+  --auth <creds>       Shorthand for --svc-param "Authorization=<creds>",
+                       e.g. --auth "Bearer $(gcloud auth print-access-token)".
+  --svc-param <k=v>    Service parameter sent with every request, as an HTTP header
+                       (JSON-RPC / REST) or request metadata (gRPC). Repeatable.
+  --card-path <path>   Agent card path relative to the url. Default: ${AGENT_CARD_PATH}.
+  --no-agent-card      Skip discovery and synthesize a card from the url and --transport.
+  --help               Show this message.
+`;
+
+function exitWithUsage(message: string): never {
+  console.error(colorize('red', message));
+  console.error(USAGE);
+  process.exit(2);
+}
+
+function parseCliArgs() {
+  try {
+    return parseArgs({
+      args: process.argv.slice(2),
+      allowPositionals: true,
+      options: {
+        transport: { type: 'string' },
+        auth: { type: 'string' },
+        'svc-param': { type: 'string', multiple: true },
+        'card-path': { type: 'string' },
+        'no-agent-card': { type: 'boolean' },
+        help: { type: 'boolean' },
+      },
+    });
+  } catch (err) {
+    return exitWithUsage(err instanceof Error ? err.message : String(err));
+  }
+}
+
+/** Merges `--auth` and every `--svc-param key=value` into one parameter map. */
+function toServiceParameters(auth: string | undefined, params: string[]): ServiceParameters {
+  const serviceParameters: ServiceParameters = auth ? { Authorization: auth } : {};
+  for (const param of params) {
+    const eq = param.indexOf('='); // Split on the first `=`; values may contain more.
+    if (eq < 1) {
+      exitWithUsage(`--svc-param expects "key=value", got "${param}".`);
     }
-    throw new Error('Failed to retrieve ADC access token.');
+    serviceParameters[param.slice(0, eq)] = param.slice(eq + 1);
   }
+  return serviceParameters;
+}
 
-  async shouldRetryWithHeaders(
-    _req: RequestInit,
-    res: Response
-  ): Promise<Record<string, string> | undefined> {
-    if (res.status !== 401 && res.status !== 403) return undefined;
-    return this.headers();
-  }
+/** Agent card discovery bypasses the transports, so it needs its own headers. */
+function fetchWithHeaders(headers: ServiceParameters): typeof fetch {
+  return (input, init) => {
+    const merged = new Headers(headers);
+    new Headers(init?.headers).forEach((value, key) => merged.set(key, value));
+    return fetch(input, { ...init, headers: merged });
+  };
 }
 
 // --- State ---
 let currentTaskId: string | undefined = undefined; // Initialize as undefined
 let currentContextId: string | undefined = undefined; // Initialize as undefined
 
-const preferredTransport = process.argv
-  .find((arg) => arg.startsWith('--transport='))
-  ?.split('=')[1];
-const serverUrlArg = process.argv.slice(2).find((arg) => !arg.startsWith('--'));
-const serverUrl = serverUrlArg || 'http://localhost:41241'; // Agent's base URL
-
-const buildAgentCardFromTransport = process.argv.includes('--no-agent-card');
-const useAdcAuth =
-  process.argv.includes('--google-auth') || process.argv.includes('--agent-engine');
-
-let fetchImpl: typeof fetch = fetch;
-let agentCardPath = AGENT_CARD_PATH;
-if (useAdcAuth) {
-  fetchImpl = createAuthenticatingFetchWithRetry(fetch, new ADCHandler());
+const { values: flags, positionals } = parseCliArgs();
+if (flags.help) {
+  console.log(USAGE);
+  process.exit(0);
 }
-if (process.argv.includes('--agent-engine')) {
-  agentCardPath = 'a2a/extendedAgentCard'; // Agent Engine doesn't use well-known public agent card endpoint.
-}
+
+const serverUrl = positionals[0] ?? 'http://localhost:41241'; // Agent's base URL
+const serviceParameters = toServiceParameters(flags.auth, flags['svc-param'] ?? []);
+
 const factory = new ClientFactory(
   ClientFactoryOptions.createFrom(ClientFactoryOptions.default, {
-    cardResolver: new DefaultAgentCardResolver({ fetchImpl }),
+    cardResolver: new DefaultAgentCardResolver({ fetchImpl: fetchWithHeaders(serviceParameters) }),
     transports: [
-      new JsonRpcTransportFactory({ fetchImpl }),
-      new RestTransportFactory({ fetchImpl }),
+      new JsonRpcTransportFactory(),
+      new RestTransportFactory(),
       new GrpcTransportFactory(),
     ],
-    preferredTransports: preferredTransport ? [preferredTransport] : undefined,
+    preferredTransports: flags.transport ? [flags.transport] : undefined,
   })
 );
-const client = buildAgentCardFromTransport
-  ? await factory.createFromAgentCard(agentCardFromTransport(serverUrl, preferredTransport))
-  : await factory.createFromUrl(serverUrl, agentCardPath);
+const client = flags['no-agent-card']
+  ? await factory.createFromAgentCard(agentCardFromTransport(serverUrl, flags.transport))
+  : await factory.createFromUrl(serverUrl, flags['card-path']);
 let agentName = 'Agent'; // Default, try to get from agent card later
 
 // --- Readline Setup ---
@@ -261,19 +290,19 @@ function printMessageContent(message: Message) {
 async function fetchAndDisplayAgentCard() {
   // Use the client's getAgentCard method.
   // The client was initialized with serverUrl, which is the agent's base URL.
-  if (buildAgentCardFromTransport) {
+  if (flags['no-agent-card']) {
     console.log(colorize('dim', `Using synthesized agent card (no discovery) for: ${serverUrl}`));
   } else {
     console.log(colorize('dim', `Attempting to fetch agent card from agent at: ${serverUrl}`));
   }
   try {
     // client.getAgentCard() uses the agentBaseUrl provided during client construction
-    const card: AgentCard = await client.getAgentCard();
+    const card: AgentCard = await client.getAgentCard({ serviceParameters });
     agentName = card.name || 'Agent'; // Update global agent name
     console.log(
       colorize(
         'green',
-        buildAgentCardFromTransport ? `✓ Using Synthesized Agent Card:` : `✓ Agent Card Found:`
+        flags['no-agent-card'] ? `✓ Using Synthesized Agent Card:` : `✓ Agent Card Found:`
       )
     );
     console.log(`  Name:        ${colorize('bright', agentName)}`);
@@ -314,9 +343,6 @@ async function fetchAndDisplayAgentCard() {
 async function main() {
   console.log(colorize('bright', `A2A Terminal Client`));
   console.log(colorize('dim', `Agent Base URL: ${serverUrl}`));
-  if (useAdcAuth) {
-    console.log(colorize('dim', `Auth: ${colorize('green', 'Google ADC (Bearer token)')}`));
-  }
 
   await fetchAndDisplayAgentCard(); // Fetch the card before starting the loop
 
@@ -403,7 +429,7 @@ async function main() {
     try {
       console.log(colorize('red', 'Sending message...'));
       // Use sendMessageStream
-      const stream = client.sendMessageStream(params);
+      const stream = client.sendMessageStream(params, { serviceParameters });
 
       // Iterate over the events from the stream
       for await (const event of stream) {

--- a/src/samples/package-lock.json
+++ b/src/samples/package-lock.json
@@ -7,7 +7,6 @@
       "dependencies": {
         "@bufbuild/protobuf": "^2.10.2",
         "@grpc/grpc-js": "^1.14.4",
-        "google-auth-library": "^10.5.0",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -1653,7 +1652,9 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -1670,7 +1671,9 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -1682,7 +1685,9 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=12"
       },
@@ -1694,13 +1699,17 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -1717,7 +1726,9 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -1732,7 +1743,9 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -3170,6 +3183,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3589,6 +3603,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -3737,12 +3752,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3763,6 +3781,7 @@
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -3797,7 +3816,9 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3806,6 +3827,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
@@ -4002,7 +4024,9 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -4016,6 +4040,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -4025,6 +4050,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4126,12 +4152,15 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -4375,6 +4404,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/farmhash-modern": {
@@ -4478,6 +4508,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
       "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4756,7 +4787,9 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
       "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
         "signal-exit": "^4.0.1"
@@ -4813,6 +4846,7 @@
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -5029,7 +5063,9 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
       "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
@@ -5049,7 +5085,9 @@
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
       "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -5067,7 +5105,9 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
       "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -5082,7 +5122,9 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
       "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "gaxios": "^7.0.0",
         "google-logging-utils": "^1.0.0",
@@ -5096,7 +5138,9 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
       "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=14"
       }
@@ -5331,7 +5375,9 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
       "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "gaxios": "^7.0.0",
         "jws": "^4.0.0"
@@ -5344,7 +5390,9 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz",
       "integrity": "sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==",
+      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -5495,6 +5543,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -5622,13 +5671,17 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -5663,6 +5716,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
@@ -5760,6 +5814,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -5790,6 +5845,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jwa": "^2.0.1",
@@ -6021,7 +6077,9 @@
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^2.0.2"
       },
@@ -6045,7 +6103,9 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -6060,6 +6120,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -6083,6 +6144,7 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6102,6 +6164,7 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -6201,7 +6264,9 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "license": "BlueOak-1.0.0"
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -6279,7 +6344,9 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -6294,7 +6361,9 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -6310,7 +6379,9 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/path-to-regexp": {
       "version": "8.3.0",
@@ -6618,7 +6689,9 @@
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
       "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^10.3.7"
       },
@@ -6650,6 +6723,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6746,7 +6820,9 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -6758,7 +6834,9 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -6845,7 +6923,9 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=14"
       },
@@ -6928,7 +7008,9 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -6955,7 +7037,9 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -7238,6 +7322,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -7292,7 +7377,9 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -7369,7 +7456,9 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/src/samples/package.json
+++ b/src/samples/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.10.2",
     "@grpc/grpc-js": "^1.14.4",
-    "google-auth-library": "^10.5.0",
     "uuid": "^11.1.0"
   }
 }

--- a/test/integration/samples_smoke.spec.ts
+++ b/test/integration/samples_smoke.spec.ts
@@ -1,5 +1,6 @@
 import { ChildProcess, spawn } from 'node:child_process';
 import { once } from 'node:events';
+import http from 'node:http';
 import path from 'node:path';
 import net from 'node:net';
 import { fileURLToPath } from 'node:url';
@@ -73,6 +74,34 @@ async function waitForAgentCard(url: string, agent: ChildProcess): Promise<void>
   throw new Error(`Agent did not become ready at ${url}`);
 }
 
+/**
+ * Runs the CLI with `args`, sends one greeting once it has connected, and
+ * returns everything it printed. `done` says when the exchange is over: the
+ * CLI must not be closed mid-request or readline tears down the loop.
+ */
+async function driveCli(
+  args: string[],
+  label: string,
+  done: (output: string) => boolean
+): Promise<string> {
+  const cli = runSample(CLI_SCRIPT, args, {});
+  let output = '';
+  const collect = (chunk: Buffer): void => {
+    output += chunk.toString('utf8');
+  };
+  cli.stdout?.on('data', collect);
+  cli.stderr?.on('data', collect);
+
+  await waitFor(() => output.includes('Connected via'), `${label} to connect`, cli);
+  cli.stdin?.write('hello\n');
+  await waitFor(() => done(output), `${label} response`, cli);
+  cli.stdin?.end('/exit\n');
+
+  const [code] = (await once(cli, 'exit')) as [number | null];
+  expect(code, output).toBe(0);
+  return output;
+}
+
 describe('samples smoke: multi-transport-agent + cli', () => {
   let agent: ChildProcess | undefined;
   let baseUrl: string;
@@ -100,34 +129,59 @@ describe('samples smoke: multi-transport-agent + cli', () => {
 
   describe.each(TRANSPORTS)('transport %s', (transport) => {
     it('round-trips a greeting', async () => {
-      const output = await runCli(transport);
+      const output = await driveCli(
+        [`--transport=${transport}`, baseUrl],
+        transport,
+        (out) => out.includes(EXPECTED_REPLY) && out.includes(COMPLETED_MARKER)
+      );
       expect(output, output).toContain(EXPECTED_REPLY);
       expect(output, output).toContain(COMPLETED_MARKER);
     });
   });
+});
 
-  async function runCli(transport: string): Promise<string> {
-    const cli = runSample(CLI_SCRIPT, [`--transport=${transport}`, baseUrl], {});
-    let output = '';
-    const collect = (chunk: Buffer): void => {
-      output += chunk.toString('utf8');
-    };
-    cli.stdout?.on('data', collect);
-    cli.stderr?.on('data', collect);
+describe('samples smoke: cli service parameters', () => {
+  it('sends --auth and --svc-param on discovery and on every request', async () => {
+    // Stub agent: serves a card, records what it was called with, and fails the
+    // message request — the CLI reports the error and stays in its loop.
+    const requests: http.IncomingMessage[] = [];
+    const server = http.createServer((req, res) => {
+      requests.push(req);
+      if (req.url?.includes('agent-card')) {
+        res.setHeader('content-type', 'application/json');
+        res.end(
+          JSON.stringify({
+            name: 'Header Probe',
+            supportedInterfaces: [
+              { url: `http://${req.headers.host}`, protocolBinding: 'JSONRPC' },
+            ],
+          })
+        );
+        return;
+      }
+      res.statusCode = 500;
+      res.end('{}');
+    });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+    const { port } = server.address() as net.AddressInfo;
 
-    // Send the greeting only once connected, and wait for the terminal event
-    // before `/exit`, otherwise readline closes the loop mid-request.
-    await waitFor(() => output.includes('Connected via'), `${transport} to connect`, cli);
-    cli.stdin?.write('hello\n');
-    await waitFor(
-      () => output.includes(EXPECTED_REPLY) && output.includes(COMPLETED_MARKER),
-      `${transport} greeting reply`,
-      cli
-    );
-    cli.stdin?.end('/exit\n');
+    try {
+      await driveCli(
+        ['--auth', 'Bearer test-token', '--svc-param', 'X-Demo=1', `http://127.0.0.1:${port}`],
+        'probe',
+        () => requests.some((req) => req.method === 'POST')
+      );
+    } finally {
+      server.close();
+    }
 
-    const [code] = (await once(cli, 'exit')) as [number | null];
-    expect(code, output).toBe(0);
-    return output;
-  }
+    // The card GET and the message POST take different paths through the CLI:
+    // the resolver's fetch wrapper and per-call `serviceParameters`.
+    expect(requests.map((req) => req.method)).toEqual(['GET', 'POST']);
+    for (const req of requests) {
+      expect(req.headers.authorization, req.url).toBe('Bearer test-token');
+      expect(req.headers['x-demo'], req.url).toBe('1');
+    }
+  });
 });


### PR DESCRIPTION
Replace ad-hoc `google-auth-library` integration with `--auth`/`--svc-param` so that auth header can be provided externally, e.g. `--auth "Bearer $(gcloud auth print-access-token)"` (inspired by [a2a-go cli](https://github.com/a2aproject/a2a-go/tree/main/cmd)).

1. Remove `google-auth-library` dependency.
2. Replace manual args parsing with `node:util.parseArgs` as it got too complicated with repeated `--svc-param` support.
3. Update integration test to test new functionality.
