### PR TITLE
fix: clone push notification configs before storing

### DIFF
--- a/src/server/push_notification/push_notification_store.ts
+++ b/src/server/push_notification/push_notification_store.ts
@@ -94,7 +94,10 @@ export class InMemoryPushNotificationStore implements PushNotificationStore {
       entries.splice(existingIndex, 1);
     }
 
-    entries.push({ config: pushNotificationConfig, wireVersion });
+    // Store a deep copy so caller-side mutation can't drift our state.
+    // The in-place id write above is kept so callers still observe a
+    // generated UUID on the object they passed.
+    entries.push({ config: structuredClone(pushNotificationConfig), wireVersion });
     bucket.set(taskId, entries);
   }
 

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -581,7 +581,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       await this.pushNotificationStore?.save(
         taskId,
         context,
-        params.configuration.taskPushNotificationConfig
+        structuredClone(params.configuration.taskPushNotificationConfig)
       );
     }
 
@@ -677,7 +677,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       await this.pushNotificationStore?.save(
         taskId,
         context,
-        params.configuration.taskPushNotificationConfig
+        structuredClone(params.configuration.taskPushNotificationConfig)
       );
     }
 

--- a/test/server/push_notification_store.spec.ts
+++ b/test/server/push_notification_store.spec.ts
@@ -74,6 +74,42 @@ describe('InMemoryPushNotificationStore.load() (canonical, version-agnostic read
     expect(remaining[0].id).toBe('keep');
   });
 
+  it('stores a deep clone so mutating the input after save cannot rewrite stored webhooks', async () => {
+    // Mirrors InMemoryTaskStore.save: the caller's object must not remain
+    // the store's internal row. Reproduction: save, mutate url/token, load.
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const config = makeConfig({
+      id: 'c1',
+      url: 'https://example.test/hook',
+      token: 'tok',
+    });
+
+    await store.save('task-save-iso', context, config);
+    config.url = 'https://attacker.test/';
+    config.token = 'stolen';
+
+    const loaded = await store.load('task-save-iso', context);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].id).toBe('c1');
+    expect(loaded[0].url).toBe('https://example.test/hook');
+    expect(loaded[0].token).toBe('tok');
+  });
+
+  it('still writes a generated id onto the caller object when id is empty', async () => {
+    const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
+    const config = makeConfig({ id: '' });
+
+    await store.save('task-id-inplace', context, config);
+
+    const UUIDV4_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    expect(config.id).toMatch(UUIDV4_RE);
+
+    config.url = 'https://attacker.test/';
+    const loaded = await store.load('task-id-inplace', context);
+    expect(loaded[0].id).toBe(config.id);
+    expect(loaded[0].url).toBe('http://example.test/webhook');
+  });
+
   it('returns deep-cloned configs so caller mutations cannot reach internal state', async () => {
     const context = new ServerCallContext({ requestedVersion: A2A_PROTOCOL_VERSION });
     await store.save('task-iso', context, makeConfig({ id: 'cfg-iso', url: 'http://orig/' }));

--- a/test/server/request_handler/push_notification_config.spec.ts
+++ b/test/server/request_handler/push_notification_config.spec.ts
@@ -8,13 +8,15 @@ import {
 } from '../../../src/server/index.js';
 import {
   AgentCard,
+  Role,
+  SendMessageRequest,
   Task,
   TaskPushNotificationConfig,
   TaskState,
 } from '../../../src/types/pb/a2a.js';
 import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
 import { ServerCallContext } from '../../../src/server/context.js';
-import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
+import { fakeTaskExecute, MockAgentExecutor } from '../mocks/agent-executor.mock.js';
 
 // id-less Create assigns a server-side UUID. Regression guard for the
 // pre-fix `id ||= taskId` collapse that overwrote configs.
@@ -162,6 +164,66 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
     result.url = 'https://attacker.test/';
     const stored = await pushNotificationStore.load(taskId, serverContext);
     expect(stored[0].url).toBe('https://example.test/webhook-explicit');
+  });
+
+  it('isolates sendMessage inline push config from later caller mutations', async () => {
+    // sendMessage passes params.configuration.taskPushNotificationConfig
+    // straight into save. Mutating that object after Create must not
+    // rewrite the webhook DefaultPushNotificationSender will POST to.
+    const executor = new MockAgentExecutor();
+    executor.execute.mockImplementation(fakeTaskExecute);
+    handler = new DefaultRequestHandler(
+      agentCard,
+      taskStore,
+      executor,
+      new DefaultExecutionEventBusManager(),
+      pushNotificationStore
+    );
+
+    const config: TaskPushNotificationConfig = {
+      tenant: '',
+      taskId: '',
+      id: 'c1',
+      url: 'https://example.test/hook',
+      token: 'tok',
+      authentication: undefined,
+    };
+    const params: SendMessageRequest = {
+      tenant: '',
+      metadata: {},
+      message: {
+        messageId: 'msg-push-iso',
+        role: Role.ROLE_USER,
+        parts: [
+          {
+            content: { $case: 'text', value: 'hi' },
+            mediaType: 'text/plain',
+            filename: '',
+            metadata: undefined,
+          },
+        ],
+        taskId: '',
+        contextId: '',
+        extensions: [],
+        metadata: {},
+        referenceTaskIds: [],
+      },
+      configuration: {
+        acceptedOutputModes: [],
+        taskPushNotificationConfig: config,
+        returnImmediately: false,
+      },
+    };
+
+    const result = (await handler.sendMessage(params, serverContext)) as Task;
+    config.url = 'https://attacker.test/';
+    config.token = 'stolen';
+
+    const stored = await pushNotificationStore.load(result.id, serverContext);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe('c1');
+    expect(stored[0].url).toBe('https://example.test/hook');
+    expect(stored[0].token).toBe('tok');
   });
 
   it('listTaskPushNotificationConfigs returns every entry after mixed id-less + explicit Creates', async () => {


### PR DESCRIPTION
`InMemoryPushNotificationStore.save` retained the caller's `TaskPushNotificationConfig` object. Mutating that object after saving could silently change the stored webhook URL, token, or authentication data.

This change stores a deep clone in `src/server/push_notification/push_notification_store.ts` while preserving the generated ID on the caller's object. `DefaultRequestHandler.sendMessage` and `sendMessageStream` also clone inline configurations before passing them to a store, preventing aliasing in custom implementations.

Regression coverage verifies input isolation, generated-ID behavior, and inline `sendMessage` configuration handling.

Tested with:

```sh
npx --no-install vitest run test/server/push_notification_store.spec.ts test/server/request_handler/push_notification_config.spec.ts
```
