### PR TITLE
fix: validate JSON-RPC response version

### DIFF
--- a/src/client/transports/json_rpc_transport.ts
+++ b/src/client/transports/json_rpc_transport.ts
@@ -33,6 +33,22 @@ import { pickMatchingInterface } from './pick_interface.js';
 
 const PROTOCOL_NAME: TransportProtocolName = 'JSONRPC';
 
+function assertJsonRpcResponseVersion(
+  response: unknown,
+  context: string
+): asserts response is Record<string, unknown> & { jsonrpc: '2.0' } {
+  if (
+    typeof response !== 'object' ||
+    response === null ||
+    !('jsonrpc' in response) ||
+    response.jsonrpc !== '2.0'
+  ) {
+    throw new Error(
+      `Invalid JSON-RPC response for ${context}: expected 'jsonrpc' to be exactly '2.0'.`
+    );
+  }
+}
+
 export interface JsonRpcTransportOptions {
   endpoint: string;
   fetchImpl?: typeof fetch;
@@ -249,12 +265,13 @@ export class JsonRpcTransport implements Transport {
       }
     }
 
-    const json = await httpResponse.json();
-    if ('error' in json) {
-      throw mapJsonRpcErrorToSdkError(json as JSONRPCErrorResponse);
+    const json: unknown = await httpResponse.json();
+    assertJsonRpcResponseVersion(json, method);
+    const rpcResponse = json as unknown as JSONRPCResponse<TResponsePayload>;
+    if ('error' in rpcResponse) {
+      throw mapJsonRpcErrorToSdkError(rpcResponse);
     }
 
-    const rpcResponse = json as JSONRPCSuccessResponse<TResponsePayload>;
     if (rpcResponse.id !== requestId) {
       throw new Error(
         `JSON-RPC response ID mismatch for method ${method}. Expected ${requestId}, got ${rpcResponse.id}.`
@@ -345,15 +362,17 @@ export class JsonRpcTransport implements Transport {
       throw new Error('Attempted to process empty SSE event data.');
     }
 
-    let a2aStreamResponse: JSONRPCResponse<StreamResponse>;
+    let parsedResponse: unknown;
     try {
-      a2aStreamResponse = JSON.parse(jsonData) as JSONRPCResponse<StreamResponse>;
+      parsedResponse = JSON.parse(jsonData);
     } catch (e) {
       throw new Error(
         `Failed to parse SSE event data: "${jsonData.substring(0, 100)}...". Original error: ${(e instanceof Error && e.message) || 'Unknown error'}`,
         { cause: e }
       );
     }
+    assertJsonRpcResponseVersion(parsedResponse, 'SSE event');
+    const a2aStreamResponse = parsedResponse as unknown as JSONRPCResponse<StreamResponse>;
 
     if (a2aStreamResponse.id !== originalRequestId) {
       throw new Error(

--- a/test/client/transports/json_rpc_transport.spec.ts
+++ b/test/client/transports/json_rpc_transport.spec.ts
@@ -94,6 +94,70 @@ describe('JsonRpcTransport', () => {
     });
   });
 
+  describe('JSON-RPC response validation', () => {
+    it.each([
+      ['missing', undefined],
+      ['invalid', '1.0'],
+    ])('rejects unary responses with a %s jsonrpc version', async (_description, jsonrpc) => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            ...(jsonrpc === undefined ? {} : { jsonrpc }),
+            result: { ok: true },
+            id: 1,
+          }),
+          { status: 200 }
+        )
+      );
+
+      await expect(transport.callExtensionMethod('test/method', {})).rejects.toThrow(
+        "expected 'jsonrpc' to be exactly '2.0'"
+      );
+    });
+
+    it.each([
+      ['missing', undefined],
+      ['invalid', '1.0'],
+    ])('rejects SSE events with a %s jsonrpc version', async (_description, jsonrpc) => {
+      const event: Record<string, unknown> = {
+        ...(jsonrpc === undefined ? {} : { jsonrpc }),
+        result: {
+          message: {
+            messageId: 'response-msg-1',
+            role: 'ROLE_AGENT',
+            parts: [],
+          },
+        },
+        id: 1,
+      };
+      mockFetch.mockResolvedValue(
+        new Response(`data: ${JSON.stringify(event)}\n\n`, {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        })
+      );
+
+      const request: SendMessageRequest = {
+        tenant: '',
+        message: {
+          messageId: 'test-msg-1',
+          role: Role.ROLE_USER,
+          parts: [],
+          contextId: '',
+          taskId: '',
+          extensions: [],
+          metadata: undefined,
+          referenceTaskIds: [],
+        },
+        configuration: undefined,
+        metadata: {},
+      };
+      const stream = transport.sendMessageStream(request);
+
+      await expect(stream.next()).rejects.toThrow("expected 'jsonrpc' to be exactly '2.0'");
+    });
+  });
+
   describe('TaskPushNotificationConfig', () => {
     it('createTaskPushNotificationConfig should send correct params and return config', async () => {
       const config: TaskPushNotificationConfig = {


### PR DESCRIPTION
# Description

Fixes #696.

## Summary

- reject JSON-RPC response envelopes unless `jsonrpc` is exactly `"2.0"`;
- apply the same validation to ordinary JSON responses and each streaming SSE event;
- cover missing and invalid protocol versions on both response paths.

## Testing

- `npm run lint:ci`
- `npm test -- --run test/client/transports/json_rpc_transport.spec.ts` — 17 passed
- `npm test` — 68 files and 1,529 tests passed

## Checklist

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-js/blob/main/CONTRIBUTING.md).
- [x] Use a Conventional Commits pull request title.
- [x] Ensure the tests and linter pass.
- [x] Update the appropriate documentation if necessary.
