### PR TITLE
fix: do not cache extended agent card before signature verification succeeds

### DIFF
--- a/src/client/multitransport-client.ts
+++ b/src/client/multitransport-client.ts
@@ -89,16 +89,16 @@ export class Client {
     options?: RequestOptions,
     verifySignature?: AgentCardSignatureVerifier
   ): Promise<AgentCard> {
+    let card = this.agentCard;
     if (this.agentCard.capabilities?.extendedAgentCard) {
-      this.agentCard = await this.executeWithInterceptors(
-        { method: 'getAgentCard' },
-        options,
-        (_, options) => this.transport.getExtendedAgentCard({ tenant: '' }, options)
+      card = await this.executeWithInterceptors({ method: 'getAgentCard' }, options, (_, options) =>
+        this.transport.getExtendedAgentCard({ tenant: '' }, options)
       );
     }
     if (verifySignature) {
-      await verifySignature(this.agentCard);
+      await verifySignature(card);
     }
+    this.agentCard = card;
     return this.agentCard;
   }
 

--- a/test/client/multitransport-client.spec.ts
+++ b/test/client/multitransport-client.spec.ts
@@ -122,6 +122,105 @@ describe('Client', () => {
     expect(result).to.equal(agentCard);
   });
 
+  it('should not update cached agentCard if signature verification fails on extended card', async () => {
+    const publicCard: AgentCard = {
+      ...agentCard,
+      name: 'Public Card',
+      capabilities: {
+        ...agentCard.capabilities,
+        extendedAgentCard: true,
+        pushNotifications: false,
+      },
+    };
+    const extendedCard: AgentCard = {
+      ...agentCard,
+      name: 'Unverified Extended Card',
+      capabilities: {
+        ...agentCard.capabilities,
+        extendedAgentCard: false,
+        pushNotifications: true,
+      },
+    };
+    client = new Client(transport, publicCard);
+
+    transport.getExtendedAgentCard.mockResolvedValue(extendedCard);
+
+    const verifier = vi.fn().mockRejectedValue(new Error('invalid signature'));
+
+    await expect(client.getAgentCard(undefined, verifier)).rejects.toThrow('invalid signature');
+    expect(verifier).toHaveBeenCalledTimes(1);
+    expect(verifier).toHaveBeenCalledWith(extendedCard);
+    expect(transport.getExtendedAgentCard).toHaveBeenCalledTimes(1);
+
+    // On subsequent call with passing verifier, transport is called again because original publicCard remained cached
+    const successVerifier = vi.fn().mockResolvedValue(undefined);
+    const result = await client.getAgentCard(undefined, successVerifier);
+
+    expect(transport.getExtendedAgentCard).toHaveBeenCalledTimes(2);
+    expect(successVerifier).toHaveBeenCalledWith(extendedCard);
+    expect(result).to.equal(extendedCard);
+  });
+
+  it('should update cached agentCard when signature verification succeeds', async () => {
+    const publicCard: AgentCard = {
+      ...agentCard,
+      name: 'Public Card',
+      capabilities: {
+        ...agentCard.capabilities,
+        extendedAgentCard: true,
+        pushNotifications: false,
+      },
+    };
+    const extendedCard: AgentCard = {
+      ...agentCard,
+      name: 'Verified Extended Card',
+      capabilities: {
+        ...agentCard.capabilities,
+        extendedAgentCard: false,
+        pushNotifications: true,
+      },
+    };
+    client = new Client(transport, publicCard);
+
+    transport.getExtendedAgentCard.mockResolvedValue(extendedCard);
+
+    const verifier = vi.fn().mockResolvedValue(undefined);
+    const result = await client.getAgentCard(undefined, verifier);
+
+    expect(result).to.equal(extendedCard);
+    expect(verifier).toHaveBeenCalledTimes(1);
+    expect(verifier).toHaveBeenCalledWith(extendedCard);
+    expect(transport.getExtendedAgentCard).toHaveBeenCalledTimes(1);
+
+    // Subsequent call should return cached extendedCard without invoking transport again
+    const cachedResult = await client.getAgentCard();
+    expect(cachedResult).to.equal(extendedCard);
+    expect(transport.getExtendedAgentCard).toHaveBeenCalledTimes(1);
+  });
+
+  it('should verify current card when extendedAgentCard is not supported and verifySignature is provided', async () => {
+    const verifier = vi.fn().mockResolvedValue(undefined);
+    const result = await client.getAgentCard(undefined, verifier);
+
+    expect(transport.getExtendedAgentCard).not.toHaveBeenCalled();
+    expect(verifier).toHaveBeenCalledTimes(1);
+    expect(verifier).toHaveBeenCalledWith(agentCard);
+    expect(result).to.equal(agentCard);
+  });
+
+  it('should throw and preserve cached card when extendedAgentCard is not supported and verifier rejects', async () => {
+    const verifier = vi.fn().mockRejectedValue(new Error('card signature rejected'));
+
+    await expect(client.getAgentCard(undefined, verifier)).rejects.toThrow(
+      'card signature rejected'
+    );
+    expect(transport.getExtendedAgentCard).not.toHaveBeenCalled();
+    expect(verifier).toHaveBeenCalledTimes(1);
+
+    const result = await client.getAgentCard();
+    expect(result).to.equal(agentCard);
+  });
+
   it('should call transport.sendMessage with default returnImmediately=false', async () => {
     const params: SendMessageRequest = {
       message: {


### PR DESCRIPTION
# Description

When fetching an extended Agent Card with `Client.getAgentCard()`, the client previously assigned the new card to `this.agentCard` before calling `verifySignature`. If signature verification failed, the unverified card remained cached, which corrupted client capabilities and prevented retries.

This change stores the fetched card in a local variable and only assigns it to `this.agentCard` after `verifySignature` succeeds. If verification fails, the previous trusted card is preserved, and callers can retry the request.

### Changes:
- Updated `Client.getAgentCard` in `src/client/multitransport-client.ts` to assign `this.agentCard` only after `await verifySignature(card)` succeeds.
- Added unit tests in `test/client/multitransport-client.spec.ts` to test verification failures, retries, and successful signature verification.

---

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [x] Follow the [`CONTRIBUTING` Guide](https://github.com/a2aproject/a2a-js/blob/main/CONTRIBUTING.md).
- [x] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [x] Ensure the tests and linter pass
- [ ] Appropriate docs were updated (if necessary)

Fixes #705 🦕
