### PR TITLE
fix: reject missing required extensions before mutating task history

### DIFF
--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -165,6 +165,21 @@ export class DefaultRequestHandler implements A2ARequestHandler {
     let task: Task | undefined;
     let referenceTasks: Task[] | undefined;
 
+    const agentCard = await this.getAgentCard();
+    const agentExtensions = agentCard.capabilities?.extensions ?? [];
+
+    // The client MUST declare support for every required extension.
+    const requestedSet = new Set(context.requestedExtensions ?? []);
+    const missingRequired = agentExtensions
+      .filter((ext) => ext.required && !requestedSet.has(ext.uri))
+      .map((ext) => ext.uri);
+
+    if (missingRequired.length > 0) {
+      throw new ExtensionSupportRequiredError(
+        `Client must declare support for required extensions: ${missingRequired.join(', ')}`
+      );
+    }
+
     if (incomingMessage.taskId) {
       task = await this.taskStore.load(incomingMessage.taskId, context);
       if (!task) {
@@ -205,21 +220,6 @@ export class DefaultRequestHandler implements A2ARequestHandler {
       }
     }
     const contextId = incomingMessage.contextId || task?.contextId || crypto.randomUUID();
-
-    const agentCard = await this.getAgentCard();
-    const agentExtensions = agentCard.capabilities?.extensions ?? [];
-
-    // The client MUST declare support for every required extension.
-    const requestedSet = new Set(context.requestedExtensions ?? []);
-    const missingRequired = agentExtensions
-      .filter((ext) => ext.required && !requestedSet.has(ext.uri))
-      .map((ext) => ext.uri);
-
-    if (missingRequired.length > 0) {
-      throw new ExtensionSupportRequiredError(
-        `Client must declare support for required extensions: ${missingRequired.join(', ')}`
-      );
-    }
 
     // Narrow the client-requested set to extensions the agent actually
     // exposes. Mutate in place — the transport layer holds a reference

--- a/test/server/default_request_handler.spec.ts
+++ b/test/server/default_request_handler.spec.ts
@@ -4492,8 +4492,41 @@ describe('DefaultRequestHandler as A2ARequestHandler', () => {
       const context = new ServerCallContext();
 
       await expect(requiredExtHandler.sendMessage(params, context)).rejects.toThrow(
-        requiredExtensionUri
+        ExtensionSupportRequiredError
       );
+    });
+
+    it('should not persist a follow-up that is rejected for a missing required extension', async () => {
+      const existing = createTestTask('task-ext-followup');
+      const saveSpy = vi.spyOn(mockTaskStore, 'save');
+      await mockTaskStore.save(existing, new ServerCallContext());
+      saveSpy.mockClear();
+
+      const params: SendMessageRequest = {
+        tenant: '',
+        metadata: {},
+        message: {
+          messageId: 'msg-ext-followup',
+          role: Role.ROLE_USER,
+          parts: [
+            {
+              content: { $case: 'text', value: 'follow-up' },
+              filename: '',
+              mediaType: 'text/plain',
+              metadata: undefined,
+            },
+          ],
+          contextId: existing.contextId,
+          taskId: existing.id,
+          extensions: [],
+          metadata: {},
+        },
+      } as SendMessageRequest;
+
+      await expect(requiredExtHandler.sendMessage(params, new ServerCallContext())).rejects.toThrow(
+        ExtensionSupportRequiredError
+      );
+      expect(saveSpy).not.toHaveBeenCalled();
     });
 
     it('should accept requests that declare the required extension', async () => {


### PR DESCRIPTION
# Description

- [x] Follow the CONTRIBUTING Guide
- [x] Conventional Commits title
- [x] Tests and linter pass
- [x] Docs updated if necessary

Fixes #684

## Summary

`_createRequestContext` appended the incoming message to history and saved, then later threw ExtensionSupportRequiredError if a required extension was missing. Existing tests only covered new messages (`taskId: ""`).

A follow-up that forgot a required extension still permanently landed in the task. getTask, listTasks, and resubscribe then showed a message the server refused to execute.

The required-extension check now runs before any history append or save. New-task creation is unchanged except that a rejected request does not persist.

## Testing

Added a follow-up case that asserts `save` is not called after the extension error.

```
npx --no-install vitest run test/server/default_request_handler.spec.ts
```

95 passed.