### PR TITLE
ci: Update github action versions

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
         node-version: 20
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -18,7 +18,7 @@ jobs:
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Download Coverage Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -26,14 +26,14 @@ jobs:
       
       - name: Upload Coverage Report
         id: upload-report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: coverage/
           retention-days: 14
 
       - name: Post Comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v9
         env:
           ARTIFACT_URL: ${{ steps.upload-report.outputs.artifact-url }}
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           # Min supported node (package.json engines: >=20); catches floor breakage.
           node-version: 20

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
         node-version: 20
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,8 +14,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -24,7 +24,7 @@ jobs:
       - run: npm run build
 
       # Now configure with the publish service for install.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: 'https://wombat-dressing-room.appspot.com/'

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -29,15 +29,6 @@ jobs:
           node-version: 24
           registry-url: 'https://wombat-dressing-room.appspot.com/'
 
-      # To be removed once the workflow stabilizes.
-      - name: Report token source
-        run: |
-          if [ -n "${{ secrets.NPM_TOKEN_OVERRIDE }}" ]; then
-            echo "Using NPM_TOKEN_OVERRIDE"
-          else
-            echo "Using NPM_TOKEN"
-          fi
-
       - name: Publish to NPM
         run: |
           if [ "${{ github.event.release.prerelease }}" = "true" ]; then
@@ -48,4 +39,4 @@ jobs:
             npm dist-tag add "@a2a-js/sdk@${VERSION}" next
           fi
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_OVERRIDE || secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/run-itk-nightly.yaml
+++ b/.github/workflows/run-itk-nightly.yaml
@@ -37,13 +37,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: 'npm'
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
 
       - name: Clone a2a-itk
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: a2aproject/a2a-itk
           ref: main
@@ -71,7 +71,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=itk_service
 
       - name: Cache launcher peer-SDK checkouts + build outputs
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/a2a-itk-launcher
           key: itk-launcher-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/run-itk.yaml
+++ b/.github/workflows/run-itk.yaml
@@ -37,13 +37,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 20
           cache: 'npm'
@@ -52,7 +52,7 @@ jobs:
         run: npm ci
 
       - name: Clone a2a-itk
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: a2aproject/a2a-itk
           ref: main
@@ -71,7 +71,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=itk_service
 
       - name: Cache launcher peer-SDK checkouts + build outputs
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/a2a-itk-launcher
           key: itk-launcher-${{ runner.os }}-${{ github.sha }}

--- a/.github/workflows/run-tck-compat.yaml
+++ b/.github/workflows/run-tck-compat.yaml
@@ -41,9 +41,9 @@ jobs:
         node-version: [20, 22, 24]
     steps:
       - name: Checkout a2a-js
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: 'https://registry.npmjs.org'
@@ -52,7 +52,7 @@ jobs:
           npm ci
           npm run build
       - name: Checkout a2a-tck
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: a2aproject/a2a-tck
           path: tck/a2a-tck
@@ -63,7 +63,7 @@ jobs:
             tests/optional/capabilities/test_message_send_capabilities.py
         working-directory: tck/a2a-tck
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version-file: 'tck/a2a-tck/pyproject.toml'
       - name: Install uv and Python dependencies

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         node-version: [20, 22, 24]
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
         node-version: ${{ matrix.node-version }}
         registry-url: 'https://registry.npmjs.org'
@@ -38,8 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v7
+    - uses: actions/setup-node@v7
       with:
         node-version: 24
         registry-url: 'https://registry.npmjs.org'
@@ -52,12 +52,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Base Branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ github.event.pull_request.base.ref || 'main' }}
         clean: true
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v7
       with:
         node-version: 24
         cache: 'npm'
@@ -70,7 +70,7 @@ jobs:
         mv coverage/coverage-summary.json ${{ runner.temp }}/coverage-base-summary.json
     
     - name: Upload Artifact (base)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: github.event_name != 'pull_request'
       with:
         name: coverage-report
@@ -79,7 +79,7 @@ jobs:
 
     - name: Checkout PR Branch
       if: github.event_name == 'pull_request'
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         clean: true
 
@@ -97,7 +97,7 @@ jobs:
         echo ${{ github.event.number }} > ./PR_NUMBER
     
     - name: Upload Coverage Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: github.event_name == 'pull_request'
       with:
         name: coverage-data


### PR DESCRIPTION
# Description

Update github actions to the newest stable versions. This resolves visible deprecation warnings for node 20. Additionally, removed the temporary npm token override mechanism that is no longer needed.

Actions updated:
- `actions/checkout` -> v7
- `actions/cache` -> v6
- `actions/download-artifact` -> v7 (version v8 is already present but kept on v7 for alignment with `upload-artifact` action)
- `actions/upload-artifact` -> v7
- `actions/setup-node` -> v7
- `actions/setup-python` -> v7
- `actions/github-script` -> v9

Example run before the fix: https://github.com/a2aproject/a2a-js/actions/runs/32951081332
And after the fix: https://github.com/a2aproject/a2a-js/actions/runs/32956291148