### PR TITLE
fix: accept GetExtendedAgentCard JSON-RPC calls with omitted params

### DIFF
--- a/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
+++ b/src/server/transports/jsonrpc/jsonrpc_transport_handler.ts
@@ -203,7 +203,7 @@ export class JsonRpcTransportHandler {
           case 'GetExtendedAgentCard':
             result = AgentCard.toJSON(
               await this.requestHandler.getAuthenticatedExtendedAgentCard(
-                GetExtendedAgentCardRequest.fromJSON(rpcRequest.params),
+                GetExtendedAgentCardRequest.fromJSON(rpcRequest.params ?? {}),
                 context
               )
             );

--- a/test/server/jsonrpc_transport_handler.spec.ts
+++ b/test/server/jsonrpc_transport_handler.spec.ts
@@ -219,6 +219,31 @@ describe('JsonRpcTransportHandler', () => {
         expect.anything()
       );
     });
+
+    it('should accept GetExtendedAgentCard without params', async () => {
+      (mockRequestHandler.getAuthenticatedExtendedAgentCard as Mock).mockResolvedValue({
+        name: 'test-agent',
+        description: '',
+        url: 'http://example.test',
+        version: '1.0',
+        capabilities: {},
+        defaultInputModes: [],
+        defaultOutputModes: [],
+        skills: [],
+      });
+      const request = {
+        jsonrpc: '2.0',
+        method: 'GetExtendedAgentCard',
+        id: 1,
+      };
+      const response = (await transportHandler.handle(request, defaultContext)) as {
+        result?: unknown;
+        error?: unknown;
+      };
+      expect(response.error).toBeUndefined();
+      expect(response.result).toBeDefined();
+      expect(mockRequestHandler.getAuthenticatedExtendedAgentCard).toHaveBeenCalled();
+    });
   });
 
   describe('ListTasks serialization (§3.1.4)', () => {


### PR DESCRIPTION
# Description

- [x] Follow the CONTRIBUTING Guide
- [x] Conventional Commits title
- [x] Tests and linter pass
- [x] Docs updated if necessary

Fixes #681

## Summary

`handle()` skips `paramsAreValid` for GetExtendedAgentCard so a body with no params is accepted, then calls `fromJSON(rpcRequest.params)`. `fromJSON` reads `object.tenant` and throws TypeError on undefined. That becomes JSON-RPC -32603.

v0.3 already accepts the same request. The official client hides the hole by sending `params: {}`. Interop clients that omit an empty params object fail.

The handler now calls `fromJSON(rpcRequest.params ?? {})`. Generated codecs are left alone.

## Testing

```
npx --no-install vitest run test/server/jsonrpc_transport_handler.spec.ts
```

36 passed.