### PR TITLE
fix: reject whitespace-only taskId on sendMessage

### DIFF
--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -166,6 +166,7 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     let referenceTasks: Task[] | undefined;
 
     if (incomingMessage.taskId) {
+      this._requireValidTaskId(incomingMessage.taskId);
       task = await this.taskStore.load(incomingMessage.taskId, context);
       if (!task) {
         throw new TaskNotFoundError(`Task not found: ${incomingMessage.taskId}`);

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -1724,6 +1724,32 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
     ).rejects.toThrow(RequestMalformedError);
   });
 
+  it('sendMessage: should reject a whitespace-only taskId with RequestMalformedError', async () => {
+    const params: SendMessageRequest = {
+      tenant: '',
+      metadata: {},
+      message: {
+        messageId: 'msg-ws-taskid',
+        role: Role.ROLE_USER,
+        parts: [
+          {
+            content: { $case: 'text', value: 'hi' },
+            filename: '',
+            mediaType: 'text/plain',
+            metadata: undefined,
+          },
+        ],
+        contextId: '',
+        taskId: '   ',
+        extensions: [],
+        metadata: {},
+      },
+    } as SendMessageRequest;
+    await expect(handler.sendMessage(params, serverCallContext)).rejects.toThrow(
+      RequestMalformedError
+    );
+  });
+
   it('getTask: should return an existing task from the store', async () => {
     const fakeTask = createTestTask('task-exist');
     await mockTaskStore.save(fakeTask, serverCallContext);


### PR DESCRIPTION
# Description

- [x] Follow the CONTRIBUTING Guide
- [x] Conventional Commits title
- [x] Tests and linter pass
- [x] Docs updated if necessary

Fixes #683

## Summary

`_createRequestContext` used `if (incomingMessage.taskId)`, which is true for `"   "`, then loaded that id and threw TaskNotFoundError (-32001 / 404).

getTask, cancelTask, push-config methods, and resubscribe already use `_requireValidTaskId` after #629 and return RequestMalformedError (-32602 / 400) for whitespace. Empty `""` stays "create new task".

If taskId is non-empty, sendMessage now runs `_requireValidTaskId` before load.

## Testing

```
npx --no-install vitest run test/server/default_request_handler.spec.ts
```

95 passed.