### PR TITLE
fix: stamp the resolved taskId onto sendMessage push configs

### DIFF
--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -598,11 +598,9 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       params.configuration?.taskPushNotificationConfig &&
       this.agentCard.capabilities?.pushNotifications
     ) {
-      await this.pushNotificationStore?.save(
-        taskId,
-        context,
-        structuredClone(params.configuration.taskPushNotificationConfig)
-      );
+      const pushConfig = structuredClone(params.configuration.taskPushNotificationConfig);
+      pushConfig.taskId = taskId;
+      await this.pushNotificationStore?.save(taskId, context, pushConfig);
     }
 
     const eventBus = this.eventBusManager.createOrGetByTaskId(taskId);
@@ -694,11 +692,9 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       params.configuration?.taskPushNotificationConfig &&
       this.agentCard.capabilities?.pushNotifications
     ) {
-      await this.pushNotificationStore?.save(
-        taskId,
-        context,
-        structuredClone(params.configuration.taskPushNotificationConfig)
-      );
+      const pushConfig = structuredClone(params.configuration.taskPushNotificationConfig);
+      pushConfig.taskId = taskId;
+      await this.pushNotificationStore?.save(taskId, context, pushConfig);
     }
 
     // Run the executor in the background. Bus cleanup is tied to the

--- a/test/server/request_handler/push_notification_config.spec.ts
+++ b/test/server/request_handler/push_notification_config.spec.ts
@@ -227,6 +227,68 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
     expect(stored[0].token).toBe('tok');
   });
 
+  it('stamps the resolved taskId on sendMessageStream inline push config', async () => {
+    const executor = new MockAgentExecutor();
+    executor.execute.mockImplementation(fakeTaskExecute);
+    handler = new DefaultRequestHandler(
+      agentCard,
+      taskStore,
+      executor,
+      new DefaultExecutionEventBusManager(),
+      pushNotificationStore
+    );
+
+    const config: TaskPushNotificationConfig = {
+      tenant: '',
+      taskId: '',
+      id: 'c-stream',
+      url: 'https://example.test/hook-stream',
+      token: 'tok-stream',
+      authentication: undefined,
+    };
+    const params: SendMessageRequest = {
+      tenant: '',
+      metadata: {},
+      message: {
+        messageId: 'msg-push-iso-stream',
+        role: Role.ROLE_USER,
+        parts: [
+          {
+            content: { $case: 'text', value: 'hi' },
+            mediaType: 'text/plain',
+            filename: '',
+            metadata: undefined,
+          },
+        ],
+        taskId: '',
+        contextId: '',
+        extensions: [],
+        metadata: {},
+        referenceTaskIds: [],
+      },
+      configuration: {
+        acceptedOutputModes: [],
+        taskPushNotificationConfig: config,
+        returnImmediately: false,
+      },
+    };
+
+    let taskId = '';
+    for await (const event of handler.sendMessageStream(params, serverContext)) {
+      if (event.payload?.$case === 'task') {
+        taskId = event.payload.value.id;
+      }
+    }
+
+    config.url = 'https://attacker.test/';
+    const stored = await pushNotificationStore.load(taskId, serverContext);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe('c-stream');
+    expect(stored[0].taskId).toBe(taskId);
+    expect(stored[0].url).toBe('https://example.test/hook-stream');
+    expect(stored[0].token).toBe('tok-stream');
+  });
+
   it('listTaskPushNotificationConfigs returns every entry after mixed id-less + explicit Creates', async () => {
     const taskId = 'task-list-after-multi';
     await taskStore.save(makeTask(taskId), serverContext);

--- a/test/server/request_handler/push_notification_config.spec.ts
+++ b/test/server/request_handler/push_notification_config.spec.ts
@@ -222,6 +222,7 @@ describe('DefaultRequestHandler.createTaskPushNotificationConfig (§3.1.7, §5.1
     const stored = await pushNotificationStore.load(result.id, serverContext);
     expect(stored).toHaveLength(1);
     expect(stored[0].id).toBe('c1');
+    expect(stored[0].taskId).toBe(result.id);
     expect(stored[0].url).toBe('https://example.test/hook');
     expect(stored[0].token).toBe('tok');
   });


### PR DESCRIPTION
# Description

- [x] Follow the CONTRIBUTING Guide
- [x] Conventional Commits title
- [x] Tests and linter pass
- [x] Docs updated if necessary

Fixes #682

## Summary

sendMessage and sendMessageStream save a clone of `configuration.taskPushNotificationConfig` keyed by the resolved taskId, but never set `config.taskId`. Proto says input taskId should be empty on SendMessage. Get/List later return `taskId: ""` for a config stored under a real task.

Before save, the clone now gets `taskId` set to the resolved requestContext.taskId on both the blocking and stream paths.

## Testing

Extended the existing inline-config isolation test to assert `stored[0].taskId === task.id`.

```
npx --no-install vitest run test/server/request_handler/push_notification_config.spec.ts
```

5 passed.