### PR TITLE
fix: take push-config taskId from the REST path when the body omits it

### DIFF
--- a/src/compat/v0_3/server/express/rest_handler.ts
+++ b/src/compat/v0_3/server/express/rest_handler.ts
@@ -377,6 +377,11 @@ export function legacyRestRouter(options: LegacyRestHandlerOptions): RequestHand
     asyncHandler(async (req, res) => {
       const context = await buildContext(req);
       const params = decodeTaskPushNotificationConfig(req.body);
+      const pathTaskId = req.params.taskId ?? '';
+      if (params.taskId && params.taskId !== pathTaskId) {
+        throw LegacyA2AError.invalidParams('taskId in the body must match the path');
+      }
+      params.taskId = pathTaskId;
       const result = await transportHandler.setTaskPushNotificationConfig(params, context);
       sendResponse(res, HTTP_STATUS.CREATED, context, encodeTaskPushNotificationConfig(result));
     })

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -471,6 +471,11 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
   registerRoute('post', '/tasks/:taskId/pushNotificationConfigs', async (req, res) => {
     const context = await buildContext(req);
     const params = TaskPushNotificationConfig.fromJSON(req.body ?? {});
+    const pathTaskId = req.params.taskId ?? '';
+    if (params.taskId && params.taskId !== pathTaskId) {
+      throw new RequestMalformedError('taskId in the body must match the path');
+    }
+    params.taskId = pathTaskId;
     const result = await restTransportHandler.createTaskPushNotificationConfig(params, context);
     sendResponse<TaskPushNotificationConfig>(
       res,

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -719,6 +719,33 @@ describe('restHandler', () => {
           .calls[0][0];
         assert.equal(passedConfig.id, '');
       });
+
+      it('should use the path taskId when the body omits taskId', async () => {
+        (mockRequestHandler.createTaskPushNotificationConfig as Mock).mockResolvedValue(mockConfig);
+
+        await request(app)
+          .post('/tasks/task-1/pushNotificationConfigs')
+          .set('A2A-Version', '1.0')
+          .send({
+            url: 'http://127.0.0.1:9999/webhook',
+          })
+          .expect(201);
+
+        const passedConfig = (mockRequestHandler.createTaskPushNotificationConfig as Mock).mock
+          .calls[0][0];
+        assert.equal(passedConfig.taskId, 'task-1');
+      });
+
+      it('should reject a body taskId that disagrees with the path', async () => {
+        await request(app)
+          .post('/tasks/task-1/pushNotificationConfigs')
+          .set('A2A-Version', '1.0')
+          .send({
+            url: 'http://127.0.0.1:9999/webhook',
+            taskId: 'other-task',
+          })
+          .expect(400);
+      });
     });
 
     describe('GET /tasks/:taskId/pushNotificationConfigs', () => {


### PR DESCRIPTION
# Description

- [x] Follow the CONTRIBUTING Guide
- [x] Conventional Commits title
- [x] Tests and linter pass
- [x] Docs updated if necessary

Fixes #680

## Summary

`POST /tasks/:taskId/pushNotificationConfigs` parsed only the JSON body. Path taskId was ignored. `fromJSON` defaults a missing taskId to `""`, which after #629 is RequestMalformedError.

The proto mapping is `POST /tasks/{task_id=*}/pushNotificationConfigs` with `body: "*"`. Transcoding clients put task_id in the URL and may omit it from the body. Same-SDK RestTransport sends both, which is why existing tests passed. The v0.3 Express handler had the same hole.

After fromJSON, path taskId is copied onto the config. A non-empty body taskId that disagrees with the path is 400.

## Testing

```
npx --no-install vitest run test/server/express/rest_handler.spec.ts
```

79 passed.