### PR TITLE
fix: include wire version in push notification headers

### DIFF
--- a/docs/compatibility-v0_3.md
+++ b/docs/compatibility-v0_3.md
@@ -309,16 +309,21 @@ A v1.0-only deployment delivers every push as a `StreamResponse` envelope
 with `Content-Type: application/a2a+json`. With the compat layer enabled, the
 sender (`createLegacyAwarePushNotificationSender`) routes per webhook:
 
-| Wire version the webhook was registered under   | Body shape                                                                                                                   | Content-Type           |
-| :---------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- | :--------------------- |
-| `1.0`                                           | `StreamResponse` envelope                                                                                                    | `application/a2a+json` |
-| `0.3` (or absent `A2A-Version` at registration) | The bare event object (v0.3 `Task`, `TaskStatusUpdateEvent`, or `TaskArtifactUpdateEvent` discriminated by its `kind` field) | `application/json`     |
+| Wire version the webhook was registered under   | Body shape                                                                                                                   | Content-Type           | Outgoing `A2A-Version` |
+| :---------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------- | :--------------------- | :--------------------- |
+| `1.0`                                           | `StreamResponse` envelope                                                                                                    | `application/a2a+json` | `1.0`                  |
+| `0.3` (or absent `A2A-Version` at registration) | The bare event object (v0.3 `Task`, `TaskStatusUpdateEvent`, or `TaskArtifactUpdateEvent` discriminated by its `kind` field) | `application/json`     | `0.3`                  |
 
 Routing is anchored on the `requestedVersion` recorded **when the webhook was
 registered** (captured by `InMemoryPushNotificationStore` on `save()` and
 exposed via `loadWithMetadata`), not the version of the request that
 triggered the delivery. A v0.3-registered webhook keeps receiving v0.3 bodies
 even when the task is later driven by a v1.0 client.
+
+The outgoing version header identifies the serializer and body actually used
+for that webhook. If a stored version has no registered serializer, the sender
+falls back to the v1.0 serializer and sends `A2A-Version: 1.0`; it does not
+repeat the unknown stored value and create a header/body mismatch.
 
 > **Caveat for custom `PushNotificationStore` implementations.**
 > `loadWithMetadata` is optional. If your custom store does not implement

--- a/src/compat/v0_3/README.md
+++ b/src/compat/v0_3/README.md
@@ -90,7 +90,7 @@ This is implemented by two pieces working together:
 
 1. **`PushNotificationStore` captures the wire version.** The `InMemoryPushNotificationStore` (and any conforming implementation) reads `context.requestedVersion` on `save()` and persists it alongside the config as a `StoredPushNotificationConfig { config, wireVersion }`. The wire version is surfaced via the optional `loadWithMetadata` read method.
 
-2. **`DefaultPushNotificationSender` routes per wire version.** The sender prefers `loadWithMetadata` when the store implements it, otherwise falls back to `load` and defaults every entry to wire version `'0.3'` per spec §3.6.2's absent-header rule. It always registers `V1PushNotificationSerializer` under `'1.0'` and falls back to it (with a one-time warning per unknown version) when no serializer is registered for the entry's version.
+2. **`DefaultPushNotificationSender` routes per wire version.** The sender prefers `loadWithMetadata` when the store implements it. Otherwise it falls back to `load` and uses the triggering request's wire version for every entry, defaulting to `'0.3'` per spec §3.6.2 only when that request carries no version. It always registers `V1PushNotificationSerializer` under `'1.0'` and falls back to it (with a one-time warning per unknown version) when no serializer is registered for the entry's version. Each webhook POST sends an `A2A-Version` header matching the serializer and body actually used; an unknown stored version that falls back to v1.0 is therefore advertised as `1.0`.
 
 ### Enabling v0.3 push delivery
 
@@ -106,7 +106,7 @@ const sender = createLegacyAwarePushNotificationSender(store);
 // Hand both to your DefaultRequestHandler as usual.
 ```
 
-v1.0-registered webhooks continue to receive the canonical `StreamResponse` body with `application/a2a+json`; v0.3-registered webhooks receive the bare-event JSON with `application/json`. Custom serializers (or overrides for the built-in `'0.3'` / `'1.0'` entries) can be supplied via the `serializers` option; user-supplied entries take precedence.
+v1.0-registered webhooks continue to receive the canonical `StreamResponse` body with `application/a2a+json` and `A2A-Version: 1.0`; v0.3-registered webhooks receive the bare-event JSON with `application/json` and `A2A-Version: 0.3`. Custom serializers (or overrides for the built-in `'0.3'` / `'1.0'` entries) can be supplied via the `serializers` option; user-supplied entries take precedence, and each key must use `Major.Minor` format.
 
 ### Caveat for custom `PushNotificationStore` implementations
 

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -95,7 +95,10 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
   }
 
   async send(streamResponse: StreamResponse, context: ServerCallContext): Promise<void> {
-    const taskId = this._getTaskId(streamResponse);
+    // Snapshot before the first await so callers cannot mutate an event while
+    // it is loading configs or queued behind another send for the same task.
+    const responseSnapshot = structuredClone(streamResponse);
+    const taskId = this._getTaskId(responseSnapshot);
     // Stand-alone messages with no task association can't have a
     // registered push config — skip the store round-trip.
     if (!taskId) {
@@ -116,7 +119,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
       .then(async () => {
         const dispatches = storedConfigs.map(async (storedConfig) => {
           try {
-            await this._dispatchNotification(streamResponse, storedConfig, taskId);
+            await this._dispatchNotification(responseSnapshot, storedConfig, taskId);
           } catch (error) {
             console.error(
               `Error sending push notification for task_id=${taskId} to URL: ${storedConfig.config.url}. Error:`,
@@ -239,7 +242,10 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     try {
       const resolved = this._resolveSerializer(wireVersion);
       const serializer = resolved.serializer;
-      const { body, contentType } = serializer.serialize(streamResponse);
+      // Each config gets an isolated event object. Custom serializers are
+      // user-supplied code and must not be able to mutate the payload seen by
+      // another version's dispatch (or the caller's original event).
+      const { body, contentType } = serializer.serialize(structuredClone(streamResponse));
 
       const response = await fetch(url, {
         method: 'POST',

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -13,6 +13,8 @@ import {
   V1PushNotificationSerializer,
 } from './push_notification_serializer.js';
 
+const HTTP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
 export interface DefaultPushNotificationSenderOptions {
   /** Timeout in milliseconds for the abort controller. Defaults to 5000ms. */
   timeout?: number;
@@ -58,6 +60,9 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     this.pushNotificationStore = pushNotificationStore;
     this.notificationChain = new Map();
     const tokenHeaderName = options.tokenHeaderName ?? 'X-A2A-Notification-Token';
+    if (!HTTP_HEADER_NAME_PATTERN.test(tokenHeaderName)) {
+      throw new TypeError('tokenHeaderName must be a valid HTTP header name');
+    }
     const normalizedTokenHeaderName = tokenHeaderName.toLowerCase();
     if (
       normalizedTokenHeaderName === 'content-type' ||

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -122,7 +122,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
             await this._dispatchNotification(responseSnapshot, storedConfig, taskId);
           } catch (error) {
             console.error(
-              `Error sending push notification for task_id=${taskId} to URL: ${storedConfig.config.url}. Error:`,
+              `Error sending push notification for task_id=${taskId}, config_id=${storedConfig.config.id}. Error:`,
               error
             );
           }
@@ -262,7 +262,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
-      console.info(`Push notification sent for task_id=${taskId} to URL: ${url}`);
+      console.info(`Push notification sent for task_id=${taskId}, config_id=${pushConfig.id}`);
     } finally {
       clearTimeout(timeoutId);
     }

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -1,5 +1,6 @@
 import { TaskPushNotificationConfig, StreamResponse } from '../../index.js';
 import {
+  A2A_VERSION_HEADER,
   A2A_LEGACY_PROTOCOL_VERSION,
   A2A_PROTOCOL_VERSION,
   ProtocolVersion,
@@ -171,10 +172,13 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
    * falling back to v1.0 (with a one-time warning) when no entry is
    * registered.
    */
-  private _resolveSerializer(wireVersion: string): PushNotificationSerializer {
+  private _resolveSerializer(wireVersion: string): {
+    serializer: PushNotificationSerializer;
+    wireVersion: string;
+  } {
     const serializer = this.serializers.get(wireVersion);
     if (serializer) {
-      return serializer;
+      return { serializer, wireVersion };
     }
     if (!this.warnedMissingSerializers.has(wireVersion)) {
       this.warnedMissingSerializers.add(wireVersion);
@@ -184,7 +188,9 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
           `DefaultPushNotificationSenderOptions.serializers to silence this warning.`
       );
     }
-    return this.fallbackSerializer;
+    // The fallback body is v1.0, so advertise the version that matches the
+    // actual wire representation rather than the unknown stored version.
+    return { serializer: this.fallbackSerializer, wireVersion: A2A_PROTOCOL_VERSION };
   }
 
   /**
@@ -216,13 +222,15 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     const timeoutId = setTimeout(() => controller.abort(), this.options.timeout);
 
     try {
-      const serializer = this._resolveSerializer(wireVersion);
+      const resolved = this._resolveSerializer(wireVersion);
+      const serializer = resolved.serializer;
       const { body, contentType } = serializer.serialize(streamResponse);
 
       const response = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': contentType,
+          [A2A_VERSION_HEADER]: resolved.wireVersion,
           ...this._buildAuthHeaders(pushConfig),
         },
         body,

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -20,6 +20,8 @@ export interface DefaultPushNotificationSenderOptions {
    * Custom header name for the legacy token (defaults to
    * `X-A2A-Notification-Token`). Used only when `pushConfig.token` is set
    * and `pushConfig.authentication` is not.
+   * Must not be `Content-Type` or `A2A-Version` (case-insensitive), because
+   * those headers describe the serialized protocol body.
    * @deprecated Use `pushConfig.authentication` with `AuthenticationInfo`.
    */
   tokenHeaderName?: string;
@@ -55,9 +57,17 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
   ) {
     this.pushNotificationStore = pushNotificationStore;
     this.notificationChain = new Map();
+    const tokenHeaderName = options.tokenHeaderName ?? 'X-A2A-Notification-Token';
+    const normalizedTokenHeaderName = tokenHeaderName.toLowerCase();
+    if (
+      normalizedTokenHeaderName === 'content-type' ||
+      normalizedTokenHeaderName === A2A_VERSION_HEADER.toLowerCase()
+    ) {
+      throw new TypeError(`tokenHeaderName must not override ${tokenHeaderName}`);
+    }
     this.options = {
       timeout: options.timeout ?? 5000,
-      tokenHeaderName: options.tokenHeaderName ?? 'X-A2A-Notification-Token',
+      tokenHeaderName,
     };
 
     // Seed with the built-in v1.0 serializer, then overlay user-supplied

--- a/src/server/push_notification/default_push_notification_sender.ts
+++ b/src/server/push_notification/default_push_notification_sender.ts
@@ -14,6 +14,7 @@ import {
 } from './push_notification_serializer.js';
 
 const HTTP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const PROTOCOL_VERSION_PATTERN = /^[0-9]+\.[0-9]+$/;
 
 export interface DefaultPushNotificationSenderOptions {
   /** Timeout in milliseconds for the abort controller. Defaults to 5000ms. */
@@ -38,8 +39,7 @@ export interface DefaultPushNotificationSenderOptions {
    * When a stored config carries a wire version with no registered
    * serializer, the sender logs a warning and falls back to `'1.0'`.
    *
-   * The typed key set is a developer affordance; the underlying registry
-   * accepts any string at runtime.
+   * Runtime keys must use the protocol's `Major.Minor` format.
    */
   serializers?: Partial<Record<ProtocolVersion, PushNotificationSerializer>>;
 }
@@ -85,6 +85,9 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
     if (options.serializers) {
       for (const [version, serializer] of Object.entries(options.serializers)) {
         if (serializer) {
+          if (!PROTOCOL_VERSION_PATTERN.test(version)) {
+            throw new TypeError('serializer version keys must use Major.Minor format');
+          }
           this.serializers.set(version, serializer);
         }
       }
@@ -105,24 +108,39 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
       return;
     }
 
-    const storedConfigs = await this._loadStoredConfigs(taskId, context);
-    if (!storedConfigs || storedConfigs.length === 0) {
-      return;
-    }
-
     const lastPromise = this.notificationChain.get(taskId) ?? Promise.resolve();
+    // Start loading immediately, but convert either outcome to data so a fast
+    // load failure cannot settle this queue entry ahead of an earlier send.
+    // Deferring the store call by one microtask also reserves the chain slot
+    // before a custom store can re-enter send().
+    const storedConfigsResult = Promise.resolve()
+      .then(() => this._loadStoredConfigs(taskId, context))
+      .then((configs) => structuredClone(configs))
+      .then(
+        (storedConfigs) => ({ ok: true as const, storedConfigs }),
+        (error: unknown) => ({ ok: false as const, error })
+      );
     // Chain promises so notifications for the same task are sent
     // sequentially; once resolved the GC can clean them up so memory
     // doesn't grow linearly with the number of notifications sent.
     const newPromise = lastPromise
       .catch(() => {})
       .then(async () => {
+        const result = await storedConfigsResult;
+        if (result.ok === false) {
+          throw result.error;
+        }
+        const storedConfigs = result.storedConfigs;
+        if (!storedConfigs || storedConfigs.length === 0) {
+          return;
+        }
+
         const dispatches = storedConfigs.map(async (storedConfig) => {
           try {
             await this._dispatchNotification(responseSnapshot, storedConfig, taskId);
           } catch (error) {
             console.error(
-              `Error sending push notification for task_id=${taskId}, config_id=${storedConfig.config.id}. Error:`,
+              `Error sending push notification for task_id=${taskId} to URL: ${storedConfig.config.url}. Error:`,
               error
             );
           }
@@ -262,7 +280,7 @@ export class DefaultPushNotificationSender implements PushNotificationSender {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
-      console.info(`Push notification sent for task_id=${taskId}, config_id=${pushConfig.id}`);
+      console.info(`Push notification sent for task_id=${taskId} to URL: ${url}`);
     } finally {
       clearTimeout(timeoutId);
     }

--- a/src/server/push_notification/push_notification_store.ts
+++ b/src/server/push_notification/push_notification_store.ts
@@ -95,7 +95,9 @@ export class InMemoryPushNotificationStore implements PushNotificationStore {
       entries.splice(existingIndex, 1);
     }
 
-    entries.push({ config: pushNotificationConfig, wireVersion });
+    // Snapshot after assigning the id so later caller mutation or reuse of
+    // the same object cannot alter a previously stored config or its version.
+    entries.push({ config: structuredClone(pushNotificationConfig), wireVersion });
     bucket.set(taskId, entries);
   }
 

--- a/test/compat/v0_3/server/push_notification/create_legacy_aware_sender.spec.ts
+++ b/test/compat/v0_3/server/push_notification/create_legacy_aware_sender.spec.ts
@@ -14,7 +14,11 @@ import {
   TaskPushNotificationConfig,
   TaskState,
 } from '../../../../../src/types/pb/a2a.js';
-import { A2A_LEGACY_PROTOCOL_VERSION, A2A_PROTOCOL_VERSION } from '../../../../../src/constants.js';
+import {
+  A2A_LEGACY_PROTOCOL_VERSION,
+  A2A_PROTOCOL_VERSION,
+  A2A_VERSION_HEADER,
+} from '../../../../../src/constants.js';
 import {
   PushNotificationSerializer,
   SerializedPushNotification,
@@ -95,6 +99,7 @@ describe('createLegacyAwarePushNotificationSender', () => {
 
     expect(received).toHaveLength(1);
     expect(received[0].headers['content-type']).toBe('application/json');
+    expect(received[0].headers[A2A_VERSION_HEADER.toLowerCase()]).toBe(A2A_LEGACY_PROTOCOL_VERSION);
     // Body should be the bare event object (V03 shape), not wrapped.
     expect(received[0].body.kind).toBe('status-update');
     expect(received[0].body).not.toHaveProperty('jsonrpc');
@@ -110,8 +115,36 @@ describe('createLegacyAwarePushNotificationSender', () => {
 
     expect(received).toHaveLength(1);
     expect(received[0].headers['content-type']).toBe('application/a2a+json');
+    expect(received[0].headers[A2A_VERSION_HEADER.toLowerCase()]).toBe(A2A_PROTOCOL_VERSION);
     // v1.0 body is the wrapped StreamResponse.
     expect(received[0].body).toHaveProperty('statusUpdate');
+  });
+
+  it('keeps header, content type, and body aligned for mixed-version registrations', async () => {
+    const sender = createLegacyAwarePushNotificationSender(store);
+    const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const v03Config = makeConfig();
+    v03Config.id = 'cfg-v03';
+    const v1Config = makeConfig();
+    v1Config.id = 'cfg-v1';
+    await store.save('task-mixed', ctxV03, v03Config);
+    await store.save('task-mixed', ctxV1, v1Config);
+
+    await sender.send(makeStatusUpdate('task-mixed'), ctxV1);
+
+    expect(received).toHaveLength(2);
+    const byVersion = new Map(
+      received.map((entry) => [entry.headers[A2A_VERSION_HEADER.toLowerCase()], entry])
+    );
+    expect(byVersion.get(A2A_LEGACY_PROTOCOL_VERSION)?.headers['content-type']).toBe(
+      'application/json'
+    );
+    expect(byVersion.get(A2A_LEGACY_PROTOCOL_VERSION)?.body.kind).toBe('status-update');
+    expect(byVersion.get(A2A_PROTOCOL_VERSION)?.headers['content-type']).toBe(
+      'application/a2a+json'
+    );
+    expect(byVersion.get(A2A_PROTOCOL_VERSION)?.body).toHaveProperty('statusUpdate');
   });
 
   it('lets user-supplied serializers[0.3] override the pre-registered V03 serializer', async () => {

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -279,6 +279,15 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     }
   );
 
+  it.each(['', ' ', 'Bad Header', 'bad:header', 'bad\nheader'])(
+    'rejects invalid legacy token header name %j',
+    (tokenHeaderName) => {
+      expect(() => new DefaultPushNotificationSender(store, { tokenHeaderName })).toThrowError(
+        TypeError
+      );
+    }
+  );
+
   it('delivers message payloads with task association per §4.3.3', async () => {
     // Push notifications accept all four StreamResponse payload
     // variants. The built-in v1.0 serializer encodes the message as part

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -330,6 +330,29 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
   });
 
+  it('does not expose webhook URL or auth secrets in failure logs', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const secretUrl = 'https://user:password@example.test/private-hook?token=query-secret';
+    await store.save(
+      'task-sensitive-log',
+      context,
+      makeConfig(secretUrl, { id: 'safe-config-id', token: 'header-secret' })
+    );
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 500, statusText: 'probe failure' })
+    );
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const sender = new DefaultPushNotificationSender(store);
+
+    await sender.send(makeStatusUpdate('task-sensitive-log'), context);
+
+    const logged = error.mock.calls.flat().map(String).join(' ');
+    expect(logged).toContain('config_id=safe-config-id');
+    expect(logged).not.toContain('password');
+    expect(logged).not.toContain('query-secret');
+    expect(logged).not.toContain('header-secret');
+  });
+
   it.each([A2A_VERSION_HEADER, A2A_VERSION_HEADER.toLowerCase(), 'Content-Type', 'content-type'])(
     'rejects a legacy token header that collides with protocol header %s',
     (tokenHeaderName) => {

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -7,6 +7,7 @@ import { DefaultPushNotificationSender } from '../../src/server/push_notificatio
 import {
   InMemoryPushNotificationStore,
   PushNotificationStore,
+  StoredPushNotificationConfig,
 } from '../../src/server/push_notification/push_notification_store.js';
 import {
   PushNotificationSerializer,
@@ -249,6 +250,138 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     );
   });
 
+  it.each([
+    ['an empty result', false],
+    ['a rejection', true],
+  ] as const)(
+    'preserves same-task call order when an intervening custom-store load returns %s early',
+    async (_outcome, rejectMiddleLoad) => {
+      const config = makeConfig('https://example.test/webhook');
+      const entry: StoredPushNotificationConfig = {
+        config,
+        wireVersion: A2A_PROTOCOL_VERSION,
+      };
+      const pendingLoads: Array<{
+        resolve: (entries: StoredPushNotificationConfig[]) => void;
+        reject: (error: Error) => void;
+      }> = [];
+      const customStore: PushNotificationStore = {
+        save: vi.fn(async () => {}),
+        load: vi.fn(async () => [config]),
+        loadWithMetadata: vi.fn(
+          () =>
+            new Promise<StoredPushNotificationConfig[]>((resolve, reject) => {
+              pendingLoads.push({ resolve, reject });
+            })
+        ),
+        delete: vi.fn(async () => {}),
+      };
+      const fetchMock = vi
+        .spyOn(globalThis, 'fetch')
+        .mockResolvedValue(new Response(null, { status: 200 }));
+      const sender = new DefaultPushNotificationSender(customStore);
+      const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+
+      const first = sender.send(makeStatusUpdate('task-load-order', 'first'), context);
+      const middle = sender.send(makeStatusUpdate('task-load-order', 'middle'), context);
+      const third = sender.send(makeStatusUpdate('task-load-order', 'third'), context);
+      const outcomes = Promise.allSettled([first, middle, third]);
+      await vi.waitFor(() => expect(pendingLoads).toHaveLength(3));
+
+      if (rejectMiddleLoad) {
+        pendingLoads[1].reject(new Error('probe load failure'));
+      } else {
+        pendingLoads[1].resolve([]);
+      }
+      pendingLoads[2].resolve([entry]);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const dispatchesBeforeFirstLoad = fetchMock.mock.calls.length;
+      pendingLoads[0].resolve([entry]);
+      const results = await outcomes;
+
+      const deliveredContexts = fetchMock.mock.calls.map(([, init]) => {
+        const body = JSON.parse(String(init?.body));
+        return body.statusUpdate.contextId;
+      });
+      expect(dispatchesBeforeFirstLoad).toBe(0);
+      expect(deliveredContexts).toEqual(['first', 'third']);
+      expect(results.map((result) => result.status)).toEqual(
+        rejectMiddleLoad
+          ? ['fulfilled', 'rejected', 'fulfilled']
+          : ['fulfilled', 'fulfilled', 'fulfilled']
+      );
+      if (rejectMiddleLoad) {
+        expect(results[1]).toMatchObject({
+          status: 'rejected',
+          reason: expect.objectContaining({ message: 'probe load failure' }),
+        });
+      }
+    }
+  );
+
+  it.each(['loadWithMetadata', 'load'] as const)(
+    'snapshots custom-store configs returned by %s before a queued dispatch',
+    async (loadMethod) => {
+      const sharedConfig = makeConfig('https://original.example/webhook', {
+        id: 'shared-config',
+        authentication: { scheme: 'Bearer', credentials: 'original-secret' },
+      });
+      const sharedEntry: StoredPushNotificationConfig = {
+        config: sharedConfig,
+        wireVersion: A2A_PROTOCOL_VERSION,
+      };
+      const customStore: PushNotificationStore = {
+        save: vi.fn(async () => {}),
+        load: vi.fn(async () => [sharedConfig]),
+        loadWithMetadata:
+          loadMethod === 'loadWithMetadata' ? vi.fn(async () => [sharedEntry]) : undefined,
+        delete: vi.fn(async () => {}),
+      };
+      const v03Serializer: PushNotificationSerializer = {
+        serialize(): SerializedPushNotification {
+          return { body: '{"wire":"0.3"}', contentType: 'application/json' };
+        },
+      };
+      const releases: Array<() => void> = [];
+      const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+        async () =>
+          await new Promise<Response>((resolve) => {
+            releases.push(() => resolve(new Response(null, { status: 200 })));
+          })
+      );
+      const sender = new DefaultPushNotificationSender(customStore, {
+        serializers: { [A2A_LEGACY_PROTOCOL_VERSION]: v03Serializer },
+      });
+      const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+
+      const first = sender.send(makeStatusUpdate('task-shared-config', 'first'), context);
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      const second = sender.send(makeStatusUpdate('task-shared-config', 'second'), context);
+      const loadSpy =
+        loadMethod === 'loadWithMetadata' ? customStore.loadWithMetadata : customStore.load;
+      await vi.waitFor(() => expect(loadSpy).toHaveBeenCalledTimes(2));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      sharedConfig.url = 'https://mutated.example/webhook';
+      sharedConfig.authentication!.credentials = 'mutated-secret';
+      sharedEntry.wireVersion = A2A_LEGACY_PROTOCOL_VERSION;
+
+      releases.shift()?.();
+      await first;
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+      releases.shift()?.();
+      await second;
+
+      const [request, init] = fetchMock.mock.calls[1];
+      expect(String(request)).toBe('https://original.example/webhook');
+      expect(new Headers(init?.headers).get('Authorization')).toBe('Bearer original-secret');
+      expect(new Headers(init?.headers).get(A2A_VERSION_HEADER)).toBe(A2A_PROTOCOL_VERSION);
+      expect(JSON.parse(String(init?.body))).toEqual(
+        StreamResponse.toJSON(makeStatusUpdate('task-shared-config', 'second'))
+      );
+    }
+  );
+
   it('falls back to the v1.0 serializer with a one-time warning for unknown wire versions', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const sender = new DefaultPushNotificationSender(store);
@@ -294,6 +427,40 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     expect(received[0].rawBody).toBe('"custom-v1-body"');
   });
 
+  it.each(['', '1', '1.0.1', '-1.0', '1.-1', '1.0 ', 'v1.0'])(
+    'rejects serializer registry keys outside Major.Minor format: %j',
+    (version) => {
+      const serializers = {
+        [version]: new V1PushNotificationSerializer(),
+      } as Partial<Record<ProtocolVersion, PushNotificationSerializer>>;
+
+      expect(() => new DefaultPushNotificationSender(store, { serializers })).toThrowError(
+        TypeError
+      );
+    }
+  );
+
+  it('accepts a future Major.Minor serializer key without numeric parsing', async () => {
+    const futureVersion = '999999999999999999999999.0';
+    const futureSerializer: PushNotificationSerializer = {
+      serialize(): SerializedPushNotification {
+        return { body: '{"wire":"future"}', contentType: 'application/json' };
+      },
+    };
+    const serializers = {
+      [futureVersion]: futureSerializer,
+    } as Partial<Record<ProtocolVersion, PushNotificationSerializer>>;
+    const sender = new DefaultPushNotificationSender(store, { serializers });
+    const context = new ServerCallContext({ requestedVersion: futureVersion });
+    await store.save('task-future', context, makeConfig(`${baseUrl}/notify`));
+
+    await sender.send(makeStatusUpdate('task-future'), context);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers[A2A_VERSION_HEADER.toLowerCase()]).toBe(futureVersion);
+    expect(received[0].rawBody).toBe('{"wire":"future"}');
+  });
+
   it('preserves auth headers alongside serializer-supplied content type', async () => {
     const sender = new DefaultPushNotificationSender(store);
     const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
@@ -328,29 +495,6 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     expect(received[0].headers['x-a2a-notification-token']).toBe('legacy-token');
     expect(received[0].headers[A2A_VERSION_HEADER.toLowerCase()]).toBe(A2A_PROTOCOL_VERSION);
     expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
-  });
-
-  it('does not expose webhook URL or auth secrets in failure logs', async () => {
-    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
-    const secretUrl = 'https://user:password@example.test/private-hook?token=query-secret';
-    await store.save(
-      'task-sensitive-log',
-      context,
-      makeConfig(secretUrl, { id: 'safe-config-id', token: 'header-secret' })
-    );
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(null, { status: 500, statusText: 'probe failure' })
-    );
-    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const sender = new DefaultPushNotificationSender(store);
-
-    await sender.send(makeStatusUpdate('task-sensitive-log'), context);
-
-    const logged = error.mock.calls.flat().map(String).join(' ');
-    expect(logged).toContain('config_id=safe-config-id');
-    expect(logged).not.toContain('password');
-    expect(logged).not.toContain('query-secret');
-    expect(logged).not.toContain('header-secret');
   });
 
   it.each([A2A_VERSION_HEADER, A2A_VERSION_HEADER.toLowerCase(), 'Content-Type', 'content-type'])(

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -270,6 +270,15 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
   });
 
+  it.each([A2A_VERSION_HEADER, A2A_VERSION_HEADER.toLowerCase(), 'Content-Type', 'content-type'])(
+    'rejects a legacy token header that collides with protocol header %s',
+    (tokenHeaderName) => {
+      expect(() => new DefaultPushNotificationSender(store, { tokenHeaderName })).toThrowError(
+        TypeError
+      );
+    }
+  );
+
   it('delivers message payloads with task association per §4.3.3', async () => {
     // Push notifications accept all four StreamResponse payload
     // variants. The built-in v1.0 serializer encodes the message as part

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -24,6 +24,7 @@ import {
   A2A_CONTENT_TYPE,
   A2A_LEGACY_PROTOCOL_VERSION,
   A2A_PROTOCOL_VERSION,
+  A2A_VERSION_HEADER,
   ProtocolVersion,
 } from '../../src/constants.js';
 
@@ -132,6 +133,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
 
     expect(received).toHaveLength(1);
     expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
+    expect(received[0].headers[A2A_VERSION_HEADER.toLowerCase()]).toBe(A2A_PROTOCOL_VERSION);
     expect(received[0].body).toEqual(StreamResponse.toJSON(makeStatusUpdate('task-v1')));
   });
 
@@ -151,6 +153,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
 
     expect(received).toHaveLength(1);
     expect(received[0].headers['content-type']).toBe('application/json');
+    expect(received[0].headers[A2A_VERSION_HEADER.toLowerCase()]).toBe(A2A_LEGACY_PROTOCOL_VERSION);
     expect(received[0].body).toEqual({ kind: 'task', fake: 'v0.3-body' });
   });
 
@@ -173,9 +176,17 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     await sender.send(makeStatusUpdate('task-mix'), ctxV1);
 
     expect(received).toHaveLength(2);
-    const bodies = received.map((r) => r.rawBody).sort();
-    expect(bodies).toContain('{"v":"0.3"}');
-    expect(bodies.some((b) => b.includes('"statusUpdate"'))).toBe(true);
+    const byVersion = new Map(
+      received.map((r) => [r.headers[A2A_VERSION_HEADER.toLowerCase()], r])
+    );
+    expect(byVersion.get(A2A_LEGACY_PROTOCOL_VERSION)?.rawBody).toBe('{"v":"0.3"}');
+    expect(byVersion.get(A2A_LEGACY_PROTOCOL_VERSION)?.headers['content-type']).toBe(
+      'application/json'
+    );
+    expect(byVersion.get(A2A_PROTOCOL_VERSION)?.body).toEqual(
+      StreamResponse.toJSON(makeStatusUpdate('task-mix'))
+    );
+    expect(byVersion.get(A2A_PROTOCOL_VERSION)?.headers['content-type']).toBe(A2A_CONTENT_TYPE);
   });
 
   it('falls back to the v1.0 serializer with a one-time warning for unknown wire versions', async () => {
@@ -194,6 +205,8 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     // Both dispatches must produce v1.0 bodies.
     for (const r of received) {
       expect(r.headers['content-type']).toBe(A2A_CONTENT_TYPE);
+      expect(r.headers[A2A_VERSION_HEADER.toLowerCase()]).toBe(A2A_PROTOCOL_VERSION);
+      expect(r.body).toEqual(StreamResponse.toJSON(makeStatusUpdate('task-unknown')));
     }
     // Only one warning despite two missing-serializer lookups.
     const matching = warn.mock.calls.filter((args) =>
@@ -236,6 +249,24 @@ describe('DefaultPushNotificationSender serializer registry', () => {
 
     expect(received).toHaveLength(1);
     expect(received[0].headers['authorization']).toBe('Bearer token-xyz');
+    expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
+    expect(received[0].headers[A2A_VERSION_HEADER.toLowerCase()]).toBe(A2A_PROTOCOL_VERSION);
+  });
+
+  it('preserves the legacy token header alongside the version header', async () => {
+    const sender = new DefaultPushNotificationSender(store);
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save(
+      'task-token',
+      ctxV1,
+      makeConfig(`${baseUrl}/notify`, { token: 'legacy-token' })
+    );
+
+    await sender.send(makeStatusUpdate('task-token'), ctxV1);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].headers['x-a2a-notification-token']).toBe('legacy-token');
+    expect(received[0].headers[A2A_VERSION_HEADER.toLowerCase()]).toBe(A2A_PROTOCOL_VERSION);
     expect(received[0].headers['content-type']).toBe(A2A_CONTENT_TYPE);
   });
 

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -320,6 +320,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
 
     expect(received).toHaveLength(1);
     expect(received[0].headers['content-type']).toBe('application/json');
+    expect(received[0].headers[A2A_VERSION_HEADER.toLowerCase()]).toBe(A2A_LEGACY_PROTOCOL_VERSION);
     expect(received[0].rawBody).toBe('{"v":"0.3-fallback"}');
     expect(customStore.load).toHaveBeenCalledTimes(1);
   });
@@ -347,6 +348,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
 
     expect(received).toHaveLength(1);
     expect(received[0].headers['content-type']).toBe('application/json');
+    expect(received[0].headers[A2A_VERSION_HEADER.toLowerCase()]).toBe(A2A_LEGACY_PROTOCOL_VERSION);
     expect(received[0].rawBody).toBe('{"v":"defensive-0.3"}');
   });
 

--- a/test/server/push_notification_sender_serializer.spec.ts
+++ b/test/server/push_notification_sender_serializer.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Server } from 'http';
 import { AddressInfo } from 'net';
-import express, { Request, Response } from 'express';
+import express, { Request, Response as ExpressResponse } from 'express';
 
 import { DefaultPushNotificationSender } from '../../src/server/push_notification/default_push_notification_sender.js';
 import {
@@ -98,7 +98,7 @@ describe('DefaultPushNotificationSender serializer registry', () => {
     const app = express();
     // Accept any content type so the webhook can decode either v1.0 or v0.3.
     app.use(express.text({ type: '*/*' }));
-    app.post('/notify', (req: Request, res: Response) => {
+    app.post('/notify', (req: Request, res: ExpressResponse) => {
       const rawBody = typeof req.body === 'string' ? req.body : '';
       received.push({
         body: rawBody ? JSON.parse(rawBody) : undefined,
@@ -187,6 +187,66 @@ describe('DefaultPushNotificationSender serializer registry', () => {
       StreamResponse.toJSON(makeStatusUpdate('task-mix'))
     );
     expect(byVersion.get(A2A_PROTOCOL_VERSION)?.headers['content-type']).toBe(A2A_CONTENT_TYPE);
+  });
+
+  it('isolates serializers from mutating the shared StreamResponse payload', async () => {
+    const mutatingV03Serializer: PushNotificationSerializer = {
+      serialize(response): SerializedPushNotification {
+        response.payload = undefined;
+        return { body: '{"wire":"0.3"}', contentType: 'application/json' };
+      },
+    };
+    const sender = new DefaultPushNotificationSender(store, {
+      serializers: { [A2A_LEGACY_PROTOCOL_VERSION]: mutatingV03Serializer },
+    });
+    const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save(
+      'task-event-isolation',
+      ctxV03,
+      makeConfig(`${baseUrl}/notify`, { id: 'v03' })
+    );
+    await store.save('task-event-isolation', ctxV1, makeConfig(`${baseUrl}/notify`, { id: 'v1' }));
+    const response = makeStatusUpdate('task-event-isolation');
+
+    await sender.send(response, ctxV1);
+
+    const byVersion = new Map(
+      received.map((r) => [r.headers[A2A_VERSION_HEADER.toLowerCase()], r])
+    );
+    expect(byVersion.get(A2A_LEGACY_PROTOCOL_VERSION)?.rawBody).toBe('{"wire":"0.3"}');
+    expect(byVersion.get(A2A_PROTOCOL_VERSION)?.body).toEqual(StreamResponse.toJSON(response));
+    expect(response.payload).toBeDefined();
+  });
+
+  it('snapshots an event before it waits behind an in-flight same-task send', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    await store.save('task-queued-event', context, makeConfig('https://example.test/webhook'));
+    const releases: Array<() => void> = [];
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () =>
+        await new Promise<Response>((resolve) => {
+          releases.push(() => resolve(new Response(null, { status: 200 })));
+        })
+    );
+    const sender = new DefaultPushNotificationSender(store);
+    const firstEvent = makeStatusUpdate('task-queued-event', 'first');
+    const secondEvent = makeStatusUpdate('task-queued-event', 'second');
+
+    const first = sender.send(firstEvent, context);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const second = sender.send(secondEvent, context);
+    secondEvent.payload = undefined;
+
+    releases.shift()?.();
+    await first;
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    releases.shift()?.();
+    await second;
+
+    expect(JSON.parse(String(fetchMock.mock.calls[1][1]?.body))).toEqual(
+      StreamResponse.toJSON(makeStatusUpdate('task-queued-event', 'second'))
+    );
   });
 
   it('falls back to the v1.0 serializer with a one-time warning for unknown wire versions', async () => {

--- a/test/server/push_notification_store.spec.ts
+++ b/test/server/push_notification_store.spec.ts
@@ -174,6 +174,43 @@ describe('InMemoryPushNotificationStore.loadWithMetadata() wire-version capture'
     expect(loaded[0].config.url).toBe('http://example.test/changed');
   });
 
+  it('snapshots reused config objects so versions and authentication remain independent', async () => {
+    const ctxV1 = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const ctxV03 = new ServerCallContext({ requestedVersion: A2A_LEGACY_PROTOCOL_VERSION });
+    const reused = makeConfig({
+      id: 'v1-cfg',
+      url: 'http://example.test/v1',
+      token: 'token-v1',
+    });
+
+    await store.save('task-reused-object', ctxV1, reused);
+    reused.id = 'v03-cfg';
+    reused.url = 'http://example.test/v03';
+    reused.token = 'token-v03';
+    await store.save('task-reused-object', ctxV03, reused);
+
+    const loaded = await store.loadWithMetadata('task-reused-object', ctxV1);
+    expect(loaded).toHaveLength(2);
+    expect(loaded).toEqual([
+      {
+        config: makeConfig({
+          id: 'v1-cfg',
+          url: 'http://example.test/v1',
+          token: 'token-v1',
+        }),
+        wireVersion: A2A_PROTOCOL_VERSION,
+      },
+      {
+        config: makeConfig({
+          id: 'v03-cfg',
+          url: 'http://example.test/v03',
+          token: 'token-v03',
+        }),
+        wireVersion: A2A_LEGACY_PROTOCOL_VERSION,
+      },
+    ]);
+  });
+
   it('returns deep-cloned wrappers so caller mutations cannot reach internal state', async () => {
     const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
     await store.save(


### PR DESCRIPTION
## Summary

Fixes #647.

`DefaultPushNotificationSender` already chose a serializer per stored
push-notification config, but its webhook request omitted the corresponding
`A2A-Version` header. That made the header ambiguous for legacy payloads and
was incorrect when one task had registrations from multiple protocol versions.

This change:

- sends `A2A-Version: 1.0` with the v1.0 body and `A2A-Version: 0.3` with the
  v0.3 body;
- keeps serializer, body, content type, authentication headers, and version
  header independent for each stored config, including mixed-version configs
  on one task;
- makes unknown stored versions fall back to the registered v1.0 serializer
  and advertise `1.0`, so the header always describes the body actually sent;
- records the registration wire version in `InMemoryPushNotificationStore` and
  documents the optional `loadWithMetadata` compatibility path for custom
  stores (empty triggering versions default to `0.3`);
- snapshots events and configs across asynchronous loads and same-task
  dispatch queues, preserving order across out-of-order, empty, or failed
  custom-store loads;
- validates serializer registry keys as `Major.Minor` and prevents the legacy
  token header option from overriding `Content-Type` or `A2A-Version`.

The related request-handler work in #658 must use the same per-config body
selection semantics, or be co-merged only after that interaction is resolved;
this PR does not modify #658.

## Tests

- Focused push-notification/compatibility Vitest suite: 94 passed (7 files)
- `npx vitest run`: 1,513 passed (68 files)
- `npx tsc --noEmit` and `npx tsc --noEmit -p tsconfig.test.json`: passed
- changed-file ESLint and Prettier checks: passed
- fresh-worktree `npm run lint:ci`: passed
- `npm run build` and `npm run test-build`: passed
- `git diff --check`: passed
