### PR TITLE
feat: make event bus keep-alive states configurable

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -24,7 +24,10 @@ export { ExecutionEventQueue } from './events/execution_event_queue.js';
 
 export type { A2ARequestHandler } from './request_handler/a2a_request_handler.js';
 export { DefaultRequestHandler } from './request_handler/default_request_handler.js';
-export type { ExtendedAgentCardProvider } from './request_handler/default_request_handler.js';
+export type {
+  DefaultRequestHandlerOptions,
+  ExtendedAgentCardProvider,
+} from './request_handler/default_request_handler.js';
 export { ResultManager } from './result_manager.js';
 export type { TaskStore } from './store.js';
 export { InMemoryTaskStore } from './store.js';

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -68,6 +68,9 @@ export interface DefaultRequestHandlerOptions {
   /**
    * Task states that keep the execution event bus alive after the agent
    * executor returns. Defaults to INPUT_REQUIRED and AUTH_REQUIRED.
+   * To add another keep-alive state while preserving those defaults, include
+   * both default states and the additional state. Any custom value overrides
+   * the default list.
    */
   keepBusAliveStates?: TaskState[];
 }

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -64,6 +64,14 @@ import {
 import { AgentCardSignatureGenerator } from '../../signature.js';
 import { extractErrorMessage } from '../../errors/index.js';
 
+export interface DefaultRequestHandlerOptions {
+  /**
+   * Task states that keep the execution event bus alive after the agent
+   * executor returns. Defaults to INPUT_REQUIRED and AUTH_REQUIRED.
+   */
+  keepBusAliveStates?: TaskState[];
+}
+
 /**
  * Default implementation of the A2A request handler.
  *
@@ -82,6 +90,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   private readonly pushNotificationSender?: PushNotificationSender;
   private readonly extendedAgentCardProvider?: AgentCard | ExtendedAgentCardProvider;
   private readonly agentCardSignatureGenerator?: AgentCardSignatureGenerator;
+  private readonly keepBusAliveStates: Set<TaskState>;
 
   constructor(
     agentCard: AgentCard,
@@ -91,7 +100,8 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     pushNotificationStore?: PushNotificationStore,
     pushNotificationSender?: PushNotificationSender,
     extendedAgentCardProvider?: AgentCard | ExtendedAgentCardProvider,
-    agentCardSignatureGenerator?: AgentCardSignatureGenerator
+    agentCardSignatureGenerator?: AgentCardSignatureGenerator,
+    options: DefaultRequestHandlerOptions = {}
   ) {
     this.agentCard = agentCard;
     this.taskStore = taskStore;
@@ -99,6 +109,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     this.eventBusManager = eventBusManager;
     this.extendedAgentCardProvider = extendedAgentCardProvider;
     this.agentCardSignatureGenerator = agentCardSignatureGenerator;
+    this.keepBusAliveStates = new Set(options.keepBusAliveStates ?? INTERRUPTED_STATE_LIST);
 
     if (agentCard.capabilities?.pushNotifications) {
       this.pushNotificationStore = pushNotificationStore || new InMemoryPushNotificationStore();
@@ -437,15 +448,15 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   /**
    * Settles the event bus once the executor returns. Terminal states
    * (and the bare-Message stream pattern) close the bus immediately;
-   * interrupted states (INPUT_REQUIRED, AUTH_REQUIRED) keep it alive
-   * so follow-up sends and resubscribers can still attach.
+   * states configured in `keepBusAliveStates` keep it alive so follow-up
+   * sends and resubscribers can still attach.
    */
   private _settleBus(
     taskId: string,
     eventBus: ExecutionEventBus,
     lastState: TaskState | undefined
   ): void {
-    if (lastState !== undefined && INTERRUPTED_STATE_LIST.includes(lastState)) {
+    if (lastState !== undefined && this.keepBusAliveStates.has(lastState)) {
       return;
     }
     eventBus.finished();

--- a/test/server/request_handler/streaming_errors.spec.ts
+++ b/test/server/request_handler/streaming_errors.spec.ts
@@ -328,7 +328,22 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
     expect(eventBusManager.getByTaskId(observedRequestTaskId)).toBeUndefined();
   });
 
-  it('keeps the event bus alive when the final state is configured', async () => {
+  it.each([
+    {
+      description: 'when configured states replace the defaults',
+      keepBusAliveStates: [TaskState.TASK_STATE_COMPLETED],
+      messageId: 'msg-stream-err-configured-override',
+    },
+    {
+      description: 'when configured states extend the defaults',
+      keepBusAliveStates: [
+        TaskState.TASK_STATE_INPUT_REQUIRED,
+        TaskState.TASK_STATE_AUTH_REQUIRED,
+        TaskState.TASK_STATE_COMPLETED,
+      ],
+      messageId: 'msg-stream-err-configured-extended',
+    },
+  ])('keeps the event bus alive $description', async ({ keepBusAliveStates, messageId }) => {
     let observedRequestTaskId = '';
     mockExecutor.execute.mockImplementation(async (ctx, bus) => {
       observedRequestTaskId = ctx.taskId;
@@ -369,11 +384,11 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
       undefined,
       undefined,
       undefined,
-      { keepBusAliveStates: [TaskState.TASK_STATE_COMPLETED] }
+      { keepBusAliveStates }
     );
 
     const params: SendMessageRequest = {
-      message: makeMessage('msg-stream-err-configured', 'kick off'),
+      message: makeMessage(messageId, 'kick off'),
       tenant: '',
       configuration: undefined,
       metadata: {},

--- a/test/server/request_handler/streaming_errors.spec.ts
+++ b/test/server/request_handler/streaming_errors.spec.ts
@@ -328,22 +328,7 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
     expect(eventBusManager.getByTaskId(observedRequestTaskId)).toBeUndefined();
   });
 
-  it.each([
-    {
-      description: 'when configured states replace the defaults',
-      keepBusAliveStates: [TaskState.TASK_STATE_COMPLETED],
-      messageId: 'msg-stream-err-configured-override',
-    },
-    {
-      description: 'when configured states extend the defaults',
-      keepBusAliveStates: [
-        TaskState.TASK_STATE_INPUT_REQUIRED,
-        TaskState.TASK_STATE_AUTH_REQUIRED,
-        TaskState.TASK_STATE_COMPLETED,
-      ],
-      messageId: 'msg-stream-err-configured-extended',
-    },
-  ])('keeps the event bus alive $description', async ({ keepBusAliveStates, messageId }) => {
+  it('keeps the event bus alive when configured states replace the defaults', async () => {
     let observedRequestTaskId = '';
     mockExecutor.execute.mockImplementation(async (ctx, bus) => {
       observedRequestTaskId = ctx.taskId;
@@ -384,11 +369,11 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
       undefined,
       undefined,
       undefined,
-      { keepBusAliveStates }
+      { keepBusAliveStates: [TaskState.TASK_STATE_COMPLETED] }
     );
 
     const params: SendMessageRequest = {
-      message: makeMessage(messageId, 'kick off'),
+      message: makeMessage('msg-stream-err-configured-override', 'kick off'),
       tenant: '',
       configuration: undefined,
       metadata: {},
@@ -401,6 +386,102 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
     await new Promise<void>((resolve) => setImmediate(resolve));
 
     expect(eventBusManager.getByTaskId(observedRequestTaskId)).toBeDefined();
+  });
+
+  it('persists a late event after the executor returns in a configured non-terminal state', async () => {
+    let observedRequestTaskId = '';
+    let executorReturned = false;
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+      observedRequestTaskId = ctx.taskId;
+      bus.publish(
+        AgentEvent.task({
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_WORKING,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        })
+      );
+      executorReturned = true;
+    });
+
+    const configuredHandler = new DefaultRequestHandler(
+      agentCard,
+      taskStore,
+      mockExecutor,
+      eventBusManager,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      {
+        keepBusAliveStates: [
+          TaskState.TASK_STATE_INPUT_REQUIRED,
+          TaskState.TASK_STATE_AUTH_REQUIRED,
+          TaskState.TASK_STATE_WORKING,
+        ],
+      }
+    );
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-stream-err-configured-working', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    const iterator = configuredHandler
+      .sendMessageStream(params, serverContext)
+      [Symbol.asyncIterator]();
+
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    const firstPayload = (first.value as StreamResponse).payload as {
+      $case: 'task';
+      value: Task;
+    };
+    expect(firstPayload.$case).toBe('task');
+    expect(firstPayload.value.status?.state).toBe(TaskState.TASK_STATE_WORKING);
+
+    // Let the executor's `.finally()` settle before publishing again. WORKING
+    // is configured, so the bus and the original stream consumer must remain
+    // active even though the executor has returned.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(executorReturned).toBe(true);
+    const eventBus = eventBusManager.getByTaskId(observedRequestTaskId);
+    expect(eventBus).toBeDefined();
+
+    const lateEventPromise = iterator.next();
+    eventBus!.publish(
+      AgentEvent.statusUpdate({
+        taskId: observedRequestTaskId,
+        contextId: firstPayload.value.contextId,
+        status: {
+          state: TaskState.TASK_STATE_COMPLETED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        metadata: {},
+      })
+    );
+
+    const lateEvent = await lateEventPromise;
+    expect(lateEvent.done).toBe(false);
+    const latePayload = (lateEvent.value as StreamResponse).payload as {
+      $case: 'statusUpdate';
+      value: TaskStatusUpdateEvent;
+    };
+    expect(latePayload.$case).toBe('statusUpdate');
+    expect(latePayload.value.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+
+    const storedTask = await taskStore.load(observedRequestTaskId, serverContext);
+    expect(storedTask?.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+    await expect(iterator.next()).resolves.toEqual({ done: true, value: undefined });
   });
 
   it('does not leak the published-task listener on the success path (regression: gemini-code-assist)', async () => {

--- a/test/server/request_handler/streaming_errors.spec.ts
+++ b/test/server/request_handler/streaming_errors.spec.ts
@@ -328,6 +328,66 @@ describe('DefaultRequestHandler streaming error synthesis (_runStreamExecutor)',
     expect(eventBusManager.getByTaskId(observedRequestTaskId)).toBeUndefined();
   });
 
+  it('keeps the event bus alive when the final state is configured', async () => {
+    let observedRequestTaskId = '';
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+      observedRequestTaskId = ctx.taskId;
+      bus.publish(
+        AgentEvent.task({
+          id: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_SUBMITTED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          artifacts: [],
+          history: [],
+          metadata: {},
+        })
+      );
+      bus.publish(
+        AgentEvent.statusUpdate({
+          taskId: ctx.taskId,
+          contextId: ctx.contextId,
+          status: {
+            state: TaskState.TASK_STATE_COMPLETED,
+            message: undefined,
+            timestamp: undefined,
+          },
+          metadata: {},
+        })
+      );
+    });
+
+    const configuredHandler = new DefaultRequestHandler(
+      agentCard,
+      taskStore,
+      mockExecutor,
+      eventBusManager,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { keepBusAliveStates: [TaskState.TASK_STATE_COMPLETED] }
+    );
+
+    const params: SendMessageRequest = {
+      message: makeMessage('msg-stream-err-configured', 'kick off'),
+      tenant: '',
+      configuration: undefined,
+      metadata: {},
+    };
+
+    for await (const _event of configuredHandler.sendMessageStream(params, serverContext)) {
+      void _event;
+    }
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(eventBusManager.getByTaskId(observedRequestTaskId)).toBeDefined();
+  });
+
   it('does not leak the published-task listener on the success path (regression: gemini-code-assist)', async () => {
     // Regression for the listener leak gemini-code-assist flagged on
     // PR #525: `trackLatestPublishedTask` registers a listener on the


### PR DESCRIPTION
# Description

`DefaultRequestHandler` always cleaned up the execution event bus unless the final state was `INPUT_REQUIRED` or `AUTH_REQUIRED`. That prevents applications with persistent event buses from retaining a bus for additional states.

This change:

- adds an exported `DefaultRequestHandlerOptions` type with `keepBusAliveStates`
- preserves the existing interrupted-state list as the default
- copies the configured states into a `Set` and uses it when settling the bus
- covers a configured terminal state while retaining the existing default-cleanup test

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-js/blob/main/CONTRIBUTING.md).
- [x] Make the Pull Request title follow the Conventional Commits specification.
- [x] Ensure the tests and linter pass.
- [x] Appropriate docs were updated (the exported option includes API documentation).

Tests:

- `npm test` (1,491 tests)
- `npm run lint:ci`
- `npm run build`
- `npm run test-build`

Fixes #620
