### PR TITLE
fix(rest): forward pageSize and pageToken for push-notification config listing

### DIFF
--- a/src/client/transports/rest_transport.ts
+++ b/src/client/transports/rest_transport.ts
@@ -149,8 +149,18 @@ export class RestTransport implements Transport {
     params: ListTaskPushNotificationConfigsRequest,
     options?: RequestOptions
   ): Promise<ListTaskPushNotificationConfigsResponse> {
+    const queryParams = new URLSearchParams();
+    // Unlike ListTasksRequest.pageSize (proto3 `optional`, so `undefined` means
+    // "unspecified"), this field has no `optional` modifier and is always a
+    // concrete number, so 0 — its proto3 zero value — is the "unspecified" case.
+    if (params.pageSize > 0) queryParams.set('pageSize', String(params.pageSize));
+    if (params.pageToken) queryParams.set('pageToken', params.pageToken);
+    const queryString = queryParams.toString();
+
     const path = this._buildPath(
-      `/tasks/${encodeURIComponent(params.taskId)}/pushNotificationConfigs`,
+      `/tasks/${encodeURIComponent(params.taskId)}/pushNotificationConfigs${
+        queryString ? `?${queryString}` : ''
+      }`,
       params.tenant
     );
     const response = await this._sendRequest<void, ListTaskPushNotificationConfigsResponse>(

--- a/src/server/express/rest_handler.ts
+++ b/src/server/express/rest_handler.ts
@@ -494,8 +494,8 @@ export function restHandler(options: RestHandlerOptions): RequestHandler {
     const context = await buildContext(req);
     const result = await restTransportHandler.listTaskPushNotificationConfigs(
       req.params.taskId as string,
-      context,
-      (req.query.tenant as string) || ''
+      req.query,
+      context
     );
     sendResponse<ListTaskPushNotificationConfigsResponse>(
       res,

--- a/src/server/transports/rest/rest_transport_handler.ts
+++ b/src/server/transports/rest/rest_transport_handler.ts
@@ -144,11 +144,16 @@ export class RestTransportHandler {
 
   async listTaskPushNotificationConfigs(
     taskId: string,
-    context: ServerCallContext,
-    tenant?: string
+    queryParams: Record<string, unknown>,
+    context: ServerCallContext
   ): Promise<ListTaskPushNotificationConfigsResponse> {
     const result = await this.requestHandler.listTaskPushNotificationConfigs(
-      { taskId, pageSize: 0, pageToken: '', tenant: tenant || '' },
+      {
+        taskId,
+        pageSize: queryParams.pageSize ? Number(queryParams.pageSize) : 0,
+        pageToken: (queryParams.pageToken as string) || '',
+        tenant: (queryParams.tenant as string) || '',
+      },
       context
     );
     return result;

--- a/test/client/transports/rest_transport.spec.ts
+++ b/test/client/transports/rest_transport.spec.ts
@@ -447,6 +447,26 @@ describe('RestTransport', () => {
         expect(url).to.equal(`${endpoint}/tasks/${taskId}/pushNotificationConfigs`);
         expect(options?.method).to.equal('GET');
       });
+
+      it('sends pageSize and pageToken as query parameters when specified', async () => {
+        mockFetch.mockResolvedValue(
+          createRestResponse(
+            ListTaskPushNotificationConfigsResponse.toJSON({ configs: [], nextPageToken: '' })
+          )
+        );
+
+        await transport.listTaskPushNotificationConfig({
+          taskId,
+          tenant: '',
+          pageSize: 7,
+          pageToken: 'cursor-abc',
+        });
+
+        const [url] = mockFetch.mock.calls[0];
+        expect(url).to.equal(
+          `${endpoint}/tasks/${taskId}/pushNotificationConfigs?pageSize=7&pageToken=cursor-abc`
+        );
+      });
     });
 
     describe('deleteTaskPushNotificationConfig', () => {

--- a/test/server/express/rest_handler.spec.ts
+++ b/test/server/express/rest_handler.spec.ts
@@ -740,6 +740,23 @@ describe('restHandler', () => {
         assert.isArray(convertedResult);
         assert.lengthOf(convertedResult, configs.length);
       });
+
+      it('should forward pageSize and pageToken query params to the request handler', async () => {
+        (mockRequestHandler.listTaskPushNotificationConfigs as Mock).mockResolvedValue({
+          configs: [],
+          nextPageToken: '',
+        });
+
+        await request(app)
+          .get('/tasks/task-1/pushNotificationConfigs?pageSize=7&pageToken=cursor-abc')
+          .set('A2A-Version', '1.0')
+          .expect(200);
+
+        expect(mockRequestHandler.listTaskPushNotificationConfigs).toHaveBeenCalledWith(
+          expect.objectContaining({ taskId: 'task-1', pageSize: 7, pageToken: 'cursor-abc' }),
+          expect.anything()
+        );
+      });
     });
 
     describe('GET /tasks/:taskId/pushNotificationConfigs/:configId', () => {

--- a/test/server/rest_transport_handler.spec.ts
+++ b/test/server/rest_transport_handler.spec.ts
@@ -471,12 +471,43 @@ describe('RestTransportHandler', () => {
 
         const result = await transportHandler.listTaskPushNotificationConfigs(
           'task-1',
+          {},
           mockContext
         );
 
         expect(result).to.deep.equal([mockConfig]);
         expect(mockRequestHandler.listTaskPushNotificationConfigs as Mock).toHaveBeenCalledWith(
           { taskId: 'task-1', pageSize: 0, pageToken: '', tenant: '' },
+          mockContext
+        );
+      });
+
+      it('should forward pageSize and pageToken from the query params', async () => {
+        (mockRequestHandler.listTaskPushNotificationConfigs as Mock).mockResolvedValue([]);
+
+        await transportHandler.listTaskPushNotificationConfigs(
+          'task-1',
+          { pageSize: '7', pageToken: 'cursor-abc' },
+          mockContext
+        );
+
+        expect(mockRequestHandler.listTaskPushNotificationConfigs as Mock).toHaveBeenCalledWith(
+          { taskId: 'task-1', pageSize: 7, pageToken: 'cursor-abc', tenant: '' },
+          mockContext
+        );
+      });
+
+      it('should forward tenant from the query params', async () => {
+        (mockRequestHandler.listTaskPushNotificationConfigs as Mock).mockResolvedValue([]);
+
+        await transportHandler.listTaskPushNotificationConfigs(
+          'task-1',
+          { tenant: 'tenant-a' },
+          mockContext
+        );
+
+        expect(mockRequestHandler.listTaskPushNotificationConfigs as Mock).toHaveBeenCalledWith(
+          { taskId: 'task-1', pageSize: 0, pageToken: '', tenant: 'tenant-a' },
           mockContext
         );
       });


### PR DESCRIPTION
## What

The REST transport silently drops `pageSize` and `pageToken` when listing a task's push-notification configs:

- `RestTransport.listTaskPushNotificationConfig` sends `GET /tasks/:taskId/pushNotificationConfigs` with **no query string**, even when `pageSize`/`pageToken` are supplied.
- The Express `restHandler` always invokes the request handler with `pageSize: 0`, `pageToken: ''` regardless of the request's query parameters.

Pagination works on the JSON-RPC and gRPC transports, so REST behaved inconsistently — and there was no way to request a bounded page or follow a returned `nextPageToken`. Per A2A spec §11.5, GET request parameters must be sent as camelCase query parameters (`pageSize`, `pageToken`).

## Changes

- **Client** (`RestTransport.listTaskPushNotificationConfig`): append `pageSize`/`pageToken` as query params, mirroring the existing `listTasks` implementation. `ListTaskPushNotificationConfigsRequest.pageSize` has no proto3 `optional` modifier (unlike `ListTasksRequest.pageSize`), so `0` is its unspecified value — only sent when `> 0`.
- **Server** (`RestTransportHandler.listTaskPushNotificationConfigs`): take a `queryParams` object like `listTasks` already does, and parse `pageSize`/`pageToken`/`tenant` from it instead of hard-coding.

The v0.3 compat REST layer is intentionally left alone — its wire response is a bare array with no pagination fields.

## Testing

- New unit tests: client sends the query params; the REST transport handler forwards `pageSize`/`pageToken`/`tenant`; the Express route passes them through end to end.
- `npx vitest run` — 68 files / 1529 tests pass.
- `npx tsc --noEmit` + `-p tsconfig.test.json`, `npx eslint .`, `npm run build` — all clean.

Closes #700