### PR TITLE
docs: replace broken and legacy project links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -27,7 +27,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/google-a2a/A2A?tab=coc-ov-file#readme)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/a2aproject/a2a-js/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -35,7 +35,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/google-a2a/A2A?tab=coc-ov-file#readme)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/a2aproject/a2a-js/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 Thank you for opening a Pull Request!
 Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
 
-- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-js/blob/main/CONTRIBUTING.md).
+- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-js/blob/main/CONTRIBUTING.md).
 - [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
   - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
     - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
    <h2 align="center">
    <img src="https://raw.githubusercontent.com/a2aproject/A2A/refs/heads/main/docs/assets/a2a_logo/color/SVG/a2a_color.svg" width="800" alt="Agent2Agent Protocol Logo"/>
    </h2>
-   <h3 align="center">A JavaScript library that helps run agentic applications as A2AServers following the <a href="https://google-a2a.github.io/A2A">Agent2Agent (A2A) Protocol</a>.</h3>
+   <h3 align="center">A JavaScript library that helps run agentic applications as A2AServers following the <a href="https://a2a-protocol.org/">Agent2Agent (A2A) Protocol</a>.</h3>
 </html>
 
 <!-- markdownlint-enable no-inline-html -->
@@ -271,8 +271,8 @@ end-to-end demonstration across every transport.
 
 ## License
 
-This project is licensed under the terms of the [Apache 2.0 License](https://raw.githubusercontent.com/google-a2a/a2a-python/refs/heads/main/LICENSE).
+This project is licensed under the terms of the [Apache 2.0 License](LICENSE).
 
 ## Contributing
 
-See [CONTRIBUTING.md](https://github.com/google-a2a/a2a-js/blob/main/CONTRIBUTING.md) for contribution guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines.


### PR DESCRIPTION
# Description

Fixes #694.

## Summary

- replace the README header protocol URL that returns HTTP 404 with the canonical A2A protocol site;
- use repository-local links for `LICENSE` and `CONTRIBUTING.md` in the README;
- update contribution and Code of Conduct links in the pull request and issue templates to the current `a2aproject` repository;
- preserve legacy `google-a2a` links in `CHANGELOG.md` because they are part of the historical release record.

## Verification

- `npm run format:readme`
- `npm run lint:ci`
- `npm test` — 68 test files and 1,525 tests passed
- confirmed the canonical protocol, License, Contributing, and Code of Conduct targets return HTTP 200

## Checklist

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-js/blob/main/CONTRIBUTING.md).
- [x] Use a Conventional Commits pull request title.
- [x] Ensure the tests and linter pass.
- [x] Update the appropriate documentation.