### PR TITLE
feat(server): Introduce SettleByTaskId method

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,25 @@ See the spec section
 and the [`push-notification-agent`](src/samples/agents/push-notification-agent/)
 sample (which includes a runnable webhook receiver).
 
+### Custom event bus and task store
+
+`TaskStore`, `ExecutionEventBus` and `ExecutionEventBusManager` are all
+constructor-injected into `DefaultRequestHandler`, so you can back them with a
+database, a cache, or a message broker instead of the in-process defaults.
+
+One caveat applies to a bus that does not deliver events synchronously. When the
+agent executor returns, the handler decides whether to tear that task's bus down
+from the last state it saw published, so a bus that batches or persists events
+before handing them to subscribers has shown the handler nothing by that point
+and its bus is released too early. Such a bus should take over the decision by
+implementing the optional `settleByTaskId` on its manager and settling from its
+own drain instead.
+
+See the doc comments on
+[`ExecutionEventBusManager`](src/server/events/execution_event_bus_manager.ts)
+for the full contract, and `test/integration/delayed_event_bus.spec.ts` for a
+worked example against a bus that withholds every batch.
+
 ### Client customization
 
 `@a2a-js/sdk/client` exposes a transport-agnostic `CallInterceptor` interface

--- a/src/server/events/execution_event_bus_manager.ts
+++ b/src/server/events/execution_event_bus_manager.ts
@@ -1,11 +1,86 @@
+import type { TaskState } from '../../index.js';
 import { DefaultExecutionEventBus, ExecutionEventBus } from './execution_event_bus.js';
 
+/**
+ * Owns the lifetime of one {@link ExecutionEventBus} per task.
+ *
+ * The request handler creates or looks up a bus when a request starts and
+ * settles it once the agent executor returns. Implementations are free to
+ * back the bus with anything (in-process, database-backed, a message broker)
+ * as long as the methods below behave as documented.
+ */
 export interface ExecutionEventBusManager {
+  /**
+   * Returns the bus for `taskId`, creating one if it does not exist. Called
+   * on the request path before the executor starts, so implementations
+   * should be cheap: the signature is synchronous and cannot await I/O.
+   */
   createOrGetByTaskId(taskId: string): ExecutionEventBus;
+
+  /**
+   * Returns the existing bus for `taskId`, or `undefined` if there is none.
+   * Unlike {@link createOrGetByTaskId} this never creates one — `resubscribe`
+   * uses it to distinguish a live execution from a task with no active
+   * executor.
+   */
   getByTaskId(taskId: string): ExecutionEventBus | undefined;
+
+  /**
+   * Releases the bus for `taskId` and detaches its listeners. Call when the
+   * execution flow ends; afterwards {@link getByTaskId} returns `undefined`.
+   */
   cleanupByTaskId(taskId: string): void;
+
+  /**
+   * Optional. Decides the fate of a task's event bus once the agent executor
+   * returns. Implementations take **full ownership** of the outcome: while
+   * this method is present the request handler performs no teardown of its
+   * own, so an implementation that wants the default behaviour must call both
+   * `eventBus.finished()` and {@link cleanupByTaskId} itself.
+   *
+   * When omitted, the handler applies its own policy — see
+   * `DefaultRequestHandlerOptions.keepBusAliveStates`. That option is ignored
+   * entirely while this method is present.
+   *
+   * `lastObservedState` is the most recent task state the handler saw
+   * published on the bus before the executor settled. It is `undefined` when
+   * nothing was observed, which has two very different causes:
+   *
+   * - the executor published no task or status event at all; or
+   * - the bus defers delivery, and the events have not been delivered *yet*.
+   *
+   * This argument cannot distinguish the two, so a bus that defers delivery
+   * should ignore it and settle from its own drain signal instead.
+   *
+   * Deferring is safe with respect to callers: `ExecutionEventQueue`
+   * terminates on a `message`, a terminal status or an `INPUT_REQUIRED` event
+   * and does not depend on `finished()`, so a blocking `sendMessage` still
+   * resolves once the real terminal event is delivered. The converse is the
+   * risk to weigh: if this method never settles a bus whose executor never
+   * publishes a terminal state, that bus leaks and a blocking `sendMessage`
+   * against it never resolves.
+   *
+   * @param taskId The task whose bus is being settled.
+   * @param eventBus The bus itself, passed so implementations need not look
+   *   it up again.
+   * @param lastObservedState Most recent state seen on the bus, or
+   *   `undefined` — read the caveat above before branching on it.
+   */
+  settleByTaskId?(
+    taskId: string,
+    eventBus: ExecutionEventBus,
+    lastObservedState: TaskState | undefined
+  ): void;
 }
 
+/**
+ * In-process {@link ExecutionEventBusManager} backed by a `Map`, pairing each
+ * task with a {@link DefaultExecutionEventBus}.
+ *
+ * Deliberately does not implement
+ * {@link ExecutionEventBusManager.settleByTaskId}, so the request handler's
+ * own settle policy stays in effect.
+ */
 export class DefaultExecutionEventBusManager implements ExecutionEventBusManager {
   private taskIdToBus: Map<string, ExecutionEventBus> = new Map();
 

--- a/src/server/request_handler/default_request_handler.ts
+++ b/src/server/request_handler/default_request_handler.ts
@@ -72,6 +72,12 @@ export interface DefaultRequestHandlerOptions {
    * To add another keep-alive state while preserving those defaults, include
    * both default states and the additional state. Any custom value overrides
    * the default list.
+   *
+   * This option decides the fate of the bus from the last state observed on
+   * it, which only works for a bus that delivers its events before the
+   * executor returns. A bus that defers delivery should instead implement
+   * {@link ExecutionEventBusManager.settleByTaskId}, which takes precedence
+   * and makes this option inert.
    */
   keepBusAliveStates?: TaskState[];
 }
@@ -459,12 +465,23 @@ export class DefaultRequestHandler implements A2ARequestHandler {
    * (and the bare-Message stream pattern) close the bus immediately;
    * states configured in `keepBusAliveStates` keep it alive so follow-up
    * sends and resubscribers can still attach.
+   *
+   * A bus manager that implements
+   * {@link ExecutionEventBusManager.settleByTaskId} takes full ownership of
+   * this decision instead: we delegate and do no teardown of our own, so
+   * `keepBusAliveStates` does not apply. That seam exists for buses whose
+   * delivery is deferred, where `lastState` is still `undefined` when the
+   * executor returns and no state-based policy can work.
    */
   private _settleBus(
     taskId: string,
     eventBus: ExecutionEventBus,
     lastState: TaskState | undefined
   ): void {
+    if (this.eventBusManager.settleByTaskId) {
+      this.eventBusManager.settleByTaskId(taskId, eventBus, lastState);
+      return;
+    }
     if (lastState !== undefined && this.keepBusAliveStates.has(lastState)) {
       return;
     }

--- a/test/integration/delayed_event_bus.spec.ts
+++ b/test/integration/delayed_event_bus.spec.ts
@@ -1,0 +1,306 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { DefaultRequestHandler, InMemoryTaskStore, TaskStore } from '../../src/server/index.js';
+import { AgentEvent, ExecutionEventBus } from '../../src/server/events/execution_event_bus.js';
+import { DefaultExecutionEventBusManager } from '../../src/server/events/execution_event_bus_manager.js';
+import { ServerCallContext } from '../../src/server/context.js';
+import { RequestContext } from '../../src/server/agent_execution/request_context.js';
+import { AgentExecutor } from '../../src/server/agent_execution/agent_executor.js';
+import { Task, TaskState } from '../../src/types/pb/a2a.js';
+import {
+  DeferredSettleBusManager,
+  DelayingExecutionEventBusManager,
+  settlesWithin,
+  waitFor,
+} from './support/delaying.js';
+import { agentCard, drain, lastState, makeParams } from './support/fixtures.js';
+
+// How long the bus withholds each batch before handing it to subscribers. Small
+// enough to keep the suite quick, large enough that every event is still
+// undelivered when the executor returns — the condition reported on #620.
+const BUS_DELAY_MS = 60;
+
+interface Observed {
+  taskId: string;
+  contextId: string;
+}
+
+/**
+ * Publishes a Task in `openingState` and returns immediately, leaving the task
+ * to be completed by something else later — a proxying executor that has just
+ * handed work to another agent.
+ */
+class OutOfBandExecutor implements AgentExecutor {
+  public readonly observed: Observed = { taskId: '', contextId: '' };
+  public returned = false;
+
+  constructor(private readonly openingState: TaskState) {}
+
+  async execute(ctx: RequestContext, bus: ExecutionEventBus): Promise<void> {
+    this.observed.taskId = ctx.taskId;
+    this.observed.contextId = ctx.contextId;
+    bus.publish(
+      AgentEvent.task({
+        id: ctx.taskId,
+        contextId: ctx.contextId,
+        status: { state: this.openingState, message: undefined, timestamp: undefined },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      })
+    );
+    this.returned = true;
+  }
+
+  async cancelTask(): Promise<void> {}
+}
+
+/** Publishes a full lifecycle and returns; delivery still lags behind. */
+class CompletingExecutor implements AgentExecutor {
+  public readonly observed: Observed = { taskId: '', contextId: '' };
+
+  async execute(ctx: RequestContext, bus: ExecutionEventBus): Promise<void> {
+    this.observed.taskId = ctx.taskId;
+    this.observed.contextId = ctx.contextId;
+    bus.publish(
+      AgentEvent.task({
+        id: ctx.taskId,
+        contextId: ctx.contextId,
+        status: {
+          state: TaskState.TASK_STATE_SUBMITTED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      })
+    );
+    bus.publish(
+      AgentEvent.statusUpdate({
+        taskId: ctx.taskId,
+        contextId: ctx.contextId,
+        status: { state: TaskState.TASK_STATE_WORKING, message: undefined, timestamp: undefined },
+        metadata: {},
+      })
+    );
+    bus.publish(
+      AgentEvent.statusUpdate({
+        taskId: ctx.taskId,
+        contextId: ctx.contextId,
+        status: {
+          state: TaskState.TASK_STATE_COMPLETED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        metadata: {},
+      })
+    );
+  }
+
+  async cancelTask(): Promise<void> {}
+}
+
+// A bus whose delivery is deferred breaks every state-based settle policy: by
+// the time the executor returns, nothing has been observed. These tests pin the
+// supported answer — a manager implementing `settleByTaskId` that settles from
+// its own drain instead.
+describe('delayed event bus (issue #620)', () => {
+  let taskStore: TaskStore;
+  let busManager: DeferredSettleBusManager;
+  const serverContext = new ServerCallContext();
+
+  beforeEach(() => {
+    taskStore = new InMemoryTaskStore();
+    busManager = new DeferredSettleBusManager(BUS_DELAY_MS);
+  });
+
+  afterEach(() => {
+    busManager.disposeAll();
+  });
+
+  const makeHandler = (executor: AgentExecutor) =>
+    new DefaultRequestHandler(agentCard, taskStore, executor, busManager);
+
+  it('blocking sendMessage resolves once the delayed events are delivered', async () => {
+    const executor = new CompletingExecutor();
+    const result = (await makeHandler(executor).sendMessage(
+      makeParams('delayed-bus-blocking'),
+      serverContext
+    )) as Task;
+
+    expect(result.id).toBe(executor.observed.taskId);
+    expect(result.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+
+    const stored = await taskStore.load(result.id, serverContext);
+    expect(stored?.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+  });
+
+  it('sendMessageStream yields the full lifecycle and closes', async () => {
+    const executor = new CompletingExecutor();
+    const events = await drain(
+      makeHandler(executor).sendMessageStream(makeParams('delayed-bus-stream'), serverContext)
+    );
+
+    expect(events.length).toBeGreaterThanOrEqual(2);
+    expect(events[0].payload?.$case).toBe('task');
+    expect(lastState(events)).toBe(TaskState.TASK_STATE_COMPLETED);
+  });
+
+  it('the handler delegates the settle decision and observes no state', async () => {
+    const executor = new CompletingExecutor();
+    await makeHandler(executor).sendMessage(makeParams('delayed-bus-delegates'), serverContext);
+
+    expect(busManager.settleRequests).toHaveLength(1);
+    expect(busManager.settleRequests[0].taskId).toBe(executor.observed.taskId);
+    // The whole point: the executor published three events, yet the handler saw
+    // none of them, so `keepBusAliveStates` could never have worked here.
+    expect(busManager.settleRequests[0].lastObservedState).toBeUndefined();
+  });
+
+  it('keeps the bus alive past the executor, then releases it once the terminal event lands', async () => {
+    const executor = new OutOfBandExecutor(TaskState.TASK_STATE_WORKING);
+    const handler = makeHandler(executor);
+    const pending = handler.sendMessage(makeParams('delayed-bus-out-of-band'), serverContext);
+
+    await waitFor(() => executor.returned, 'the executor to return');
+    await waitFor(
+      () => busManager.settleRequests.length === 1,
+      'the handler to ask the manager to settle'
+    );
+    // Bus must survive: the WORKING event has not even been delivered yet.
+    expect(busManager.getByTaskId(executor.observed.taskId)).toBeDefined();
+    expect(await settlesWithin(pending, BUS_DELAY_MS * 2)).toBe('pending');
+
+    // Something out of band — another agent's webhook, a reader loop —
+    // completes the task after the executor is long gone.
+    busManager.getByTaskId(executor.observed.taskId)!.publish(
+      AgentEvent.statusUpdate({
+        taskId: executor.observed.taskId,
+        contextId: executor.observed.contextId,
+        status: {
+          state: TaskState.TASK_STATE_COMPLETED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        metadata: {},
+      })
+    );
+
+    const result = (await pending) as Task;
+    expect(result.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+
+    await waitFor(
+      () => busManager.getByTaskId(executor.observed.taskId) === undefined,
+      'the manager to release the bus after delivering the terminal event'
+    );
+  });
+
+  it('resubscribe attaches to the still-live bus and receives later events', async () => {
+    const executor = new OutOfBandExecutor(TaskState.TASK_STATE_WORKING);
+    const handler = makeHandler(executor);
+    const pending = handler.sendMessage(makeParams('delayed-bus-resubscribe'), serverContext);
+
+    // Resubscribe reads the task from the store first, so wait for the delayed
+    // WORKING event to have been delivered and persisted.
+    await waitFor(
+      async () => (await taskStore.load(executor.observed.taskId, serverContext)) !== undefined,
+      'the WORKING task to be persisted'
+    );
+
+    const resubscribed = drain(
+      handler.resubscribe({ id: executor.observed.taskId, tenant: '' }, serverContext)
+    );
+
+    busManager.getByTaskId(executor.observed.taskId)!.publish(
+      AgentEvent.statusUpdate({
+        taskId: executor.observed.taskId,
+        contextId: executor.observed.contextId,
+        status: {
+          state: TaskState.TASK_STATE_COMPLETED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        metadata: {},
+      })
+    );
+
+    const events = await resubscribed;
+    // First frame is the snapshot required by the spec, then the live update.
+    expect(events[0].payload?.$case).toBe('task');
+    expect(lastState(events)).toBe(TaskState.TASK_STATE_COMPLETED);
+
+    const result = (await pending) as Task;
+    expect(result.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+  });
+
+  describe('without settleByTaskId (default handler policy)', () => {
+    let plainManager: DelayingExecutionEventBusManager;
+
+    beforeEach(() => {
+      plainManager = new DelayingExecutionEventBusManager(BUS_DELAY_MS);
+    });
+
+    afterEach(() => {
+      plainManager.disposeAll();
+    });
+
+    it('tears the bus down before anything is delivered, and the caller hangs', async () => {
+      // Characterises the #620 failure so the seam's necessity is pinned by a
+      // test. `keepBusAliveStates` cannot help even when it lists every state:
+      // the handler settles on a state it never observed.
+      const executor = new CompletingExecutor();
+      const everyState = Object.values(TaskState).filter(
+        (value): value is TaskState => typeof value === 'number'
+      );
+      const handler = new DefaultRequestHandler(
+        agentCard,
+        taskStore,
+        executor,
+        plainManager,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        { keepBusAliveStates: everyState }
+      );
+
+      // Never awaited to completion: it never settles. The reporter's "the task
+      // got stuck entirely" is this. Nothing keeps the loop alive once the
+      // manager is disposed in afterEach.
+      const pending = handler.sendMessage(makeParams('delayed-bus-no-seam'), serverContext);
+      pending.catch(() => {});
+
+      await waitFor(
+        () => plainManager.getByTaskId(executor.observed.taskId) === undefined,
+        'the handler to tear the bus down'
+      );
+
+      expect(await settlesWithin(pending, BUS_DELAY_MS * 4)).toBe('pending');
+      // Nothing was ever delivered, so nothing was ever persisted either.
+      expect(await taskStore.load(executor.observed.taskId, serverContext)).toBeUndefined();
+    });
+
+    it.todo(
+      'a built-in bounded linger (busLingerMs) would let a delayed bus work without a custom manager — deferred out of Tier 0'
+    );
+  });
+
+  it('default in-process bus is unaffected by the seam', async () => {
+    // Regression guard: the fast path still settles on observed state.
+    const defaultManager = new DefaultExecutionEventBusManager();
+    const executor = new CompletingExecutor();
+    const handler = new DefaultRequestHandler(agentCard, taskStore, executor, defaultManager);
+
+    const result = (await handler.sendMessage(
+      makeParams('default-bus-control'),
+      serverContext
+    )) as Task;
+
+    expect(result.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+    await waitFor(
+      () => defaultManager.getByTaskId(executor.observed.taskId) === undefined,
+      'the default manager to release the bus'
+    );
+  });
+});

--- a/test/integration/delayed_task_store.spec.ts
+++ b/test/integration/delayed_task_store.spec.ts
@@ -1,0 +1,272 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { DefaultRequestHandler } from '../../src/server/index.js';
+import { AgentEvent, ExecutionEventBus } from '../../src/server/events/execution_event_bus.js';
+import { DefaultExecutionEventBusManager } from '../../src/server/events/execution_event_bus_manager.js';
+import { ServerCallContext } from '../../src/server/context.js';
+import { RequestContext } from '../../src/server/agent_execution/request_context.js';
+import { AgentExecutor } from '../../src/server/agent_execution/agent_executor.js';
+import { Role, Task, TaskState } from '../../src/types/pb/a2a.js';
+import { DeferredSettleBusManager, DelayingTaskStore, waitFor } from './support/delaying.js';
+import { agentCard, drain, lastState, makeParams } from './support/fixtures.js';
+
+const STORE_DELAY_MS = 25;
+const BUS_DELAY_MS = 60;
+
+/** Publishes a Task, an agent Message into history, then completes. */
+class ChattyExecutor implements AgentExecutor {
+  public taskId = '';
+  public contextId = '';
+
+  async execute(ctx: RequestContext, bus: ExecutionEventBus): Promise<void> {
+    this.taskId = ctx.taskId;
+    this.contextId = ctx.contextId;
+
+    bus.publish(
+      AgentEvent.task({
+        id: ctx.taskId,
+        contextId: ctx.contextId,
+        status: {
+          state: TaskState.TASK_STATE_SUBMITTED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      })
+    );
+
+    bus.publish(
+      AgentEvent.statusUpdate({
+        taskId: ctx.taskId,
+        contextId: ctx.contextId,
+        status: {
+          state: TaskState.TASK_STATE_WORKING,
+          message: {
+            messageId: `agent-${ctx.taskId}`,
+            role: Role.ROLE_AGENT,
+            parts: [
+              {
+                content: { $case: 'text', value: 'working on it' },
+                mediaType: 'text/plain',
+                filename: '',
+                metadata: undefined,
+              },
+            ],
+            taskId: ctx.taskId,
+            contextId: ctx.contextId,
+            extensions: [],
+            metadata: {},
+            referenceTaskIds: [],
+          },
+          timestamp: undefined,
+        },
+        metadata: {},
+      })
+    );
+
+    bus.publish(
+      AgentEvent.artifactUpdate({
+        taskId: ctx.taskId,
+        contextId: ctx.contextId,
+        artifact: {
+          artifactId: `artifact-${ctx.taskId}`,
+          name: 'result',
+          description: '',
+          parts: [
+            {
+              content: { $case: 'text', value: 'the answer' },
+              mediaType: 'text/plain',
+              filename: '',
+              metadata: undefined,
+            },
+          ],
+          metadata: {},
+          extensions: [],
+        },
+        append: false,
+        lastChunk: true,
+        metadata: {},
+      })
+    );
+
+    bus.publish(
+      AgentEvent.statusUpdate({
+        taskId: ctx.taskId,
+        contextId: ctx.contextId,
+        status: {
+          state: TaskState.TASK_STATE_COMPLETED,
+          message: undefined,
+          timestamp: undefined,
+        },
+        metadata: {},
+      })
+    );
+  }
+
+  async cancelTask(): Promise<void> {}
+}
+
+// A database-backed TaskStore has latency on every read and write. These cover
+// the latency dimension only: the store still deep-copies on load and save, as
+// the built-in one does.
+describe('delayed task store', () => {
+  let taskStore: DelayingTaskStore;
+  let busManager: DefaultExecutionEventBusManager;
+  const serverContext = new ServerCallContext();
+
+  beforeEach(() => {
+    taskStore = new DelayingTaskStore(STORE_DELAY_MS);
+    busManager = new DefaultExecutionEventBusManager();
+  });
+
+  const makeHandler = (executor: AgentExecutor) =>
+    new DefaultRequestHandler(agentCard, taskStore, executor, busManager);
+
+  it('blocking sendMessage completes and persists the full task', async () => {
+    const executor = new ChattyExecutor();
+    const result = (await makeHandler(executor).sendMessage(
+      makeParams('delayed-store-blocking'),
+      serverContext
+    )) as Task;
+
+    expect(result.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+
+    const stored = await taskStore.load(result.id, serverContext);
+    expect(stored?.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+    expect(stored?.artifacts).toHaveLength(1);
+    // The user turn plus the agent's WORKING message.
+    expect(stored?.history?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('sendMessageStream completes against a slow store', async () => {
+    const executor = new ChattyExecutor();
+    const events = await drain(
+      makeHandler(executor).sendMessageStream(makeParams('delayed-store-stream'), serverContext)
+    );
+
+    expect(lastState(events)).toBe(TaskState.TASK_STATE_COMPLETED);
+    const stored = await taskStore.load(executor.taskId, serverContext);
+    expect(stored?.artifacts).toHaveLength(1);
+  });
+
+  it('getTask returns the persisted history after completion', async () => {
+    const executor = new ChattyExecutor();
+    const handler = makeHandler(executor);
+    const result = (await handler.sendMessage(
+      makeParams('delayed-store-gettask'),
+      serverContext
+    )) as Task;
+
+    const fetched = await handler.getTask({ id: result.id, tenant: '' }, serverContext);
+    expect(fetched.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+    expect(fetched.history?.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('two sequential turns on the same task accumulate history', async () => {
+    // Second turn re-reads through the slow store before merging, so a
+    // read-modify-write that lost the race would drop the first turn.
+    class PausingExecutor implements AgentExecutor {
+      public taskId = '';
+      public turn = 0;
+
+      async execute(ctx: RequestContext, bus: ExecutionEventBus): Promise<void> {
+        this.taskId = ctx.taskId;
+        this.turn += 1;
+        const terminal =
+          this.turn === 1 ? TaskState.TASK_STATE_INPUT_REQUIRED : TaskState.TASK_STATE_COMPLETED;
+        bus.publish(
+          AgentEvent.task({
+            id: ctx.taskId,
+            contextId: ctx.contextId,
+            status: {
+              state: TaskState.TASK_STATE_WORKING,
+              message: undefined,
+              timestamp: undefined,
+            },
+            artifacts: [],
+            history: [],
+            metadata: {},
+          })
+        );
+        bus.publish(
+          AgentEvent.statusUpdate({
+            taskId: ctx.taskId,
+            contextId: ctx.contextId,
+            status: { state: terminal, message: undefined, timestamp: undefined },
+            metadata: {},
+          })
+        );
+      }
+
+      async cancelTask(): Promise<void> {}
+    }
+
+    const executor = new PausingExecutor();
+    const handler = makeHandler(executor);
+
+    const first = (await handler.sendMessage(
+      makeParams('delayed-store-turn-1', 'first'),
+      serverContext
+    )) as Task;
+    expect(first.status?.state).toBe(TaskState.TASK_STATE_INPUT_REQUIRED);
+
+    const followUp = makeParams('delayed-store-turn-2', 'second');
+    followUp.message!.taskId = first.id;
+    followUp.message!.contextId = first.contextId;
+    const second = (await handler.sendMessage(followUp, serverContext)) as Task;
+
+    expect(second.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+    const texts = (second.history ?? []).flatMap((message) =>
+      message.parts.map((part) => (part.content?.$case === 'text' ? part.content.value : ''))
+    );
+    expect(texts).toContain('first');
+    expect(texts).toContain('second');
+  });
+
+  describe('combined with a delayed event bus', () => {
+    let deferredManager: DeferredSettleBusManager;
+
+    beforeEach(() => {
+      deferredManager = new DeferredSettleBusManager(BUS_DELAY_MS);
+    });
+
+    afterEach(() => {
+      deferredManager.disposeAll();
+    });
+
+    it('completes when both the store and the bus are slow', async () => {
+      const executor = new ChattyExecutor();
+      const handler = new DefaultRequestHandler(agentCard, taskStore, executor, deferredManager);
+
+      const result = (await handler.sendMessage(
+        makeParams('delayed-store-and-bus'),
+        serverContext
+      )) as Task;
+
+      expect(result.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+      await waitFor(
+        () => deferredManager.getByTaskId(executor.taskId) === undefined,
+        'the manager to release the bus'
+      );
+    });
+  });
+
+  // The cases below need a store that hands back live references rather than
+  // deep copies. They fail today: the SDK mutates store-returned objects in
+  // place, which is only safe because InMemoryTaskStore clones. Tracked as
+  // Tier 1 of the custom-integration audit, out of scope for the settle seam.
+  describe('non-cloning task store (Tier 1 — not yet supported)', () => {
+    it.todo(
+      'getTask with historyLength 0 must not truncate the stored history (default_request_handler.ts _applyHistoryLengthSemantics on the loaded task)'
+    );
+    it.todo('listTasks with historyLength must not truncate stored histories for the same reason');
+    it.todo(
+      'a streaming push-notification payload must not be retro-mutated by later history trimming (clone asymmetry between _processEvents and sendMessageStream)'
+    );
+    it.todo(
+      'a custom OwnerResolver must still serialize concurrent writes (result_manager.ts lockKey hardcodes context.user?.userName)'
+    );
+  });
+});

--- a/test/integration/support/delaying.ts
+++ b/test/integration/support/delaying.ts
@@ -1,0 +1,258 @@
+/**
+ * Test doubles that model a deployment which does NOT use the SDK's default
+ * in-process, zero-latency implementations.
+ */
+
+import {
+  AgentExecutionEvent,
+  DefaultExecutionEventBus,
+  EventListener,
+  ExecutionEventBus,
+  ExecutionEventName,
+  FinishedListener,
+} from '../../../src/server/events/execution_event_bus.js';
+import { ExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
+import { ServerCallContext } from '../../../src/server/context.js';
+import { InMemoryTaskStore, TaskStore } from '../../../src/server/store.js';
+import { ListTasksRequest, ListTasksResponse, Task, TaskState } from '../../../src/types/pb/a2a.js';
+import { TERMINAL_STATE_LIST } from '../../../src/server/utils.js';
+
+export const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Polls `predicate` until it returns true or `timeoutMs` elapses. Reports what
+ * was being waited for so a failure is legible instead of a bare timeout.
+ */
+export async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  description: string,
+  timeoutMs = 5_000,
+  intervalMs = 10
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await predicate()) return;
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for: ${description}`);
+    }
+    await sleep(intervalMs);
+  }
+}
+
+/**
+ * Resolves to `'pending'` if `promise` has not settled within `ms`. Used to
+ * assert that a call is still outstanding without hanging the test.
+ */
+export async function settlesWithin<T>(promise: Promise<T>, ms: number): Promise<T | 'pending'> {
+  return Promise.race([promise, sleep(ms).then(() => 'pending' as const)]);
+}
+
+/**
+ * An {@link ExecutionEventBus} that defers delivery. `publish()` and
+ * `finished()` append to a queue which is flushed to the delegate one batch at
+ * a time, `delayMs` later — mirroring a bus that persists events and replays
+ * them from a reader loop.
+ *
+ * Subscription (`on`/`off`/`once`) is *not* delayed: only delivery is. Events
+ * and `finished()` share one queue so `finished()` can never overtake events
+ * published before it.
+ */
+export class DelayingExecutionEventBus implements ExecutionEventBus {
+  private readonly delegate: ExecutionEventBus;
+  private readonly delayMs: number;
+  private readonly pending: Array<() => void> = [];
+  private timer: ReturnType<typeof setTimeout> | undefined;
+
+  /** Total events handed to the delegate; useful for delivery assertions. */
+  public deliveredCount = 0;
+
+  constructor(delayMs: number, delegate: ExecutionEventBus = new DefaultExecutionEventBus()) {
+    this.delayMs = delayMs;
+    this.delegate = delegate;
+  }
+
+  publish(event: AgentExecutionEvent): void {
+    this.enqueue(() => {
+      this.deliveredCount += 1;
+      this.delegate.publish(event);
+    });
+  }
+
+  finished(): void {
+    this.enqueue(() => this.delegate.finished());
+  }
+
+  on(eventName: 'event', listener: EventListener): this;
+  on(eventName: 'finished', listener: FinishedListener): this;
+  on(eventName: ExecutionEventName, listener: EventListener & FinishedListener): this {
+    this.delegate.on(eventName as 'event', listener);
+    return this;
+  }
+
+  off(eventName: 'event', listener: EventListener): this;
+  off(eventName: 'finished', listener: FinishedListener): this;
+  off(eventName: ExecutionEventName, listener: EventListener & FinishedListener): this {
+    this.delegate.off(eventName as 'event', listener);
+    return this;
+  }
+
+  once(eventName: 'event', listener: EventListener): this;
+  once(eventName: 'finished', listener: FinishedListener): this;
+  once(eventName: ExecutionEventName, listener: EventListener & FinishedListener): this {
+    this.delegate.once(eventName as 'event', listener);
+    return this;
+  }
+
+  removeAllListeners(eventName?: ExecutionEventName): this {
+    this.delegate.removeAllListeners(eventName);
+    return this;
+  }
+
+  /** Drops anything still queued and cancels the pending flush. */
+  dispose(): void {
+    this.pending.length = 0;
+    if (this.timer !== undefined) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  private enqueue(action: () => void): void {
+    this.pending.push(action);
+    this.scheduleFlush();
+  }
+
+  private scheduleFlush(): void {
+    if (this.timer !== undefined) return;
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      const batch = this.pending.splice(0, this.pending.length);
+      for (const action of batch) action();
+      if (this.pending.length > 0) this.scheduleFlush();
+    }, this.delayMs);
+  }
+}
+
+/**
+ * Hands out {@link DelayingExecutionEventBus} instances but leaves the settle
+ * decision to the request handler — i.e. it does NOT implement
+ * `settleByTaskId`.
+ */
+export class DelayingExecutionEventBusManager implements ExecutionEventBusManager {
+  protected readonly buses = new Map<string, DelayingExecutionEventBus>();
+  protected readonly delayMs: number;
+
+  constructor(delayMs: number) {
+    this.delayMs = delayMs;
+  }
+
+  createOrGetByTaskId(taskId: string): ExecutionEventBus {
+    let bus = this.buses.get(taskId);
+    if (!bus) {
+      bus = new DelayingExecutionEventBus(this.delayMs);
+      this.buses.set(taskId, bus);
+      this.onBusCreated(taskId, bus);
+    }
+    return bus;
+  }
+
+  getByTaskId(taskId: string): ExecutionEventBus | undefined {
+    return this.buses.get(taskId);
+  }
+
+  cleanupByTaskId(taskId: string): void {
+    const bus = this.buses.get(taskId);
+    if (bus) {
+      bus.removeAllListeners();
+      bus.dispose();
+    }
+    this.buses.delete(taskId);
+  }
+
+  /** Clears every bus; call from `afterEach` so no timer outlives a test. */
+  disposeAll(): void {
+    for (const taskId of [...this.buses.keys()]) this.cleanupByTaskId(taskId);
+  }
+
+  protected onBusCreated(_taskId: string, _bus: DelayingExecutionEventBus): void {}
+}
+
+/**
+ * The supported configuration for a deferred-delivery bus: it implements
+ * `settleByTaskId` so the request handler performs no teardown, and settles
+ * from its own drain instead — when a terminal status is actually *delivered*
+ * to subscribers.
+ */
+export class DeferredSettleBusManager extends DelayingExecutionEventBusManager {
+  /** Records handler settle requests so tests can assert delegation happened. */
+  public readonly settleRequests: Array<{
+    taskId: string;
+    lastObservedState: TaskState | undefined;
+  }> = [];
+
+  settleByTaskId(
+    taskId: string,
+    _eventBus: ExecutionEventBus,
+    lastObservedState: TaskState | undefined
+  ): void {
+    // Deliberately no teardown: our reader loop below decides when the task is
+    // really finished. `lastObservedState` is always undefined here because
+    // nothing has been delivered yet, which is exactly why the handler's
+    // state-based policy cannot be used.
+    this.settleRequests.push({ taskId, lastObservedState });
+  }
+
+  protected onBusCreated(taskId: string, bus: DelayingExecutionEventBus): void {
+    bus.on('event', (event: AgentExecutionEvent) => {
+      const state =
+        event.kind === 'statusUpdate' || event.kind === 'task'
+          ? event.data.status?.state
+          : undefined;
+      const isTerminal = state !== undefined && TERMINAL_STATE_LIST.includes(state);
+      if (!isTerminal && event.kind !== 'message') return;
+
+      // Settle on the next tick, not inline: this listener is registered
+      // before the handler's ExecutionEventQueue subscribes, and tearing the
+      // bus down mid-dispatch would strip the queue's listener before it sees
+      // this very event.
+      setTimeout(() => {
+        const current = this.buses.get(taskId);
+        if (current !== bus) return;
+        bus.finished();
+        this.cleanupByTaskId(taskId);
+      }, 0);
+    });
+  }
+}
+
+/**
+ * A {@link TaskStore} with real latency on every operation, delegating to
+ * {@link InMemoryTaskStore}. Cloning semantics are unchanged, so this isolates
+ * *latency* from the separate question of whether a store returns live
+ * references.
+ */
+export class DelayingTaskStore implements TaskStore {
+  private readonly delegate: TaskStore;
+  private readonly delayMs: number;
+
+  constructor(delayMs: number, delegate: TaskStore = new InMemoryTaskStore()) {
+    this.delayMs = delayMs;
+    this.delegate = delegate;
+  }
+
+  async save(task: Task, context: ServerCallContext): Promise<void> {
+    await sleep(this.delayMs);
+    return this.delegate.save(task, context);
+  }
+
+  async load(taskId: string, context: ServerCallContext): Promise<Task | undefined> {
+    await sleep(this.delayMs);
+    return this.delegate.load(taskId, context);
+  }
+
+  async list(params: ListTasksRequest, context: ServerCallContext): Promise<ListTasksResponse> {
+    await sleep(this.delayMs);
+    return this.delegate.list(params, context);
+  }
+}

--- a/test/integration/support/fixtures.ts
+++ b/test/integration/support/fixtures.ts
@@ -1,0 +1,90 @@
+import {
+  AgentCard,
+  Message,
+  Role,
+  SendMessageRequest,
+  StreamResponse,
+} from '../../../src/types/pb/a2a.js';
+
+export const agentCard: AgentCard = {
+  name: 'Delayed Integration Agent',
+  description: 'Agent used to exercise non-default task store and event bus implementations',
+  version: '1.0.0',
+  provider: undefined,
+  documentationUrl: '',
+  supportedInterfaces: [
+    {
+      url: 'http://localhost/a2a',
+      protocolBinding: 'HTTP+JSON',
+      tenant: '',
+      protocolVersion: '1.0',
+    },
+  ],
+  capabilities: {
+    extensions: [],
+    streaming: true,
+    pushNotifications: false,
+  },
+  securitySchemes: {},
+  securityRequirements: [],
+  defaultInputModes: ['text/plain'],
+  defaultOutputModes: ['text/plain'],
+  skills: [],
+  signatures: [],
+};
+
+export function makeMessage(messageId: string, text = 'kick off'): Message {
+  return {
+    messageId,
+    role: Role.ROLE_USER,
+    parts: [
+      {
+        content: { $case: 'text', value: text },
+        mediaType: 'text/plain',
+        filename: '',
+        metadata: undefined,
+      },
+    ],
+    taskId: '',
+    contextId: '',
+    extensions: [],
+    metadata: {},
+    referenceTaskIds: [],
+  };
+}
+
+export function makeParams(messageId: string, text = 'kick off'): SendMessageRequest {
+  return {
+    message: makeMessage(messageId, text),
+    tenant: '',
+    configuration: undefined,
+    metadata: {},
+  };
+}
+
+/** Collects every event from a stream, failing loudly rather than hanging. */
+export async function drain(
+  stream: AsyncGenerator<StreamResponse, void, undefined>,
+  timeoutMs = 10_000
+): Promise<StreamResponse[]> {
+  const collected: StreamResponse[] = [];
+  const deadline = setTimeout(() => {
+    throw new Error(`Stream did not close within ${timeoutMs}ms`);
+  }, timeoutMs);
+  try {
+    for await (const event of stream) collected.push(event);
+  } finally {
+    clearTimeout(deadline);
+  }
+  return collected;
+}
+
+/** Narrows the terminal state out of a collected stream, if any. */
+export function lastState(events: StreamResponse[]): number | undefined {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const payload = events[i].payload;
+    if (payload?.$case === 'statusUpdate') return payload.value.status?.state;
+    if (payload?.$case === 'task') return payload.value.status?.state;
+  }
+  return undefined;
+}

--- a/test/server/request_handler/settle_bus_seam.spec.ts
+++ b/test/server/request_handler/settle_bus_seam.spec.ts
@@ -1,0 +1,383 @@
+import { describe, it, beforeEach, afterEach, expect, vi } from 'vitest';
+
+import { DefaultRequestHandler, InMemoryTaskStore, TaskStore } from '../../../src/server/index.js';
+import {
+  AgentCard,
+  Message,
+  Role,
+  SendMessageRequest,
+  Task,
+  TaskState,
+} from '../../../src/types/pb/a2a.js';
+import { DefaultExecutionEventBusManager } from '../../../src/server/events/execution_event_bus_manager.js';
+import { AgentEvent, ExecutionEventBus } from '../../../src/server/events/execution_event_bus.js';
+import { ServerCallContext } from '../../../src/server/context.js';
+import { MockAgentExecutor } from '../mocks/agent-executor.mock.js';
+
+interface SettleCall {
+  taskId: string;
+  eventBus: ExecutionEventBus;
+  lastObservedState: TaskState | undefined;
+}
+
+/**
+ * Bus manager that implements the optional `settleByTaskId` seam and, by
+ * default, declines to settle — the shape a database-backed bus uses when its
+ * own reader loop decides when the task is really finished.
+ */
+class DeferringBusManager extends DefaultExecutionEventBusManager {
+  public readonly settleCalls: SettleCall[] = [];
+
+  settleByTaskId(
+    taskId: string,
+    eventBus: ExecutionEventBus,
+    lastObservedState: TaskState | undefined
+  ): void {
+    this.settleCalls.push({ taskId, eventBus, lastObservedState });
+  }
+}
+
+// `settleByTaskId` lets a bus manager take over the teardown decision that
+// `_settleBus` otherwise makes from the last state seen on the bus. Buses that
+// defer delivery cannot be settled that way: nothing has been observed by the
+// time the executor returns.
+describe('DefaultRequestHandler bus settle seam (ExecutionEventBusManager.settleByTaskId)', () => {
+  let taskStore: TaskStore;
+  let mockExecutor: MockAgentExecutor;
+
+  const agentCard: AgentCard = {
+    name: 'Settle Seam Agent',
+    description: 'Test agent for ExecutionEventBusManager.settleByTaskId',
+    version: '1.0.0',
+    provider: undefined,
+    documentationUrl: '',
+    supportedInterfaces: [
+      {
+        url: 'http://localhost/a2a',
+        protocolBinding: 'HTTP+JSON',
+        tenant: '',
+        protocolVersion: '1.0',
+      },
+    ],
+    capabilities: {
+      extensions: [],
+      streaming: true,
+      pushNotifications: false,
+    },
+    securitySchemes: {},
+    securityRequirements: [],
+    defaultInputModes: ['text/plain'],
+    defaultOutputModes: ['text/plain'],
+    skills: [],
+    signatures: [],
+  };
+
+  const serverContext = new ServerCallContext();
+
+  beforeEach(() => {
+    taskStore = new InMemoryTaskStore();
+    mockExecutor = new MockAgentExecutor();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const makeMessage = (id: string, text: string): Message => ({
+    messageId: id,
+    role: Role.ROLE_USER,
+    parts: [
+      {
+        content: { $case: 'text', value: text },
+        mediaType: 'text/plain',
+        filename: '',
+        metadata: undefined,
+      },
+    ],
+    taskId: '',
+    contextId: '',
+    extensions: [],
+    metadata: {},
+    referenceTaskIds: [],
+  });
+
+  const makeParams = (messageId: string): SendMessageRequest => ({
+    message: makeMessage(messageId, 'kick off'),
+    tenant: '',
+    configuration: undefined,
+    metadata: {},
+  });
+
+  const publishTask = (
+    bus: ExecutionEventBus,
+    taskId: string,
+    contextId: string,
+    state: TaskState
+  ) =>
+    bus.publish(
+      AgentEvent.task({
+        id: taskId,
+        contextId,
+        status: { state, message: undefined, timestamp: undefined },
+        artifacts: [],
+        history: [],
+        metadata: {},
+      })
+    );
+
+  const publishStatus = (
+    bus: ExecutionEventBus,
+    taskId: string,
+    contextId: string,
+    state: TaskState
+  ) =>
+    bus.publish(
+      AgentEvent.statusUpdate({
+        taskId,
+        contextId,
+        status: { state, message: undefined, timestamp: undefined },
+        metadata: {},
+      })
+    );
+
+  /** Lets the executor's `.finally()` (and therefore `_settleBus`) run. */
+  const flushSettle = async () => {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  };
+
+  const makeHandler = (
+    eventBusManager: DefaultExecutionEventBusManager,
+    keepBusAliveStates?: TaskState[]
+  ) =>
+    new DefaultRequestHandler(
+      agentCard,
+      taskStore,
+      mockExecutor,
+      eventBusManager,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      keepBusAliveStates ? { keepBusAliveStates } : {}
+    );
+
+  // A manager without the optional method must behave exactly as before the
+  // seam existed. These three pin the fallback path.
+  describe('manager without settleByTaskId (default policy retained)', () => {
+    it('tears the bus down after a terminal state', async () => {
+      const eventBusManager = new DefaultExecutionEventBusManager();
+      let observedTaskId = '';
+      mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+        observedTaskId = ctx.taskId;
+        publishTask(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_SUBMITTED);
+        publishStatus(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_COMPLETED);
+      });
+
+      await makeHandler(eventBusManager).sendMessage(makeParams('msg-fallback-1'), serverContext);
+      await flushSettle();
+
+      expect(eventBusManager.getByTaskId(observedTaskId)).toBeUndefined();
+    });
+
+    it('keeps the bus alive for the default INPUT_REQUIRED state', async () => {
+      const eventBusManager = new DefaultExecutionEventBusManager();
+      let observedTaskId = '';
+      mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+        observedTaskId = ctx.taskId;
+        publishTask(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_SUBMITTED);
+        publishStatus(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_INPUT_REQUIRED);
+      });
+
+      await makeHandler(eventBusManager).sendMessage(makeParams('msg-fallback-2'), serverContext);
+      await flushSettle();
+
+      expect(eventBusManager.getByTaskId(observedTaskId)).toBeDefined();
+    });
+
+    it('honors a custom keepBusAliveStates list', async () => {
+      const eventBusManager = new DefaultExecutionEventBusManager();
+      let observedTaskId = '';
+      mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+        observedTaskId = ctx.taskId;
+        publishTask(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_SUBMITTED);
+        publishStatus(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_COMPLETED);
+      });
+
+      const handler = makeHandler(eventBusManager, [TaskState.TASK_STATE_COMPLETED]);
+      await handler.sendMessage(makeParams('msg-fallback-3'), serverContext);
+      await flushSettle();
+
+      expect(eventBusManager.getByTaskId(observedTaskId)).toBeDefined();
+    });
+  });
+
+  describe('manager with settleByTaskId (full delegation)', () => {
+    it('delegates from the sendMessage path and performs no teardown of its own', async () => {
+      const eventBusManager = new DeferringBusManager();
+      const cleanupSpy = vi.spyOn(eventBusManager, 'cleanupByTaskId');
+      let observedTaskId = '';
+      let finishedSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+      mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+        observedTaskId = ctx.taskId;
+        finishedSpy = vi.spyOn(bus, 'finished');
+        publishTask(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_SUBMITTED);
+        publishStatus(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_COMPLETED);
+      });
+
+      await makeHandler(eventBusManager).sendMessage(makeParams('msg-seam-1'), serverContext);
+      await flushSettle();
+
+      expect(eventBusManager.settleCalls).toHaveLength(1);
+      const call = eventBusManager.settleCalls[0];
+      expect(call.taskId).toBe(observedTaskId);
+      expect(call.eventBus).toBe(eventBusManager.getByTaskId(observedTaskId));
+      expect(call.lastObservedState).toBe(TaskState.TASK_STATE_COMPLETED);
+
+      // Full delegation: the handler must not finish or clean up itself.
+      expect(finishedSpy).toBeDefined();
+      expect(finishedSpy!).not.toHaveBeenCalled();
+      expect(cleanupSpy).not.toHaveBeenCalled();
+      expect(eventBusManager.getByTaskId(observedTaskId)).toBeDefined();
+    });
+
+    it('delegates from the sendMessageStream path too', async () => {
+      const eventBusManager = new DeferringBusManager();
+      const cleanupSpy = vi.spyOn(eventBusManager, 'cleanupByTaskId');
+      let observedTaskId = '';
+
+      mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+        observedTaskId = ctx.taskId;
+        publishTask(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_SUBMITTED);
+        publishStatus(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_COMPLETED);
+      });
+
+      const handler = makeHandler(eventBusManager);
+      for await (const _event of handler.sendMessageStream(
+        makeParams('msg-seam-2'),
+        serverContext
+      )) {
+        void _event;
+      }
+      await flushSettle();
+
+      expect(eventBusManager.settleCalls).toHaveLength(1);
+      expect(eventBusManager.settleCalls[0].taskId).toBe(observedTaskId);
+      expect(eventBusManager.settleCalls[0].lastObservedState).toBe(TaskState.TASK_STATE_COMPLETED);
+      expect(cleanupSpy).not.toHaveBeenCalled();
+      expect(eventBusManager.getByTaskId(observedTaskId)).toBeDefined();
+    });
+
+    it('receives undefined when nothing was observed, and declining to settle leaves the caller pending', async () => {
+      // An executor that published nothing is indistinguishable, through this
+      // argument, from a bus that has not delivered yet — which is exactly why
+      // the seam exists. It is also the documented hazard: a manager that
+      // never settles such a bus leaves a blocking sendMessage hanging.
+      const eventBusManager = new DeferringBusManager();
+      let observedTaskId = '';
+      mockExecutor.execute.mockImplementation(async (ctx) => {
+        observedTaskId = ctx.taskId;
+      });
+
+      const handler = makeHandler(eventBusManager);
+      // Track settlement without awaiting, and swallow the eventual rejection
+      // so it cannot leak out of this test as an unhandled rejection.
+      const settled = handler
+        .sendMessage(makeParams('msg-seam-3'), serverContext)
+        .then(() => 'resolved' as const)
+        .catch(() => 'rejected' as const);
+
+      await flushSettle();
+      expect(eventBusManager.settleCalls).toHaveLength(1);
+      expect(eventBusManager.settleCalls[0].lastObservedState).toBeUndefined();
+
+      const outcome = await Promise.race([
+        settled,
+        new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 50)),
+      ]);
+      expect(outcome).toBe('pending');
+
+      // Release the drain so the suite leaves nothing dangling.
+      eventBusManager.getByTaskId(observedTaskId)!.finished();
+      await expect(settled).resolves.toBe('rejected');
+    });
+
+    it('takes precedence over keepBusAliveStates', async () => {
+      // COMPLETED is deliberately NOT in the keep-alive list, so the fallback
+      // path would tear the bus down here. The seam must win instead.
+      const eventBusManager = new DeferringBusManager();
+      let observedTaskId = '';
+      mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+        observedTaskId = ctx.taskId;
+        publishTask(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_SUBMITTED);
+        publishStatus(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_COMPLETED);
+      });
+
+      const handler = makeHandler(eventBusManager, [TaskState.TASK_STATE_INPUT_REQUIRED]);
+      await handler.sendMessage(makeParams('msg-seam-4'), serverContext);
+      await flushSettle();
+
+      expect(eventBusManager.settleCalls).toHaveLength(1);
+      expect(eventBusManager.getByTaskId(observedTaskId)).toBeDefined();
+    });
+
+    it('a delegating manager can still settle by calling finished() and cleanupByTaskId()', async () => {
+      // Opting in does not forfeit the default outcome — it just moves who
+      // decides. This is the shape a reader loop uses once its drain is done.
+      class EagerBusManager extends DefaultExecutionEventBusManager {
+        public settleCount = 0;
+
+        settleByTaskId(taskId: string, eventBus: ExecutionEventBus): void {
+          this.settleCount += 1;
+          eventBus.finished();
+          this.cleanupByTaskId(taskId);
+        }
+      }
+
+      const eventBusManager = new EagerBusManager();
+      let observedTaskId = '';
+      // INPUT_REQUIRED would be kept alive by the fallback path, so a torn-down
+      // bus here can only be this manager's doing.
+      mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+        observedTaskId = ctx.taskId;
+        publishTask(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_SUBMITTED);
+        publishStatus(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_INPUT_REQUIRED);
+      });
+
+      await makeHandler(eventBusManager).sendMessage(makeParams('msg-seam-5'), serverContext);
+      await flushSettle();
+
+      expect(eventBusManager.settleCount).toBe(1);
+      expect(eventBusManager.getByTaskId(observedTaskId)).toBeUndefined();
+    });
+  });
+
+  it('a blocking sendMessage still resolves when the terminal event arrives after a deferred settle', async () => {
+    const eventBusManager = new DeferringBusManager();
+    let observedTaskId = '';
+    let observedContextId = '';
+    mockExecutor.execute.mockImplementation(async (ctx, bus) => {
+      observedTaskId = ctx.taskId;
+      observedContextId = ctx.contextId;
+      publishTask(bus, ctx.taskId, ctx.contextId, TaskState.TASK_STATE_WORKING);
+    });
+
+    const handler = makeHandler(eventBusManager);
+    const pending = handler.sendMessage(makeParams('msg-seam-late'), serverContext);
+
+    await flushSettle();
+    expect(eventBusManager.settleCalls).toHaveLength(1);
+
+    const bus = eventBusManager.getByTaskId(observedTaskId);
+    expect(bus).toBeDefined();
+    publishStatus(bus!, observedTaskId, observedContextId, TaskState.TASK_STATE_COMPLETED);
+
+    const result = (await pending) as Task;
+    expect(result.id).toBe(observedTaskId);
+    expect(result.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+
+    const stored = await taskStore.load(observedTaskId, serverContext);
+    expect(stored?.status?.state).toBe(TaskState.TASK_STATE_COMPLETED);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,9 +5,12 @@ export default defineConfig({
     globals: false,
     environment: 'node',
     include: ['test/**/*.spec.ts'],
-    // Integration tests spawn sample subprocesses and need the src/samples
-    // workspace installed; they run via their own config (`npm run test:integration`).
-    exclude: [...configDefaults.exclude, 'test/integration/**'],
+    // Only the samples smoke test is held back: it spawns the sample agent and
+    // CLI as subprocesses and needs the src/samples workspace installed, so it
+    // runs via its own config (`npm run test:integration`). The rest of
+    // test/integration is in-process and runs here too, which keeps it in the
+    // node version matrix and in the coverage report.
+    exclude: [...configDefaults.exclude, 'test/integration/samples_smoke.spec.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'json-summary'],

--- a/vitest.edge.config.ts
+++ b/vitest.edge.config.ts
@@ -18,6 +18,8 @@ export default defineWorkersConfig(
         'test/compat/v0_3/server/grpc/**',
         'test/compat/v0_3/client/transports/grpc/**',
         'test/e2e.spec.ts',
+        // Spawns the sample agent and CLI as child processes over real sockets.
+        'test/integration/samples_smoke.spec.ts',
         'test/server/push_notification_integration.spec.ts',
         // Push-notification senders are exercised against a real Express webhook
         // (sibling pure-unit serializer tests stay in the edge suite).

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from 'vitest/config';
 
-// Integration suite: spawns the samples as subprocesses over real transports.
-// Kept out of the default unit suite; run with `npm run test:integration`.
+// Integration suite: everything under test/integration, run with
+// `npm run test:integration`. The samples smoke test spawns the samples as
+// subprocesses over real transports and only runs here, because it needs the
+// src/samples workspace installed. The in-process specs alongside it also run
+// in the default unit suite; re-running them here is cheap and keeps this
+// suite a complete view of the directory.
 export default defineConfig({
   test: {
     globals: false,


### PR DESCRIPTION
# Description

When the agent executor returns, `_settleBus` decides whether to tear down that task's event bus from the last state it saw published on the bus. That only works when the bus delivers synchronously, as `DefaultExecutionEventBus` does. A bus that batches or persists events before handing them to subscribers has published nothing observable at that moment, so `lastState` is `undefined`, the `keepBusAliveStates` guard is skipped, and the bus is released before its events arrive. The caller then hangs, or fails with `"Agent execution finished without a result"`.

This adds an optional `settleByTaskId` to `ExecutionEventBusManager`. When present, the handler delegates the decision entirely and performs no teardown of its own, letting a deferred-delivery bus settle from its own drain instead. `_settleBus` is the only caller of `finished()` and `cleanupByTaskId()` in `src/`, so the seam covers bus lifetime completely.

`keepBusAliveStates` is unchanged and remains the default policy — it is ignored only while `settleByTaskId` is present. `DefaultExecutionEventBusManager` deliberately does not implement the new method, so nothing changes for existing users.

Fixes #620 🦕
