### PR TITLE
fix(server): send full Task on every v0.3 push trigger

### DIFF
--- a/src/compat/v0_3/README.md
+++ b/src/compat/v0_3/README.md
@@ -84,7 +84,7 @@ The legacy `tasks/resubscribe` handler always responds with `Content-Type: text/
 
 ## Push Notifications
 
-Webhooks registered over v0.3 transports must receive the v0.3-shaped HTTP body, not the v1.0 `StreamResponse` wrapper. Per the v0.3 spec example (§9.5), the body is the **bare event object** (a v0.3 JSON `Task`, `TaskStatusUpdateEvent`, or `TaskArtifactUpdateEvent` discriminated by its `kind` field) with `Content-Type: application/json` — no `StreamResponse` discriminator and no JSON-RPC envelope.
+Webhooks registered over v0.3 transports must receive the v0.3-shaped HTTP body, not the v1.0 `StreamResponse` wrapper. Per the v0.3 spec example (§9.5), a push notification **always delivers the full `Task`** on every trigger — status and artifact updates are sent as the current `Task` snapshot, not as a bare `TaskStatusUpdateEvent` / `TaskArtifactUpdateEvent`. The body is the v0.3 JSON `Task` (discriminated by its `kind` field) with `Content-Type: application/json` — no `StreamResponse` discriminator and no JSON-RPC envelope.
 
 This is implemented by two pieces working together:
 

--- a/src/compat/v0_3/server/push_notification/v03_push_notification_serializer.ts
+++ b/src/compat/v0_3/server/push_notification/v03_push_notification_serializer.ts
@@ -27,7 +27,7 @@ export class V03PushNotificationSerializer implements PushNotificationSerializer
     let legacyEvent: unknown;
     switch (payload.$case) {
       case 'task':
-        legacyEvent = toCompatTask(payload.value);
+        legacyEvent = toCompatTask(task || payload.value);
         break;
       case 'message':
         legacyEvent = toCompatMessage(payload.value);

--- a/src/compat/v0_3/server/push_notification/v03_push_notification_serializer.ts
+++ b/src/compat/v0_3/server/push_notification/v03_push_notification_serializer.ts
@@ -2,7 +2,7 @@ import {
   PushNotificationSerializer,
   SerializedPushNotification,
 } from '../../../../server/push_notification/push_notification_serializer.js';
-import { StreamResponse } from '../../../../index.js';
+import { StreamResponse, Task } from '../../../../index.js';
 import { LEGACY_JSON_CONTENT_TYPE } from '../../constants.js';
 import {
   toCompatTask,
@@ -18,7 +18,7 @@ import { toCompatMessage } from '../../translate/messages.js';
  * JSON-RPC envelope.
  */
 export class V03PushNotificationSerializer implements PushNotificationSerializer {
-  serialize(streamResponse: StreamResponse): SerializedPushNotification {
+  serialize(streamResponse: StreamResponse, task?: Task): SerializedPushNotification {
     const payload = streamResponse.payload;
     if (!payload) {
       throw new Error('StreamResponse payload is undefined');
@@ -33,10 +33,18 @@ export class V03PushNotificationSerializer implements PushNotificationSerializer
         legacyEvent = toCompatMessage(payload.value);
         break;
       case 'statusUpdate':
-        legacyEvent = toCompatTaskStatusUpdateEvent(payload.value);
+        if (task !== undefined) {
+          legacyEvent = toCompatTask(task);
+        } else {
+          legacyEvent = toCompatTaskStatusUpdateEvent(payload.value);
+        }
         break;
       case 'artifactUpdate':
-        legacyEvent = toCompatTaskArtifactUpdateEvent(payload.value);
+        if (task !== undefined) {
+          legacyEvent = toCompatTask(task);
+        } else {
+          legacyEvent = toCompatTaskArtifactUpdateEvent(payload.value);
+        }
         break;
       default: {
         // Exhaustive check on the `StreamResponse` payload union.

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -1,4 +1,4 @@
-import { TaskPushNotificationConfig, StreamResponse } from '../../index.js';
+import { TaskPushNotificationConfig, StreamResponse, Task } from '../../index.js';
 import {
   A2A_LEGACY_PROTOCOL_VERSION,
   A2A_PROTOCOL_VERSION,
@@ -78,7 +78,11 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     this.fallbackSerializer = this.serializers.get(ProtocolVersion.V1_0) ?? builtinV1;
   }
 
-  async send(streamResponse: StreamResponse, context: ServerCallContext): Promise<void> {
+  async send(
+    streamResponse: StreamResponse,
+    context: ServerCallContext,
+    task?: Task
+  ): Promise<void> {
     const taskId = this._getTaskId(streamResponse);
     // Stand-alone messages with no task association can't have a
     // registered push config — skip the store round-trip.
@@ -100,7 +104,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
       .then(async () => {
         const dispatches = storedConfigs.map(async (storedConfig) => {
           try {
-            await this._dispatchNotification(streamResponse, storedConfig, taskId);
+            await this._dispatchNotification(streamResponse, storedConfig, taskId, task);
           } catch (error) {
             console.error(
               `Error sending push notification for task_id=${taskId} to URL: ${storedConfig.config.url}. Error:`,
@@ -208,7 +212,8 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
   private async _dispatchNotification(
     streamResponse: StreamResponse,
     storedConfig: StoredPushNotificationConfig,
-    taskId: string
+    taskId: string,
+    task?: Task
   ): Promise<void> {
     const { config: pushConfig, wireVersion } = storedConfig;
     const url = pushConfig.url;
@@ -217,7 +222,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
 
     try {
       const serializer = this._resolveSerializer(wireVersion);
-      const { body, contentType } = serializer.serialize(streamResponse);
+      const { body, contentType } = serializer.serialize(streamResponse, task);
 
       const response = await fetch(url, {
         method: 'POST',

--- a/src/server/push_notification/push_notification_sender.ts
+++ b/src/server/push_notification/push_notification_sender.ts
@@ -1,6 +1,6 @@
-import { StreamResponse } from '../../index.js';
+import { StreamResponse, Task } from '../../index.js';
 import { ServerCallContext } from '../context.js';
 
 export interface PushNotificationSender {
-  send(streamResponse: StreamResponse, context: ServerCallContext): Promise<void>;
+  send(streamResponse: StreamResponse, context: ServerCallContext, task?: Task): Promise<void>;
 }

--- a/src/server/push_notification/push_notification_serializer.ts
+++ b/src/server/push_notification/push_notification_serializer.ts
@@ -1,4 +1,4 @@
-import { StreamResponse } from '../../index.js';
+import { StreamResponse, Task } from '../../index.js';
 import { A2A_CONTENT_TYPE } from '../../constants.js';
 
 /** HTTP body and content type for a single push-notification dispatch. */
@@ -20,7 +20,7 @@ export interface SerializedPushNotification {
  * over, so v0.3-registered webhooks keep receiving v0.3-shaped payloads.
  */
 export interface PushNotificationSerializer {
-  serialize(streamResponse: StreamResponse): SerializedPushNotification;
+  serialize(streamResponse: StreamResponse, task?: Task): SerializedPushNotification;
 }
 
 /**
@@ -29,7 +29,7 @@ export interface PushNotificationSerializer {
  * `application/a2a+json`.
  */
 export class V1PushNotificationSerializer implements PushNotificationSerializer {
-  serialize(streamResponse: StreamResponse): SerializedPushNotification {
+  serialize(streamResponse: StreamResponse, _task?: Task): SerializedPushNotification {
     return {
       body: JSON.stringify(StreamResponse.toJSON(streamResponse)),
       contentType: A2A_CONTENT_TYPE,

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -54,7 +54,6 @@ import { PushNotificationSender } from '../push_notification/push_notification_s
 import { DefaultPushNotificationSender } from '../push_notification/default_push_notification_sender.js';
 import { ServerCallContext } from '../context.js';
 import { DEFAULT_PAGE_SIZE } from '../../constants.js';
-import { isLegacyVersion } from '../../version_utils.js';
 import {
   AUTH_REQUIRED_STATE_LIST,
   INTERRUPTED_STATE_LIST,
@@ -74,12 +73,6 @@ export interface DefaultRequestHandlerOptions {
    * the default list.
    */
   keepBusAliveStates?: TaskState[];
-}
-
-/** Destination a mapped {@link StreamResponse} is headed for. */
-enum StreamResponseDeliveryTarget {
-  ClientStream = 'clientStream',
-  PushNotification = 'pushNotification',
 }
 
 /**
@@ -278,13 +271,12 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         await resultManager.processEvent(event);
 
         try {
-          const streamResponse = this._mapEventToStreamResponse(
-            event,
+          const streamResponse = this._mapEventToStreamResponse(event, context, resultManager);
+          await this._sendPushNotificationIfNeeded(
             context,
-            resultManager,
-            StreamResponseDeliveryTarget.PushNotification
+            streamResponse,
+            structuredClone(resultManager.getCurrentTask())
           );
-          await this._sendPushNotificationIfNeeded(context, streamResponse);
         } catch (error) {
           console.error(`Error sending push notification: ${error}`);
         }
@@ -720,12 +712,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
         await resultManager.processEvent(event);
 
-        const streamResponse = this._mapEventToStreamResponse(
-          event,
-          context,
-          resultManager,
-          StreamResponseDeliveryTarget.ClientStream
-        );
+        const streamResponse = this._mapEventToStreamResponse(event, context, resultManager);
         if (streamResponse.payload?.$case === 'task') {
           this._applyHistoryLengthSemantics(
             streamResponse.payload.value,
@@ -733,16 +720,11 @@ export class DefaultRequestHandler implements A2ARequestHandler {
           );
         }
 
-        // v0.3 push carries the full Task on every trigger; v1 mirrors the stream.
-        const pushNotificationResponse = isLegacyVersion(context.requestedVersion)
-          ? this._mapEventToStreamResponse(
-              event,
-              context,
-              resultManager,
-              StreamResponseDeliveryTarget.PushNotification
-            )
-          : streamResponse;
-        await this._sendPushNotificationIfNeeded(context, pushNotificationResponse);
+        await this._sendPushNotificationIfNeeded(
+          context,
+          streamResponse,
+          structuredClone(resultManager.getCurrentTask())
+        );
         yield streamResponse;
       }
     } finally {
@@ -1012,8 +994,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   private _mapEventToStreamResponse(
     event: AgentExecutionEvent,
     context: ServerCallContext,
-    resultManager: ResultManager,
-    deliveryTarget: StreamResponseDeliveryTarget
+    resultManager: ResultManager
   ): StreamResponse {
     switch (event.kind) {
       case 'task': {
@@ -1025,15 +1006,6 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         return { payload: { $case: 'message', value: event.data } };
       case 'statusUpdate':
       case 'artifactUpdate': {
-        const isLegacyPushNotification =
-          deliveryTarget === StreamResponseDeliveryTarget.PushNotification &&
-          isLegacyVersion(context.requestedVersion);
-
-        const currentTask = isLegacyPushNotification ? resultManager.getCurrentTask() : undefined;
-        if (currentTask) {
-          return { payload: { $case: 'task', value: structuredClone(currentTask) } };
-        }
-
         return event.kind === 'statusUpdate'
           ? { payload: { $case: 'statusUpdate', value: event.data } }
           : { payload: { $case: 'artifactUpdate', value: event.data } };
@@ -1051,10 +1023,11 @@ export class DefaultRequestHandler implements A2ARequestHandler {
    */
   private async _sendPushNotificationIfNeeded(
     context: ServerCallContext,
-    streamResponse: StreamResponse
+    streamResponse: StreamResponse,
+    task?: Task
   ): Promise<void> {
     if (this.agentCard.capabilities?.pushNotifications && this.pushNotificationSender) {
-      this.pushNotificationSender.send(streamResponse, context).catch((error) => {
+      this.pushNotificationSender.send(streamResponse, context, task).catch((error) => {
         console.error(`Failed to send push notification:`, error);
       });
     }

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -54,6 +54,7 @@ import { PushNotificationSender } from '../push_notification/push_notification_s
 import { DefaultPushNotificationSender } from '../push_notification/default_push_notification_sender.js';
 import { ServerCallContext } from '../context.js';
 import { DEFAULT_PAGE_SIZE } from '../../constants.js';
+import { isLegacyVersion } from '../../version_utils.js';
 import {
   AUTH_REQUIRED_STATE_LIST,
   INTERRUPTED_STATE_LIST,
@@ -73,6 +74,12 @@ export interface DefaultRequestHandlerOptions {
    * the default list.
    */
   keepBusAliveStates?: TaskState[];
+}
+
+/** Destination a mapped {@link StreamResponse} is headed for. */
+enum StreamResponseDeliveryTarget {
+  ClientStream = 'clientStream',
+  PushNotification = 'pushNotification',
 }
 
 /**
@@ -271,7 +278,12 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         await resultManager.processEvent(event);
 
         try {
-          const streamResponse = await this._mapEventToStreamResponse(event, context);
+          const streamResponse = this._mapEventToStreamResponse(
+            event,
+            context,
+            resultManager,
+            StreamResponseDeliveryTarget.PushNotification
+          );
           await this._sendPushNotificationIfNeeded(context, streamResponse);
         } catch (error) {
           console.error(`Error sending push notification: ${error}`);
@@ -708,14 +720,29 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
         await resultManager.processEvent(event);
 
-        const streamResponse = await this._mapEventToStreamResponse(event, context);
+        const streamResponse = this._mapEventToStreamResponse(
+          event,
+          context,
+          resultManager,
+          StreamResponseDeliveryTarget.ClientStream
+        );
         if (streamResponse.payload?.$case === 'task') {
           this._applyHistoryLengthSemantics(
             streamResponse.payload.value,
             params.configuration ?? {}
           );
         }
-        await this._sendPushNotificationIfNeeded(context, streamResponse);
+
+        // v0.3 push carries the full Task on every trigger; v1 mirrors the stream.
+        const pushNotificationResponse = isLegacyVersion(context.requestedVersion)
+          ? this._mapEventToStreamResponse(
+              event,
+              context,
+              resultManager,
+              StreamResponseDeliveryTarget.PushNotification
+            )
+          : streamResponse;
+        await this._sendPushNotificationIfNeeded(context, pushNotificationResponse);
         yield streamResponse;
       }
     } finally {
@@ -976,29 +1003,41 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   }
 
   /**
-   * Maps an {@link AgentExecutionEvent} to a `StreamResponse`. For Task
-   * events the full task is loaded from the store to include accumulated
-   * history and artifacts.
+   * Maps an {@link AgentExecutionEvent} to a `StreamResponse`, resolving
+   * Task events from the {@link ResultManager} snapshot. For a legacy
+   * (v0.3) push notification, status/artifact updates are replaced by the
+   * full Task, which v0.3 always sends; the client stream and v1.0 keep
+   * the raw event.
    */
-  private async _mapEventToStreamResponse(
+  private _mapEventToStreamResponse(
     event: AgentExecutionEvent,
-    context: ServerCallContext
-  ): Promise<StreamResponse> {
+    context: ServerCallContext,
+    resultManager: ResultManager,
+    deliveryTarget: StreamResponseDeliveryTarget
+  ): StreamResponse {
     switch (event.kind) {
       case 'task': {
-        const taskId = event.data.id;
-        const fullTask = await this.taskStore.load(taskId, context).catch((error): Task | null => {
-          console.warn('Failed to load full task from store, falling back to event data:', error);
-          return null;
-        });
-        return { payload: { $case: 'task', value: fullTask || event.data } };
+        const currentTask = resultManager.getCurrentTask();
+        const taskValue = currentTask ? structuredClone(currentTask) : event.data;
+        return { payload: { $case: 'task', value: taskValue } };
       }
       case 'message':
         return { payload: { $case: 'message', value: event.data } };
       case 'statusUpdate':
-        return { payload: { $case: 'statusUpdate', value: event.data } };
-      case 'artifactUpdate':
-        return { payload: { $case: 'artifactUpdate', value: event.data } };
+      case 'artifactUpdate': {
+        const isLegacyPushNotification =
+          deliveryTarget === StreamResponseDeliveryTarget.PushNotification &&
+          isLegacyVersion(context.requestedVersion);
+
+        const currentTask = isLegacyPushNotification ? resultManager.getCurrentTask() : undefined;
+        if (currentTask) {
+          return { payload: { $case: 'task', value: structuredClone(currentTask) } };
+        }
+
+        return event.kind === 'statusUpdate'
+          ? { payload: { $case: 'statusUpdate', value: event.data } }
+          : { payload: { $case: 'artifactUpdate', value: event.data } };
+      }
       default:
         assertUnreachableEvent(event);
     }

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -271,11 +271,11 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         await resultManager.processEvent(event);
 
         try {
-          const streamResponse = this._mapEventToStreamResponse(event, context, resultManager);
+          const streamResponse = await this._mapEventToStreamResponse(event, context);
           await this._sendPushNotificationIfNeeded(
             context,
             streamResponse,
-            structuredClone(resultManager.getCurrentTask())
+            resultManager.getCurrentTask()
           );
         } catch (error) {
           console.error(`Error sending push notification: ${error}`);
@@ -712,7 +712,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
         await resultManager.processEvent(event);
 
-        const streamResponse = this._mapEventToStreamResponse(event, context, resultManager);
+        const streamResponse = await this._mapEventToStreamResponse(event, context);
         if (streamResponse.payload?.$case === 'task') {
           this._applyHistoryLengthSemantics(
             streamResponse.payload.value,
@@ -723,7 +723,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         await this._sendPushNotificationIfNeeded(
           context,
           streamResponse,
-          structuredClone(resultManager.getCurrentTask())
+          resultManager.getCurrentTask()
         );
         yield streamResponse;
       }
@@ -991,24 +991,25 @@ export class DefaultRequestHandler implements A2ARequestHandler {
    * full Task, which v0.3 always sends; the client stream and v1.0 keep
    * the raw event.
    */
-  private _mapEventToStreamResponse(
+  private async _mapEventToStreamResponse(
     event: AgentExecutionEvent,
-    context: ServerCallContext,
-    resultManager: ResultManager
-  ): StreamResponse {
+    context: ServerCallContext
+  ): Promise<StreamResponse> {
     switch (event.kind) {
       case 'task': {
-        const currentTask = resultManager.getCurrentTask();
-        const taskValue = currentTask ? structuredClone(currentTask) : event.data;
-        return { payload: { $case: 'task', value: taskValue } };
+        const taskId = event.data.id;
+        const fullTask = await this.taskStore.load(taskId, context).catch((error): Task | null => {
+          console.warn('Failed to load full task from store, falling back to event data:', error);
+          return null;
+        });
+        return { payload: { $case: 'task', value: fullTask || event.data } };
       }
       case 'message':
         return { payload: { $case: 'message', value: event.data } };
       case 'statusUpdate':
+        return { payload: { $case: 'statusUpdate', value: event.data } };
       case 'artifactUpdate': {
-        return event.kind === 'statusUpdate'
-          ? { payload: { $case: 'statusUpdate', value: event.data } }
-          : { payload: { $case: 'artifactUpdate', value: event.data } };
+        return { payload: { $case: 'artifactUpdate', value: event.data } };
       }
       default:
         assertUnreachableEvent(event);

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -985,11 +985,9 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   }
 
   /**
-   * Maps an {@link AgentExecutionEvent} to a `StreamResponse`, resolving
-   * Task events from the {@link ResultManager} snapshot. For a legacy
-   * (v0.3) push notification, status/artifact updates are replaced by the
-   * full Task, which v0.3 always sends; the client stream and v1.0 keep
-   * the raw event.
+   * Maps an {@link AgentExecutionEvent} to a `StreamResponse`. For Task
+   * events the full task is loaded from the store to include accumulated
+   * history and artifacts.
    */
   private async _mapEventToStreamResponse(
     event: AgentExecutionEvent,
@@ -1008,9 +1006,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         return { payload: { $case: 'message', value: event.data } };
       case 'statusUpdate':
         return { payload: { $case: 'statusUpdate', value: event.data } };
-      case 'artifactUpdate': {
+      case 'artifactUpdate':
         return { payload: { $case: 'artifactUpdate', value: event.data } };
-      }
       default:
         assertUnreachableEvent(event);
     }

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -275,7 +275,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
           await this._sendPushNotificationIfNeeded(
             context,
             streamResponse,
-            resultManager.getCurrentTask()
+            structuredClone(resultManager.getCurrentTask())
           );
         } catch (error) {
           console.error(`Error sending push notification: ${error}`);

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -56,6 +56,7 @@ import { PushNotificationSender } from '../push_notification/push_notification_s
 import { DefaultPushNotificationSender } from '../push_notification/default_push_notification_sender.js';
 import { ServerCallContext } from '../context.js';
 import { DEFAULT_PAGE_SIZE } from '../../constants.js';
+import { isLegacyVersion } from '../../version_utils.js';
 import {
   AUTH_REQUIRED_STATE_LIST,
   INTERRUPTED_STATE_LIST,
@@ -65,6 +66,12 @@ import {
 } from '../utils.js';
 import { AgentCardSignatureGenerator } from '../../signature.js';
 import { extractErrorMessage } from '../../errors/index.js';
+
+/** Destination a mapped {@link StreamResponse} is headed for. */
+enum StreamResponseDeliveryTarget {
+  ClientStream = 'clientStream',
+  PushNotification = 'pushNotification',
+}
 
 /**
  * Default implementation of the A2A request handler.
@@ -259,7 +266,12 @@ export class DefaultRequestHandler implements A2ARequestHandler {
         await resultManager.processEvent(event);
 
         try {
-          const streamResponse = await this._mapEventToStreamResponse(event, context);
+          const streamResponse = this._mapEventToStreamResponse(
+            event,
+            context,
+            resultManager,
+            StreamResponseDeliveryTarget.PushNotification
+          );
           await this._sendPushNotificationIfNeeded(context, streamResponse);
         } catch (error) {
           console.error(`Error sending push notification: ${error}`);
@@ -696,14 +708,29 @@ export class DefaultRequestHandler implements A2ARequestHandler {
 
         await resultManager.processEvent(event);
 
-        const streamResponse = await this._mapEventToStreamResponse(event, context);
+        const streamResponse = this._mapEventToStreamResponse(
+          event,
+          context,
+          resultManager,
+          StreamResponseDeliveryTarget.ClientStream
+        );
         if (streamResponse.payload?.$case === 'task') {
           this._applyHistoryLengthSemantics(
             streamResponse.payload.value,
             params.configuration ?? {}
           );
         }
-        await this._sendPushNotificationIfNeeded(context, streamResponse);
+
+        // v0.3 push carries the full Task on every trigger; v1 mirrors the stream.
+        const pushNotificationResponse = isLegacyVersion(context.requestedVersion)
+          ? this._mapEventToStreamResponse(
+              event,
+              context,
+              resultManager,
+              StreamResponseDeliveryTarget.PushNotification
+            )
+          : streamResponse;
+        await this._sendPushNotificationIfNeeded(context, pushNotificationResponse);
         yield streamResponse;
       }
     } finally {
@@ -964,29 +991,41 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   }
 
   /**
-   * Maps an {@link AgentExecutionEvent} to a `StreamResponse`. For Task
-   * events the full task is loaded from the store to include accumulated
-   * history and artifacts.
+   * Maps an {@link AgentExecutionEvent} to a `StreamResponse`, resolving
+   * Task events from the {@link ResultManager} snapshot. For a legacy
+   * (v0.3) push notification, status/artifact updates are replaced by the
+   * full Task, which v0.3 always sends; the client stream and v1.0 keep
+   * the raw event.
    */
-  private async _mapEventToStreamResponse(
+  private _mapEventToStreamResponse(
     event: AgentExecutionEvent,
-    context: ServerCallContext
-  ): Promise<StreamResponse> {
+    context: ServerCallContext,
+    resultManager: ResultManager,
+    deliveryTarget: StreamResponseDeliveryTarget
+  ): StreamResponse {
     switch (event.kind) {
       case 'task': {
-        const taskId = event.data.id;
-        const fullTask = await this.taskStore.load(taskId, context).catch((error): Task | null => {
-          console.warn('Failed to load full task from store, falling back to event data:', error);
-          return null;
-        });
-        return { payload: { $case: 'task', value: fullTask || event.data } };
+        const currentTask = resultManager.getCurrentTask();
+        const taskValue = currentTask ? structuredClone(currentTask) : event.data;
+        return { payload: { $case: 'task', value: taskValue } };
       }
       case 'message':
         return { payload: { $case: 'message', value: event.data } };
       case 'statusUpdate':
-        return { payload: { $case: 'statusUpdate', value: event.data } };
-      case 'artifactUpdate':
-        return { payload: { $case: 'artifactUpdate', value: event.data } };
+      case 'artifactUpdate': {
+        const isLegacyPushNotification =
+          deliveryTarget === StreamResponseDeliveryTarget.PushNotification &&
+          isLegacyVersion(context.requestedVersion);
+
+        const currentTask = isLegacyPushNotification ? resultManager.getCurrentTask() : undefined;
+        if (currentTask) {
+          return { payload: { $case: 'task', value: structuredClone(currentTask) } };
+        }
+
+        return event.kind === 'statusUpdate'
+          ? { payload: { $case: 'statusUpdate', value: event.data } }
+          : { payload: { $case: 'artifactUpdate', value: event.data } };
+      }
       default:
         assertUnreachableEvent(event);
     }

--- a/test/compat/v0_3/server/push_notification/v03_push_notification_serializer.spec.ts
+++ b/test/compat/v0_3/server/push_notification/v03_push_notification_serializer.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { V03PushNotificationSerializer } from '../../../../../src/compat/v0_3/server/push_notification/v03_push_notification_serializer.js';
 import { LEGACY_JSON_CONTENT_TYPE } from '../../../../../src/compat/v0_3/constants.js';
-import { Role, StreamResponse, TaskState } from '../../../../../src/types/pb/a2a.js';
+import { Role, StreamResponse, Task, TaskState } from '../../../../../src/types/pb/a2a.js';
 
 describe('V03PushNotificationSerializer', () => {
   const serializer = new V03PushNotificationSerializer();
@@ -197,5 +197,118 @@ describe('V03PushNotificationSerializer', () => {
   it('throws when the StreamResponse has no payload', () => {
     const event = { payload: undefined } as unknown as StreamResponse;
     expect(() => serializer.serialize(event)).toThrow(/StreamResponse payload is undefined/);
+  });
+
+  describe('when a full Task is supplied alongside an update trigger', () => {
+    // The reverted v0.3 behavior: every status/artifact update pushes the
+    // full Task, not the bare update event. The serializer is the single
+    // place that decides this — it emits the Task whenever the sender
+    // forwards one.
+    const fullTask: Task = {
+      id: 'task-full',
+      contextId: 'ctx-full',
+      status: {
+        state: TaskState.TASK_STATE_WORKING,
+        message: undefined,
+        timestamp: '2026-04-15T14:00:00Z',
+      },
+      artifacts: [
+        {
+          artifactId: 'art-1',
+          name: 'file.txt',
+          description: '',
+          parts: [
+            {
+              content: { $case: 'text', value: 'hello' },
+              filename: 'file.txt',
+              mediaType: 'text/plain',
+              metadata: {},
+            },
+          ],
+          metadata: {},
+          extensions: [],
+        },
+      ],
+      history: [],
+      metadata: {},
+    };
+
+    it('serializes the full Task instead of the bare status-update event', () => {
+      const event: StreamResponse = {
+        payload: {
+          $case: 'statusUpdate',
+          value: {
+            taskId: 'task-full',
+            contextId: 'ctx-full',
+            status: {
+              state: TaskState.TASK_STATE_WORKING,
+              message: undefined,
+              timestamp: '2026-04-15T14:00:00Z',
+            },
+            metadata: {},
+          },
+        },
+      };
+
+      const parsed = JSON.parse(serializer.serialize(event, fullTask).body);
+
+      expect(parsed.kind).toBe('task');
+      expect(parsed.id).toBe('task-full');
+      expect(parsed.status.state).toBe('working');
+      expect(parsed).not.toHaveProperty('final');
+    });
+
+    it('serializes the full Task instead of the bare artifact-update event', () => {
+      const event: StreamResponse = {
+        payload: {
+          $case: 'artifactUpdate',
+          value: {
+            taskId: 'task-full',
+            contextId: 'ctx-full',
+            artifact: {
+              artifactId: 'art-1',
+              name: 'file.txt',
+              description: '',
+              parts: [],
+              metadata: {},
+              extensions: [],
+            },
+            append: false,
+            lastChunk: true,
+            metadata: {},
+          },
+        },
+      };
+
+      const parsed = JSON.parse(serializer.serialize(event, fullTask).body);
+
+      expect(parsed.kind).toBe('task');
+      expect(parsed.id).toBe('task-full');
+      expect(parsed.artifacts).toHaveLength(1);
+      expect(parsed).not.toHaveProperty('append');
+    });
+
+    it('ignores the supplied Task for message payloads', () => {
+      const event: StreamResponse = {
+        payload: {
+          $case: 'message',
+          value: {
+            messageId: 'm-1',
+            role: Role.ROLE_AGENT,
+            parts: [],
+            contextId: 'ctx-full',
+            taskId: 'task-full',
+            extensions: [],
+            metadata: {},
+            referenceTaskIds: [],
+          },
+        },
+      };
+
+      const parsed = JSON.parse(serializer.serialize(event, fullTask).body);
+
+      expect(parsed.kind).toBe('message');
+      expect(parsed.messageId).toBe('m-1');
+    });
   });
 });

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -2638,7 +2638,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     expect(result.nextPageToken).to.equal('');
   });
 
-  it('sends a full Task push for every update when no version header is set (defaults to v0.3)', async () => {
+  it('forwards the current full Task to the sender alongside every update event', async () => {
     const mockPushNotificationStore = new InMemoryPushNotificationStore();
     const mockPushNotificationSender = new MockPushNotificationSender();
 
@@ -2689,54 +2689,36 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       history: [params.message as Message],
     };
 
-    // Verify push notifications were sent with complete task objects
+    // The handler forwards the current full Task as the third argument on
+    // every dispatch; the serializer decides the wire shape from it.
     expect((mockPushNotificationSender as MockPushNotificationSender).send).toHaveBeenCalledTimes(
       3
     );
 
-    // Verify first call (submitted state)
-    const firstCallResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
-      .calls[0][0] as StreamResponse;
-    const expectedFirstResponse: StreamResponse = {
-      payload: {
-        $case: 'task',
-        value: {
-          ...expectedTask,
-          status: {
-            state: TaskState.TASK_STATE_SUBMITTED,
-            message: undefined,
-            timestamp: undefined,
-          },
-        },
+    const firstCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.mock
+      .calls[0][2] as Task;
+    assert.deepEqual(firstCallTask, {
+      ...expectedTask,
+      status: {
+        state: TaskState.TASK_STATE_SUBMITTED,
+        message: undefined,
+        timestamp: undefined,
       },
-    };
-    assert.deepEqual(firstCallResponse, expectedFirstResponse);
+    });
 
-    const secondCallResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
-      .calls[1][0] as StreamResponse;
-    const expectedSecondResponse: StreamResponse = {
-      payload: {
-        $case: 'task',
-        value: {
-          ...expectedTask,
-          status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
-        },
-      },
-    };
-    assert.deepEqual(secondCallResponse, expectedSecondResponse);
+    const secondCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.mock
+      .calls[1][2] as Task;
+    assert.deepEqual(secondCallTask, {
+      ...expectedTask,
+      status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
+    });
 
-    const thirdCallResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
-      .calls[2][0] as StreamResponse;
-    const expectedThirdResponse: StreamResponse = {
-      payload: {
-        $case: 'task',
-        value: expectedTask,
-      },
-    };
-    assert.deepEqual(thirdCallResponse, expectedThirdResponse);
+    const thirdCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.mock
+      .calls[2][2] as Task;
+    assert.deepEqual(thirdCallTask, expectedTask);
   });
 
-  it('sendMessageStream: yields raw events to the client but pushes a full Task when no version header is set (defaults to v0.3)', async () => {
+  it('sendMessageStream: yields raw events to the client and forwards the current full Task to the sender', async () => {
     const mockPushNotificationStore = new InMemoryPushNotificationStore();
     const mockPushNotificationSender = new MockPushNotificationSender();
 
@@ -2800,7 +2782,8 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       TaskState.TASK_STATE_COMPLETED
     );
 
-    // Verify push notifications were sent with complete task objects
+    // The client stream yields the raw events; the sender receives the
+    // current full Task as the third argument on every dispatch.
     expect((mockPushNotificationSender as MockPushNotificationSender).send).toHaveBeenCalledTimes(
       3
     );
@@ -2813,46 +2796,28 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       metadata: {},
       history: [params.message as Message],
     };
-    // Verify first call (submitted state)
-    const firstCallResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
-      .calls[0][0] as StreamResponse;
-    const expectedFirstResponse: StreamResponse = {
-      payload: {
-        $case: 'task',
-        value: {
-          ...expectedTask,
-          status: {
-            state: TaskState.TASK_STATE_SUBMITTED,
-            message: undefined,
-            timestamp: undefined,
-          },
-        },
-      },
-    };
-    assert.deepEqual(firstCallResponse, expectedFirstResponse);
 
-    const secondCallResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
-      .calls[1][0] as StreamResponse;
-    const expectedSecondResponse: StreamResponse = {
-      payload: {
-        $case: 'task',
-        value: {
-          ...expectedTask,
-          status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
-        },
+    const firstCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.mock
+      .calls[0][2] as Task;
+    assert.deepEqual(firstCallTask, {
+      ...expectedTask,
+      status: {
+        state: TaskState.TASK_STATE_SUBMITTED,
+        message: undefined,
+        timestamp: undefined,
       },
-    };
-    assert.deepEqual(secondCallResponse, expectedSecondResponse);
+    });
 
-    const thirdCallResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
-      .calls[2][0] as StreamResponse;
-    const expectedThirdResponse: StreamResponse = {
-      payload: {
-        $case: 'task',
-        value: expectedTask,
-      },
-    };
-    assert.deepEqual(thirdCallResponse, expectedThirdResponse);
+    const secondCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.mock
+      .calls[1][2] as Task;
+    assert.deepEqual(secondCallTask, {
+      ...expectedTask,
+      status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
+    });
+
+    const thirdCallTask = (mockPushNotificationSender as MockPushNotificationSender).send.mock
+      .calls[2][2] as Task;
+    assert.deepEqual(thirdCallTask, expectedTask);
   });
 
   it('should send push notification when message event is received (§4.3.3)', async () => {
@@ -2927,7 +2892,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     expect(offendingCalls).toHaveLength(0);
   });
 
-  it('converts a statusUpdate trigger into a full Task push when no version header is set (defaults to v0.3)', async () => {
+  it('forwards the current full Task alongside a raw statusUpdate trigger', async () => {
     const mockPushNotificationStore = new InMemoryPushNotificationStore();
     const mockPushNotificationSender = new MockPushNotificationSender();
 
@@ -3008,15 +2973,15 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     await handler.sendMessage(params, serverCallContext);
 
     expect((mockPushNotificationSender as MockPushNotificationSender).send).toHaveBeenCalled();
-    const callResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
-      .calls[1][0] as StreamResponse;
-    expect(callResponse.payload.$case).toBe('task');
-    expect((callResponse.payload as { value: Task }).value.status?.state).toBe(
-      TaskState.TASK_STATE_WORKING
-    );
+    const statusUpdateResponse = (mockPushNotificationSender as MockPushNotificationSender).send
+      .mock.calls[1][0] as StreamResponse;
+    expect(statusUpdateResponse.payload?.$case).toBe('statusUpdate');
+    const forwardedTask = (mockPushNotificationSender as MockPushNotificationSender).send.mock
+      .calls[1][2] as Task;
+    expect(forwardedTask.status?.state).toBe(TaskState.TASK_STATE_WORKING);
   });
 
-  it('converts an artifactUpdate trigger into a full Task push when no version header is set (defaults to v0.3)', async () => {
+  it('forwards the current full Task alongside a raw artifactUpdate trigger', async () => {
     const mockPushNotificationStore = new InMemoryPushNotificationStore();
     const mockPushNotificationSender = new MockPushNotificationSender();
 
@@ -3099,10 +3064,12 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     await handler.sendMessage(params, serverCallContext);
 
     expect((mockPushNotificationSender as MockPushNotificationSender).send).toHaveBeenCalled();
-    const callResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
-      .calls[1][0] as StreamResponse;
-    expect(callResponse.payload.$case).toBe('task');
-    expect((callResponse.payload as { value: Task }).value.artifacts).toHaveLength(1);
+    const artifactUpdateResponse = (mockPushNotificationSender as MockPushNotificationSender).send
+      .mock.calls[1][0] as StreamResponse;
+    expect(artifactUpdateResponse.payload?.$case).toBe('artifactUpdate');
+    const forwardedTask = (mockPushNotificationSender as MockPushNotificationSender).send.mock
+      .calls[1][2] as Task;
+    expect(forwardedTask.artifacts).toHaveLength(1);
   });
 
   it('preserves the raw statusUpdate push body when the request sets version v1.0', async () => {

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -3231,7 +3231,6 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
             message: undefined,
             timestamp: undefined,
           },
-          final: true,
           metadata: {},
         })
       );

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -55,6 +55,7 @@ import { MockPushNotificationSender } from './mocks/push_notification_sender.moc
 import { ServerCallContext } from '../../src/server/context.js';
 import { MockTaskStore } from './mocks/task_store.mock.js';
 import { TERMINAL_STATE_LIST } from '../../src/server/utils.js';
+import { A2A_PROTOCOL_VERSION } from '../../src/constants.js';
 
 describe('DefaultRequestHandler as A2ARequestHandler', () => {
   let handler: A2ARequestHandler;
@@ -2637,7 +2638,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     expect(result.nextPageToken).to.equal('');
   });
 
-  it('should send push notification when task update is received', async () => {
+  it('sends a full Task push for every update when no version header is set (defaults to v0.3)', async () => {
     const mockPushNotificationStore = new InMemoryPushNotificationStore();
     const mockPushNotificationSender = new MockPushNotificationSender();
 
@@ -2711,44 +2712,31 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     };
     assert.deepEqual(firstCallResponse, expectedFirstResponse);
 
-    // Verify second call (working state)
     const secondCallResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
       .calls[1][0] as StreamResponse;
     const expectedSecondResponse: StreamResponse = {
       payload: {
-        $case: 'statusUpdate',
+        $case: 'task',
         value: {
-          taskId: taskId,
-          contextId: contextId,
+          ...expectedTask,
           status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
-          metadata: {},
         },
       },
     };
     assert.deepEqual(secondCallResponse, expectedSecondResponse);
 
-    // Verify third call (completed state)
     const thirdCallResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
       .calls[2][0] as StreamResponse;
     const expectedThirdResponse: StreamResponse = {
       payload: {
-        $case: 'statusUpdate',
-        value: {
-          taskId: taskId,
-          contextId: contextId,
-          status: {
-            state: TaskState.TASK_STATE_COMPLETED,
-            message: undefined,
-            timestamp: undefined,
-          },
-          metadata: {},
-        },
+        $case: 'task',
+        value: expectedTask,
       },
     };
     assert.deepEqual(thirdCallResponse, expectedThirdResponse);
   });
 
-  it('sendMessageStream: should send push notification when task update is received', async () => {
+  it('sendMessageStream: yields raw events to the client but pushes a full Task when no version header is set (defaults to v0.3)', async () => {
     const mockPushNotificationStore = new InMemoryPushNotificationStore();
     const mockPushNotificationSender = new MockPushNotificationSender();
 
@@ -2843,38 +2831,25 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     };
     assert.deepEqual(firstCallResponse, expectedFirstResponse);
 
-    // Verify second call (working state)
     const secondCallResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
       .calls[1][0] as StreamResponse;
     const expectedSecondResponse: StreamResponse = {
       payload: {
-        $case: 'statusUpdate',
+        $case: 'task',
         value: {
-          taskId: taskId,
-          contextId: contextId,
+          ...expectedTask,
           status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
-          metadata: {},
         },
       },
     };
     assert.deepEqual(secondCallResponse, expectedSecondResponse);
 
-    // Verify third call (completed state)
     const thirdCallResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
       .calls[2][0] as StreamResponse;
     const expectedThirdResponse: StreamResponse = {
       payload: {
-        $case: 'statusUpdate',
-        value: {
-          taskId: taskId,
-          contextId: contextId,
-          status: {
-            state: TaskState.TASK_STATE_COMPLETED,
-            message: undefined,
-            timestamp: undefined,
-          },
-          metadata: {},
-        },
+        $case: 'task',
+        value: expectedTask,
       },
     };
     assert.deepEqual(thirdCallResponse, expectedThirdResponse);
@@ -2952,7 +2927,7 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     expect(offendingCalls).toHaveLength(0);
   });
 
-  it('should send push notification when statusUpdate event is received', async () => {
+  it('converts a statusUpdate trigger into a full Task push when no version header is set (defaults to v0.3)', async () => {
     const mockPushNotificationStore = new InMemoryPushNotificationStore();
     const mockPushNotificationSender = new MockPushNotificationSender();
 
@@ -3035,10 +3010,13 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     expect((mockPushNotificationSender as MockPushNotificationSender).send).toHaveBeenCalled();
     const callResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
       .calls[1][0] as StreamResponse;
-    expect(callResponse.payload.$case).toBe('statusUpdate');
+    expect(callResponse.payload.$case).toBe('task');
+    expect((callResponse.payload as { value: Task }).value.status?.state).toBe(
+      TaskState.TASK_STATE_WORKING
+    );
   });
 
-  it('should send push notification when artifactUpdate event is received', async () => {
+  it('converts an artifactUpdate trigger into a full Task push when no version header is set (defaults to v0.3)', async () => {
     const mockPushNotificationStore = new InMemoryPushNotificationStore();
     const mockPushNotificationSender = new MockPushNotificationSender();
 
@@ -3123,7 +3101,211 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     expect((mockPushNotificationSender as MockPushNotificationSender).send).toHaveBeenCalled();
     const callResponse = (mockPushNotificationSender as MockPushNotificationSender).send.mock
       .calls[1][0] as StreamResponse;
-    expect(callResponse.payload.$case).toBe('artifactUpdate');
+    expect(callResponse.payload.$case).toBe('task');
+    expect((callResponse.payload as { value: Task }).value.artifacts).toHaveLength(1);
+  });
+
+  it('preserves the raw statusUpdate push body when the request sets version v1.0', async () => {
+    const mockPushNotificationStore = new InMemoryPushNotificationStore();
+    const mockPushNotificationSender = new MockPushNotificationSender();
+    const contextV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+
+    const handler = new DefaultRequestHandler(
+      testAgentCard,
+      mockTaskStore,
+      mockAgentExecutor,
+      executionEventBusManager,
+      mockPushNotificationStore,
+      mockPushNotificationSender
+    );
+    const contextId = 'ctx-push-status-v1';
+    const params: SendMessageRequest = {
+      tenant: '',
+      metadata: {},
+      message: {
+        ...createTestMessage('msg-push-status-v1', 'Test status push v1'),
+        contextId,
+      },
+      configuration: {
+        taskPushNotificationConfig: {
+          tenant: '',
+          taskId: '',
+          url: 'https://push-v1.com',
+          id: 'push-v1',
+          token: 'token-v1',
+          authentication: undefined,
+        },
+      } as SendMessageConfiguration,
+    };
+
+    (mockAgentExecutor as MockAgentExecutor).execute.mockImplementation(fakeTaskExecute);
+
+    await handler.sendMessage(params, contextV1);
+
+    const secondCall = (mockPushNotificationSender as MockPushNotificationSender).send.mock
+      .calls[1][0] as StreamResponse;
+    expect(secondCall.payload.$case).toBe('statusUpdate');
+    expect((secondCall.payload as { value: TaskStatusUpdateEvent }).value.status?.state).toBe(
+      TaskState.TASK_STATE_WORKING
+    );
+  });
+
+  it('preserves the raw artifactUpdate push body when the request sets version v1.0', async () => {
+    const mockPushNotificationStore = new InMemoryPushNotificationStore();
+    const mockPushNotificationSender = new MockPushNotificationSender();
+    const contextV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+
+    const handler = new DefaultRequestHandler(
+      testAgentCard,
+      mockTaskStore,
+      mockAgentExecutor,
+      executionEventBusManager,
+      mockPushNotificationStore,
+      mockPushNotificationSender
+    );
+    const contextId = 'ctx-push-artifact-v1';
+    const params: SendMessageRequest = {
+      tenant: '',
+      metadata: {},
+      message: {
+        ...createTestMessage('msg-push-artifact-v1', 'Test artifact push v1'),
+        contextId,
+      },
+      configuration: {
+        taskPushNotificationConfig: {
+          tenant: '',
+          taskId: '',
+          url: 'https://push-v1.com',
+          id: 'push-v1',
+          token: 'token-v1',
+          authentication: undefined,
+        },
+      } as SendMessageConfiguration,
+    };
+
+    (mockAgentExecutor as MockAgentExecutor).execute.mockImplementation(async (ctx, bus) => {
+      bus.publish(
+        AgentEvent.task({
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        })
+      );
+      bus.publish(
+        AgentEvent.artifactUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          artifact: {
+            artifactId: 'art-v1',
+            name: 'file.txt',
+            description: '',
+            parts: [
+              {
+                content: { $case: 'text', value: 'hello' },
+                mediaType: 'text/plain',
+                filename: 'file.txt',
+                metadata: {},
+              },
+            ],
+            metadata: {},
+            extensions: [],
+          },
+          append: false,
+          lastChunk: true,
+          metadata: {},
+        })
+      );
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          final: true,
+          metadata: {},
+        })
+      );
+      bus.finished();
+    });
+
+    await handler.sendMessage(params, contextV1);
+
+    const secondCall = (mockPushNotificationSender as MockPushNotificationSender).send.mock
+      .calls[1][0] as StreamResponse;
+    expect(secondCall.payload.$case).toBe('artifactUpdate');
+  });
+
+  it('mirrors the historyLength-trimmed stream in the push body when the request sets version v1.0', async () => {
+    const mockPushNotificationStore = new InMemoryPushNotificationStore();
+    const mockPushNotificationSender = new MockPushNotificationSender();
+    const contextV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+
+    const handler = new DefaultRequestHandler(
+      testAgentCard,
+      mockTaskStore,
+      mockAgentExecutor,
+      executionEventBusManager,
+      mockPushNotificationStore,
+      mockPushNotificationSender
+    );
+    const contextId = 'ctx-push-stream-v1';
+    const params: SendMessageRequest = {
+      tenant: '',
+      metadata: {},
+      message: {
+        ...createTestMessage('msg-push-stream-v1', 'Stream push mirror v1'),
+        contextId,
+      },
+      configuration: {
+        taskPushNotificationConfig: {
+          tenant: '',
+          taskId: '',
+          url: 'https://push-stream-v1.com',
+          id: 'push-stream-v1',
+          token: 'token-stream-v1',
+          authentication: undefined,
+        },
+        historyLength: 0,
+        acceptedOutputModes: [],
+      } as SendMessageConfiguration,
+    };
+
+    (mockAgentExecutor as MockAgentExecutor).execute.mockImplementation(fakeTaskExecute);
+
+    const events: StreamResponse[] = [];
+    for await (const event of handler.sendMessageStream(params, contextV1)) {
+      events.push(event);
+    }
+
+    expect((mockPushNotificationSender as MockPushNotificationSender).send).toHaveBeenCalledTimes(
+      3
+    );
+
+    const pushCalls = (
+      mockPushNotificationSender as MockPushNotificationSender
+    ).send.mock.calls.map((call) => call[0] as StreamResponse);
+
+    assert.equal(events[0].payload?.$case, 'task');
+    assert.lengthOf(
+      (events[0].payload as { value: Task }).value.history!,
+      0,
+      'historyLength=0 should trim the streamed task history'
+    );
+    assert.deepEqual(pushCalls[0], events[0], 'v1 push must mirror the trimmed stream task event');
+    assert.deepEqual(pushCalls[1], events[1], 'v1 push must mirror the raw statusUpdate event');
+    assert.deepEqual(pushCalls[2], events[2], 'v1 push must mirror the raw statusUpdate event');
+    assert.equal(pushCalls[1].payload?.$case, 'statusUpdate');
+    assert.equal(pushCalls[2].payload?.$case, 'statusUpdate');
   });
 
   it('Push Notification methods should throw error if task does not exist', async () => {

--- a/test/server/mocks/push_notification_sender.mock.ts
+++ b/test/server/mocks/push_notification_sender.mock.ts
@@ -1,9 +1,10 @@
 import { vi, type Mock } from 'vitest';
-import { StreamResponse } from '../../../src/types/pb/a2a.js';
+import { StreamResponse, Task } from '../../../src/types/pb/a2a.js';
 import { PushNotificationSender } from '../../../src/server/push_notification/push_notification_sender.js';
 import { ServerCallContext } from '../../../src/server/context.js';
 
 export class MockPushNotificationSender implements PushNotificationSender {
-  public send: Mock<(streamResponse: StreamResponse, context: ServerCallContext) => Promise<void>> =
-    vi.fn().mockResolvedValue(undefined);
+  public send: Mock<
+    (streamResponse: StreamResponse, context: ServerCallContext, task?: Task) => Promise<void>
+  > = vi.fn().mockResolvedValue(undefined);
 }

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -364,6 +364,73 @@ describe('Push Notification Integration Tests', () => {
       await waitForPushNotifications(v03SenderSpy);
 
       assert.lengthOf(receivedNotifications, 3);
+      const historyLengths = receivedNotifications.map((n) => n.body.history?.length ?? 0);
+      assert.deepEqual(historyLengths, [1, 1, 1]);
+
+      for (const notification of receivedNotifications) {
+        assert.equal(notification.body.kind, 'task');
+        assert.notProperty(notification.body, 'statusUpdate');
+        assert.equal(notification.headers['content-type'], 'application/json');
+      }
+      const states = receivedNotifications.map((n) => n.body.status?.state);
+      assert.includeMembers(states, ['submitted', 'working', 'completed']);
+    });
+
+    it('forwards the full Task to a v0.3 webhook as a bare v0.3 Task body via the legacy-aware sender when streaming', async () => {
+      const v03Store = new InMemoryPushNotificationStore();
+      const v03Sender = createLegacyAwarePushNotificationSender(v03Store);
+      const v03Handler = new DefaultRequestHandler(
+        testAgentCard,
+        new InMemoryTaskStore(),
+        mockAgentExecutor,
+        new DefaultExecutionEventBusManager(),
+        v03Store,
+        v03Sender
+      );
+      const v03SenderSpy = vi.spyOn(v03Sender, 'send') as unknown as PushNotificationSenderSpy;
+
+      const contextId = 'ctx-v03-e2e-stream';
+      const params: SendMessageRequest = {
+        tenant: '',
+        metadata: {},
+        message: {
+          ...createTestMessage('Full task via v0.3 webhook streaming'),
+          contextId,
+          extensions: [],
+          metadata: {},
+        },
+        configuration: {
+          taskPushNotificationConfig: {
+            tenant: '',
+            taskId: '',
+            id: 'v03-config-stream',
+            url: `${testServerUrl}/notify`,
+            token: 'v03-token',
+            authentication: undefined,
+          },
+          historyLength: 0,
+          returnImmediately: false,
+          acceptedOutputModes: [],
+        },
+      };
+
+      mockAgentExecutor.execute.mockImplementation(async (ctx, bus) => {
+        await fakeTaskExecute(ctx, bus);
+      });
+
+      // Drain the stream so execution completes and all triggers fire.
+      const events: StreamResponse[] = [];
+      const generator = v03Handler.sendMessageStream(params, defaultContext);
+      for await (const event of generator) {
+        events.push(event);
+      }
+      await waitForPushNotifications(v03SenderSpy);
+
+      assert.isNotEmpty(events);
+      assert.lengthOf(receivedNotifications, 3);
+      const historyLengths = receivedNotifications.map((n) => n.body.history?.length ?? 0);
+      assert.deepEqual(historyLengths, [1, 1, 1]);
+
       for (const notification of receivedNotifications) {
         assert.equal(notification.body.kind, 'task');
         assert.notProperty(notification.body, 'statusUpdate');

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -281,16 +281,14 @@ describe('Push Notification Integration Tests', () => {
         secondNotification.body,
         StreamResponse.toJSON({
           payload: {
-            $case: 'statusUpdate',
+            $case: 'task',
             value: {
-              taskId: taskId,
-              contextId: contextId,
+              ...expectedTaskResult,
               status: {
                 state: TaskState.TASK_STATE_WORKING,
                 message: undefined,
                 timestamp: undefined,
               },
-              metadata: {},
             },
           },
         })
@@ -301,17 +299,8 @@ describe('Push Notification Integration Tests', () => {
         thirdNotification.body,
         StreamResponse.toJSON({
           payload: {
-            $case: 'statusUpdate',
-            value: {
-              taskId: taskId,
-              contextId: contextId,
-              status: {
-                state: TaskState.TASK_STATE_COMPLETED,
-                message: undefined,
-                timestamp: undefined,
-              },
-              metadata: {},
-            },
+            $case: 'task',
+            value: expectedTaskResult,
           },
         })
       );

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -277,11 +277,6 @@ describe('Push Notification Integration Tests', () => {
         })
       );
 
-      // The default sender has only the built-in v1.0 serializer, so a
-      // v0.3-defaulted context falls back to v1.0: the webhook receives the
-      // raw stream events (a Task for the initial submitted event, then
-      // statusUpdate events). The v0.3 full-Task shape is exercised by the
-      // legacy-aware sender test below and the V03 serializer unit tests.
       const secondNotification = receivedNotifications[1];
       assert.deepEqual(
         secondNotification.body,
@@ -289,8 +284,8 @@ describe('Push Notification Integration Tests', () => {
           payload: {
             $case: 'statusUpdate',
             value: {
-              taskId,
-              contextId,
+              taskId: taskId,
+              contextId: contextId,
               status: {
                 state: TaskState.TASK_STATE_WORKING,
                 message: undefined,
@@ -309,8 +304,8 @@ describe('Push Notification Integration Tests', () => {
           payload: {
             $case: 'statusUpdate',
             value: {
-              taskId,
-              contextId,
+              taskId: taskId,
+              contextId: contextId,
               status: {
                 state: TaskState.TASK_STATE_COMPLETED,
                 message: undefined,
@@ -324,11 +319,6 @@ describe('Push Notification Integration Tests', () => {
     });
 
     it('forwards the full Task to a v0.3 webhook as a bare v0.3 Task body via the legacy-aware sender', async () => {
-      // End-to-end proof of the reverted behavior: when the v0.3 serializer
-      // is registered (createLegacyAwarePushNotificationSender) and the
-      // request defaults to v0.3, every status update is delivered to the
-      // webhook as the full Task rendered in the bare v0.3 shape
-      // (kind: "task"), not as a status-update event.
       const v03Store = new InMemoryPushNotificationStore();
       const v03Sender = createLegacyAwarePushNotificationSender(v03Store);
       const v03Handler = new DefaultRequestHandler(
@@ -375,7 +365,6 @@ describe('Push Notification Integration Tests', () => {
 
       assert.lengthOf(receivedNotifications, 3);
       for (const notification of receivedNotifications) {
-        // Bare v0.3 Task shape — no v1 wrapper, no status-update event.
         assert.equal(notification.body.kind, 'task');
         assert.notProperty(notification.body, 'statusUpdate');
         assert.equal(notification.headers['content-type'], 'application/json');

--- a/test/server/push_notification_integration.spec.ts
+++ b/test/server/push_notification_integration.spec.ts
@@ -7,6 +7,7 @@ import { DefaultRequestHandler } from '../../src/server/request_handler/default_
 import { InMemoryTaskStore } from '../../src/server/store.js';
 import { InMemoryPushNotificationStore } from '../../src/server/push_notification/push_notification_store.js';
 import { DefaultPushNotificationSender } from '../../src/server/push_notification/default_push_notification_sender.js';
+import { createLegacyAwarePushNotificationSender } from '../../src/compat/v0_3/server/push_notification/index.js';
 import { DefaultExecutionEventBusManager } from '../../src/server/events/execution_event_bus_manager.js';
 import {
   AgentCard,
@@ -276,19 +277,26 @@ describe('Push Notification Integration Tests', () => {
         })
       );
 
+      // The default sender has only the built-in v1.0 serializer, so a
+      // v0.3-defaulted context falls back to v1.0: the webhook receives the
+      // raw stream events (a Task for the initial submitted event, then
+      // statusUpdate events). The v0.3 full-Task shape is exercised by the
+      // legacy-aware sender test below and the V03 serializer unit tests.
       const secondNotification = receivedNotifications[1];
       assert.deepEqual(
         secondNotification.body,
         StreamResponse.toJSON({
           payload: {
-            $case: 'task',
+            $case: 'statusUpdate',
             value: {
-              ...expectedTaskResult,
+              taskId,
+              contextId,
               status: {
                 state: TaskState.TASK_STATE_WORKING,
                 message: undefined,
                 timestamp: undefined,
               },
+              metadata: {},
             },
           },
         })
@@ -299,11 +307,81 @@ describe('Push Notification Integration Tests', () => {
         thirdNotification.body,
         StreamResponse.toJSON({
           payload: {
-            $case: 'task',
-            value: expectedTaskResult,
+            $case: 'statusUpdate',
+            value: {
+              taskId,
+              contextId,
+              status: {
+                state: TaskState.TASK_STATE_COMPLETED,
+                message: undefined,
+                timestamp: undefined,
+              },
+              metadata: {},
+            },
           },
         })
       );
+    });
+
+    it('forwards the full Task to a v0.3 webhook as a bare v0.3 Task body via the legacy-aware sender', async () => {
+      // End-to-end proof of the reverted behavior: when the v0.3 serializer
+      // is registered (createLegacyAwarePushNotificationSender) and the
+      // request defaults to v0.3, every status update is delivered to the
+      // webhook as the full Task rendered in the bare v0.3 shape
+      // (kind: "task"), not as a status-update event.
+      const v03Store = new InMemoryPushNotificationStore();
+      const v03Sender = createLegacyAwarePushNotificationSender(v03Store);
+      const v03Handler = new DefaultRequestHandler(
+        testAgentCard,
+        new InMemoryTaskStore(),
+        mockAgentExecutor,
+        new DefaultExecutionEventBusManager(),
+        v03Store,
+        v03Sender
+      );
+      const v03SenderSpy = vi.spyOn(v03Sender, 'send') as unknown as PushNotificationSenderSpy;
+
+      const contextId = 'ctx-v03-e2e';
+      const params: SendMessageRequest = {
+        tenant: '',
+        metadata: {},
+        message: {
+          ...createTestMessage('Full task via v0.3 webhook'),
+          contextId,
+          extensions: [],
+          metadata: {},
+        },
+        configuration: {
+          taskPushNotificationConfig: {
+            tenant: '',
+            taskId: '',
+            id: 'v03-config',
+            url: `${testServerUrl}/notify`,
+            token: 'v03-token',
+            authentication: undefined,
+          },
+          historyLength: 0,
+          returnImmediately: false,
+          acceptedOutputModes: [],
+        },
+      };
+
+      mockAgentExecutor.execute.mockImplementation(async (ctx, bus) => {
+        await fakeTaskExecute(ctx, bus);
+      });
+
+      await v03Handler.sendMessage(params, defaultContext);
+      await waitForPushNotifications(v03SenderSpy);
+
+      assert.lengthOf(receivedNotifications, 3);
+      for (const notification of receivedNotifications) {
+        // Bare v0.3 Task shape — no v1 wrapper, no status-update event.
+        assert.equal(notification.body.kind, 'task');
+        assert.notProperty(notification.body, 'statusUpdate');
+        assert.equal(notification.headers['content-type'], 'application/json');
+      }
+      const states = receivedNotifications.map((n) => n.body.status?.state);
+      assert.includeMembers(states, ['submitted', 'working', 'completed']);
     });
 
     it('should handle multiple push notification endpoints for the same task', async () => {

--- a/test/server/request_handler/auth_required.spec.ts
+++ b/test/server/request_handler/auth_required.spec.ts
@@ -337,7 +337,7 @@ describe('DefaultRequestHandler AUTH_REQUIRED lifecycle (§7.6.1)', () => {
 
     const completedCalls = pushNotificationSender.send.mock.calls.filter(([response]) => {
       const r = response as StreamResponse;
-      if (r.payload?.$case !== 'statusUpdate') return false;
+      if (r.payload?.$case !== 'task') return false;
       return r.payload.value.status?.state === TaskState.TASK_STATE_COMPLETED;
     });
     expect(completedCalls.length).toBe(1);

--- a/test/server/request_handler/auth_required.spec.ts
+++ b/test/server/request_handler/auth_required.spec.ts
@@ -12,7 +12,6 @@ import {
   Message,
   Role,
   SendMessageRequest,
-  StreamResponse,
   Task,
   TaskState,
 } from '../../../src/types/pb/a2a.js';
@@ -335,10 +334,12 @@ describe('DefaultRequestHandler AUTH_REQUIRED lifecycle (§7.6.1)', () => {
     const sendsAfterRelease = pushNotificationSender.send.mock.calls.length;
     expect(sendsAfterRelease).toBeGreaterThan(sendsBeforeRelease);
 
-    const completedCalls = pushNotificationSender.send.mock.calls.filter(([response]) => {
-      const r = response as StreamResponse;
-      if (r.payload?.$case !== 'task') return false;
-      return r.payload.value.status?.state === TaskState.TASK_STATE_COMPLETED;
+    // The COMPLETED event reaches the sender as a raw statusUpdate; the
+    // current full Task is forwarded as the third argument. Assert on the
+    // forwarded Task rather than the stream payload's `$case`.
+    const completedCalls = pushNotificationSender.send.mock.calls.filter((call) => {
+      const task = call[2] as Task | undefined;
+      return task?.status?.state === TaskState.TASK_STATE_COMPLETED;
     });
     expect(completedCalls.length).toBe(1);
     expect(observedTaskId).not.toBe('');


### PR DESCRIPTION
## What & why

As stated in Bug #624 the v0.3 spec (§9.5, and confirmed against the `v0.3.14` reference implementation), a v0.3 push notification must deliver the **full `Task`** on *every* trigger — task, status, and artifact updates alike. The v1 core emits per-event `StreamResponse`s, so status/artifact triggers were being pushed as bare `TaskStatusUpdateEvent` / `TaskArtifactUpdateEvent` bodies. This restores the v0.3 contract while leaving v1 untouched (v1 push keeps mirroring the client stream verbatim, `historyLength` trim included).

The switch is gated on the a2a request's version (`isLegacyVersion(context.requestedVersion)`).

## Why the code lives in `DefaultRequestHandler`

The snapshot has to be captured **synchronously and in order**, right after `resultManager.processEvent(event)` — the drain loop is the only place that holds the ordered event, the authoritative merged `Task`, and the wire version at that moment. It also carries the **least legacy into the v1 code base**: the sender and serializers stay version-agnostic, and the single v0.3 gate lives here.

It's also simply the most convenient place: in `sendMessageStream` the mapper already feeds **both** the client SSE `yield` and the push, and v0.3 streaming must stay event-shaped while only the push becomes a `Task`. So the mapper takes a `deliveryTarget` and is called once per target — raw events for the stream, full `Task` for the legacy push.

## Why we don't read the Task in the sender

The sender is fire-and-forget, so loading the Task at dispatch time races the event stream — by the time the async read resolves, a later event may have advanced the store past the triggering state. We tried exactly this in our own code base with a DB-backed `TaskStore`, and it failed consistently in our tests through that race. Freezing the snapshot by value in the drain loop side-steps it.

## Alternatives we considered

- **Per-config serializer plumbing** — thread the frozen snapshot through `send` → `_dispatchNotification` → `serialize(streamResponse, { task })` and let `V03PushNotificationSerializer` pick the `Task`. It's the *more correct* option (it keys the Task-vs-event choice off each webhook's registered `wireVersion`), but the downsides outweigh it for a v0.3-only fix:
  - carries too much legacy through the whole code base,
  - keeps the `Task` bubbling through every layer,
  - would push the `Task` to the v1 serializer, where it's useless,
  - adds unused code just to hold the interface contracts.

## `_mapEventToStreamResponse`: dropped `taskStore.load`

The `task` case previously did `await taskStore.load(taskId, context)`. We now read `resultManager.getCurrentTask()` (deep-cloned) instead — mainly a performance improvement for anyone running an alternative `TaskStore` (as we do with a DB): it drops a per-event store round-trip on the hot event path in favor of the in-memory task the `ResultManager` already holds for this request.


