### PR TITLE
fix: preserve historyLength=0 and reject invalid REST listTasks pageSize

### DIFF
--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -752,7 +752,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
   ): Promise<ListTasksResponse> {
     const pageSize = params.pageSize ?? DEFAULT_PAGE_SIZE;
 
-    if (pageSize < 1 || pageSize > 100) {
+    if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100) {
       throw new RequestMalformedError('pageSize must be between 1 and 100');
     }
 

--- a/src/server/transports/rest/rest_transport_handler.ts
+++ b/src/server/transports/rest/rest_transport_handler.ts
@@ -115,9 +115,15 @@ export class RestTransportHandler {
             isNaN(Number(queryParams.status)) ? queryParams.status : Number(queryParams.status)
           )
         : TaskState.TASK_STATE_UNSPECIFIED,
-      pageSize: queryParams.pageSize ? Number(queryParams.pageSize) : undefined,
+      pageSize:
+        queryParams.pageSize !== undefined && queryParams.pageSize !== ''
+          ? this.parsePageSize(queryParams.pageSize)
+          : undefined,
       pageToken: (queryParams.pageToken as string) || '',
-      historyLength: queryParams.historyLength ? Number(queryParams.historyLength) : undefined,
+      historyLength:
+        queryParams.historyLength !== undefined && queryParams.historyLength !== ''
+          ? this.parseHistoryLength(queryParams.historyLength)
+          : undefined,
       statusTimestampAfter: (queryParams.statusTimestampAfter as string) || undefined,
       includeArtifacts: parseIncludeArtifacts(queryParams.includeArtifacts),
     };
@@ -204,6 +210,17 @@ export class RestTransportHandler {
     }
     if (parsed < 0) {
       throw new RequestMalformedError('historyLength must be non-negative');
+    }
+    return parsed;
+  }
+
+  private parsePageSize(value: unknown): number {
+    const parsed = parseInt(String(value), 10);
+    if (isNaN(parsed) || String(parsed) !== String(value).trim()) {
+      throw new RequestMalformedError('pageSize must be a valid integer');
+    }
+    if (parsed < 1 || parsed > 100) {
+      throw new RequestMalformedError('pageSize must be between 1 and 100');
     }
     return parsed;
   }

--- a/test/server/rest_transport_handler.spec.ts
+++ b/test/server/rest_transport_handler.spec.ts
@@ -344,6 +344,29 @@ describe('RestTransportHandler', () => {
       );
     });
 
+    it('should forward historyLength=0 instead of dropping it', async () => {
+      (mockRequestHandler.listTasks as Mock).mockResolvedValue(mockListResponse);
+
+      await transportHandler.listTasks({ historyLength: '0' }, mockContext);
+
+      expect(mockRequestHandler.listTasks as Mock).toHaveBeenCalledWith(
+        expect.objectContaining({ historyLength: 0 }),
+        mockContext
+      );
+    });
+
+    it('should reject a non-numeric pageSize', async () => {
+      await expect(transportHandler.listTasks({ pageSize: 'abc' }, mockContext)).rejects.toThrow(
+        /pageSize must be a valid integer/
+      );
+    });
+
+    it('should reject pageSize=0', async () => {
+      await expect(transportHandler.listTasks({ pageSize: '0' }, mockContext)).rejects.toThrow(
+        /pageSize must be between 1 and 100/
+      );
+    });
+
     it('should pass a valid status filter through to the request handler', async () => {
       (mockRequestHandler.listTasks as Mock).mockResolvedValue(mockListResponse);
 


### PR DESCRIPTION
# Description

- [x] Follow the CONTRIBUTING Guide
- [x] Conventional Commits title
- [x] Tests and linter pass
- [x] Docs updated if necessary

Fixes #679

## Summary

`RestTransportHandler.listTasks` used truthy `Number()` on query strings. `historyLength=0` became undefined, so listTasks returned full history instead of omitting it. `getTask` already keeps 0 via `parseHistoryLength`. The JS REST client sends `historyLength=0`, so a same-SDK call was wrong.

`pageSize=abc` became NaN. The range check `pageSize < 1 || pageSize > 100` is false for NaN, so the store did `slice(0, NaN)` and returned an empty page with HTTP 200.

Closed unmerged PR #625 called out the REST Number() hole. Open PR #639 caps historyLength at 1000 and does not fix the 0 drop or NaN pageSize.

listTasks now reuses `parseHistoryLength` and adds `parsePageSize` (integer 1..100). DefaultRequestHandler.listTasks also rejects non-integer pageSize so JSON-RPC/gRPC cannot slip NaN through.

## Testing

```
npx --no-install vitest run test/server/rest_transport_handler.spec.ts test/server/default_request_handler.spec.ts
```

130 passed.